### PR TITLE
Add a profile to make use of UMLgraph for javadocs

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -157,6 +157,31 @@
                 <javadoc.opts>-Xdoclint:none</javadoc.opts>
             </properties>
         </profile>
+
+        <!-- A profile to configure the build of the Javadocs with UMLGraph -->
+        <profile>
+            <id>umlgraph</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <stylesheet>java</stylesheet>
+                            <show>private</show>
+                            <doclet>org.umlgraph.doclet.UmlGraphDoc</doclet>
+                            <docletArtifact>
+                                <groupId>org.umlgraph</groupId>
+                                <artifactId>umlgraph</artifactId>
+                                <version>5.6.6</version>
+                            </docletArtifact>
+                            <additionalparam>${javadoc.opts} -collapsible -hide 'java.*|org.joda.*|org.apache.log4j.*' -inferdep -inferrel -inferreltype 'assoc' -collpackages 'java.util.*'</additionalparam>
+                            <useStandardDocletOptions>true</useStandardDocletOptions>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
@@ -205,15 +230,15 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${maven-javadoc-plugin.version}</version>
+                <configuration>
+                    <additionalparam>${javadoc.opts}</additionalparam>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
                         <goals>
                             <goal>jar</goal>
                         </goals>
-                        <configuration>
-                            <additionalparam>${javadoc.opts}</additionalparam>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
The new profile can be activated with the CLI argument `-Pumlgraph`, e.g.
`mvn clean package -Pumlgraph`. To make this work, a dependency has to be installed on the system: graphviz. One could use `sudo apt-get install graphviz` to install this.

The UMLGraph software will produce UML class diagram pictures, which will automatically be included in the javadocs. Options for the generation of the diagrams can be found here: http://www.umlgraph.org/doc/cd-opt.html

![umlgraph](https://cloud.githubusercontent.com/assets/3939332/9360236/75bf16c4-4695-11e5-8e24-0c14607730bf.png)
