### PR TITLE
Add additional JAVA-Doc param

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -187,6 +187,9 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+			<configuration>
+			    <additionalparam>-Xdoclint:none</additionalparam>
+			</configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/pom.xml
@@ -45,6 +45,7 @@
 
         <!-- Maven Plugins -->
         <!-- <maven-remote-resources-plugin.version>1.5</maven-remote-resources-plugin.version> -->
+        <maven-javadoc-plugin.version>2.10.1</maven-javadoc-plugin.version>
         <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
         <maven-eclipse-plugin.version>2.9</maven-eclipse-plugin.version>
 
@@ -82,6 +83,23 @@
                     <downloadSources>${downloadSources}</downloadSources>
                     <downloadJavadocs>${downloadJavadocs}</downloadJavadocs>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    <configuration>
+                        <additionalparam>-Xdoclint:none</additionalparam>
+                    </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
         </plugins>


### PR DESCRIPTION
JAVA 8 uses a strict doclint. To avoid errors when building we added an additional param configuration.