### PR TITLE
Use new packages for layout and module models

### DIFF
--- a/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/LayoutDao.java
+++ b/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/LayoutDao.java
@@ -2,7 +2,7 @@ package de.terrestris.shogun2.dao;
 
 import org.springframework.stereotype.Repository;
 
-import de.terrestris.shogun2.model.Layout;
+import de.terrestris.shogun2.model.layout.Layout;
 
 @Repository
 public class LayoutDao extends GenericHibernateDao<Layout, Integer> {

--- a/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/ModuleDao.java
+++ b/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/ModuleDao.java
@@ -2,7 +2,7 @@ package de.terrestris.shogun2.dao;
 
 import org.springframework.stereotype.Repository;
 
-import de.terrestris.shogun2.model.Module;
+import de.terrestris.shogun2.model.module.Module;
 
 @Repository
 public class ModuleDao extends GenericHibernateDao<Module, Integer> {

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Application.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Application.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 import ch.rasc.extclassgenerator.Model;
+import de.terrestris.shogun2.model.module.Viewport;
 
 /**
  * This class represents a (GIS-)application, which can be opened in a browser.

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/AbsoluteLayout.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/AbsoluteLayout.java
@@ -1,8 +1,9 @@
 /**
  * 
  */
-package de.terrestris.shogun2.model;
+package de.terrestris.shogun2.model.layout;
 
+import java.awt.Point;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,12 +21,14 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import de.terrestris.shogun2.model.module.CompositeModule;
+
 /**
- * This class is the representation of an border layout, where components are
- * anchored in (predefined) regions, which are stored in the {@link #regions}
+ * This class is the representation of an absolute layout, where components are
+ * anchored in absolute positions, which are stored in the {@link #coords}
  * property.
  * 
- * The order of the {@link #regions} should match the order of the corresponding
+ * The order of the {@link #coords} should match the order of the corresponding
  * {@link CompositeModule#getSubModules()}.
  * 
  * @author Nils Bühner
@@ -33,7 +36,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
  */
 @Table
 @Entity
-public class BorderLayout extends Layout {
+public class AbsoluteLayout extends Layout {
 
 	/**
 	 * 
@@ -44,32 +47,32 @@ public class BorderLayout extends Layout {
 	 * Explicitly adding the default constructor as this is important, e.g. for
 	 * Hibernate: http://goo.gl/3Cr1pw
 	 */
-	public BorderLayout() {
-		this.setType("border");
+	public AbsoluteLayout() {
+		this.setType("absolute");
 	}
 
 	/**
 	 * 
 	 */
 	@ElementCollection(fetch = FetchType.EAGER)
-	@CollectionTable(name = "BORDERLAYOUT_REGIONS", joinColumns = @JoinColumn(name = "LAYOUT_ID") )
-	@Column(name = "REGION")
+	@CollectionTable(name = "ABSOLUTELAYOUT_COORDS", joinColumns = @JoinColumn(name = "LAYOUT_ID") )
+	@Column(name = "COORD")
 	@OrderColumn(name = "INDEX")
-	private List<String> regions = new ArrayList<String>();
+	private List<Point> coords = new ArrayList<Point>();
 
 	/**
-	 * @return the regions
+	 * @return the coords
 	 */
-	public List<String> getRegions() {
-		return regions;
+	public List<Point> getCoords() {
+		return coords;
 	}
 
 	/**
-	 * @param regions
-	 *            the regions to set
+	 * @param coords
+	 *            the coords to set
 	 */
-	public void setRegions(List<String> regions) {
-		this.regions = regions;
+	public void setCoords(List<Point> coords) {
+		this.coords = coords;
 	}
 
 	/**
@@ -82,7 +85,7 @@ public class BorderLayout extends Layout {
 	 */
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(53, 23).appendSuper(super.hashCode()).append(getRegions()).toHashCode();
+		return new HashCodeBuilder(11, 13).appendSuper(super.hashCode()).append(getCoords()).toHashCode();
 	}
 
 	/**
@@ -94,11 +97,11 @@ public class BorderLayout extends Layout {
 	 *      when using ORM like Hibernate
 	 */
 	public boolean equals(Object obj) {
-		if (!(obj instanceof BorderLayout))
+		if (!(obj instanceof AbsoluteLayout))
 			return false;
-		BorderLayout other = (BorderLayout) obj;
+		AbsoluteLayout other = (AbsoluteLayout) obj;
 
-		return new EqualsBuilder().appendSuper(super.equals(other)).append(getRegions(), other.getRegions()).isEquals();
+		return new EqualsBuilder().appendSuper(super.equals(other)).append(getCoords(), other.getCoords()).isEquals();
 	}
 
 	/**
@@ -106,7 +109,7 @@ public class BorderLayout extends Layout {
 	 */
 	public String toString() {
 		return new ToStringBuilder(this, ToStringStyle.DEFAULT_STYLE).appendSuper(super.toString())
-				.append("regions", getRegions()).toString();
+				.append("coords", getCoords()).toString();
 	}
 
 }

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/BorderLayout.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/BorderLayout.java
@@ -1,9 +1,8 @@
 /**
  * 
  */
-package de.terrestris.shogun2.model;
+package de.terrestris.shogun2.model.layout;
 
-import java.awt.Point;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,12 +20,14 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import de.terrestris.shogun2.model.module.CompositeModule;
+
 /**
- * This class is the representation of an absolute layout, where components are
- * anchored in absolute positions, which are stored in the {@link #coords}
+ * This class is the representation of an border layout, where components are
+ * anchored in (predefined) regions, which are stored in the {@link #regions}
  * property.
  * 
- * The order of the {@link #coords} should match the order of the corresponding
+ * The order of the {@link #regions} should match the order of the corresponding
  * {@link CompositeModule#getSubModules()}.
  * 
  * @author Nils Bühner
@@ -34,7 +35,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
  */
 @Table
 @Entity
-public class AbsoluteLayout extends Layout {
+public class BorderLayout extends Layout {
 
 	/**
 	 * 
@@ -45,32 +46,32 @@ public class AbsoluteLayout extends Layout {
 	 * Explicitly adding the default constructor as this is important, e.g. for
 	 * Hibernate: http://goo.gl/3Cr1pw
 	 */
-	public AbsoluteLayout() {
-		this.setType("absolute");
+	public BorderLayout() {
+		this.setType("border");
 	}
 
 	/**
 	 * 
 	 */
 	@ElementCollection(fetch = FetchType.EAGER)
-	@CollectionTable(name = "ABSOLUTELAYOUT_COORDS", joinColumns = @JoinColumn(name = "LAYOUT_ID") )
-	@Column(name = "COORD")
+	@CollectionTable(name = "BORDERLAYOUT_REGIONS", joinColumns = @JoinColumn(name = "LAYOUT_ID") )
+	@Column(name = "REGION")
 	@OrderColumn(name = "INDEX")
-	private List<Point> coords = new ArrayList<Point>();
+	private List<String> regions = new ArrayList<String>();
 
 	/**
-	 * @return the coords
+	 * @return the regions
 	 */
-	public List<Point> getCoords() {
-		return coords;
+	public List<String> getRegions() {
+		return regions;
 	}
 
 	/**
-	 * @param coords
-	 *            the coords to set
+	 * @param regions
+	 *            the regions to set
 	 */
-	public void setCoords(List<Point> coords) {
-		this.coords = coords;
+	public void setRegions(List<String> regions) {
+		this.regions = regions;
 	}
 
 	/**
@@ -83,7 +84,7 @@ public class AbsoluteLayout extends Layout {
 	 */
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(11, 13).appendSuper(super.hashCode()).append(getCoords()).toHashCode();
+		return new HashCodeBuilder(53, 23).appendSuper(super.hashCode()).append(getRegions()).toHashCode();
 	}
 
 	/**
@@ -95,11 +96,11 @@ public class AbsoluteLayout extends Layout {
 	 *      when using ORM like Hibernate
 	 */
 	public boolean equals(Object obj) {
-		if (!(obj instanceof AbsoluteLayout))
+		if (!(obj instanceof BorderLayout))
 			return false;
-		AbsoluteLayout other = (AbsoluteLayout) obj;
+		BorderLayout other = (BorderLayout) obj;
 
-		return new EqualsBuilder().appendSuper(super.equals(other)).append(getCoords(), other.getCoords()).isEquals();
+		return new EqualsBuilder().appendSuper(super.equals(other)).append(getRegions(), other.getRegions()).isEquals();
 	}
 
 	/**
@@ -107,7 +108,7 @@ public class AbsoluteLayout extends Layout {
 	 */
 	public String toString() {
 		return new ToStringBuilder(this, ToStringStyle.DEFAULT_STYLE).appendSuper(super.toString())
-				.append("coords", getCoords()).toString();
+				.append("regions", getRegions()).toString();
 	}
 
 }

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/Layout.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/Layout.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package de.terrestris.shogun2.model;
+package de.terrestris.shogun2.model.layout;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -21,6 +21,9 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+
+import de.terrestris.shogun2.model.PersistentObject;
+import de.terrestris.shogun2.model.module.Module;
 
 /**
  * This class represents the layout of a {@link Module} in a GUI. It provides

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/CompositeModule.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/CompositeModule.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package de.terrestris.shogun2.model;
+package de.terrestris.shogun2.model.module;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Header.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Header.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package de.terrestris.shogun2.model;
+package de.terrestris.shogun2.model.module;
 
 import javax.persistence.Entity;
 import javax.persistence.Table;
@@ -12,15 +12,14 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
- * The viewport is the main container representing the viewable application area
- * (i.e. the browser viewport). It is thereby used in an {@link Application}.
+ * This class represents the header area in a GUI.
  * 
  * @author Nils Bühner
  *
  */
 @Table
 @Entity
-public class Viewport extends CompositeModule {
+public class Header extends CompositeModule {
 
 	/**
 	 * 
@@ -31,7 +30,7 @@ public class Viewport extends CompositeModule {
 	 * Explicitly adding the default constructor as this is important, e.g. for
 	 * Hibernate: http://goo.gl/3Cr1pw
 	 */
-	public Viewport() {
+	public Header() {
 	}
 
 	/**
@@ -44,7 +43,7 @@ public class Viewport extends CompositeModule {
 	 */
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(7, 19).appendSuper(super.hashCode()).toHashCode();
+		return new HashCodeBuilder(23, 3).appendSuper(super.hashCode()).toHashCode();
 	}
 
 	/**
@@ -56,9 +55,9 @@ public class Viewport extends CompositeModule {
 	 *      when using ORM like Hibernate
 	 */
 	public boolean equals(Object obj) {
-		if (!(obj instanceof Viewport))
+		if (!(obj instanceof Header))
 			return false;
-		Viewport other = (Viewport) obj;
+		Header other = (Header) obj;
 
 		return new EqualsBuilder().appendSuper(super.equals(other)).isEquals();
 	}

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/LayerTree.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/LayerTree.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package de.terrestris.shogun2.model;
+package de.terrestris.shogun2.model.module;
 
 import javax.persistence.Entity;
 import javax.persistence.Table;

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Module.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Module.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package de.terrestris.shogun2.model;
+package de.terrestris.shogun2.model.module;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -22,6 +22,9 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+
+import de.terrestris.shogun2.model.PersistentObject;
+import de.terrestris.shogun2.model.layout.Layout;
 
 /**
  * A module is the visual representation of a component in the GUI. A module can

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Viewport.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Viewport.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package de.terrestris.shogun2.model;
+package de.terrestris.shogun2.model.module;
 
 import javax.persistence.Entity;
 import javax.persistence.Table;
@@ -11,15 +11,18 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import de.terrestris.shogun2.model.Application;
+
 /**
- * This class represents the header area in a GUI.
+ * The viewport is the main container representing the viewable application area
+ * (i.e. the browser viewport). It is thereby used in an {@link Application}.
  * 
  * @author Nils Bühner
  *
  */
 @Table
 @Entity
-public class Header extends CompositeModule {
+public class Viewport extends CompositeModule {
 
 	/**
 	 * 
@@ -30,7 +33,7 @@ public class Header extends CompositeModule {
 	 * Explicitly adding the default constructor as this is important, e.g. for
 	 * Hibernate: http://goo.gl/3Cr1pw
 	 */
-	public Header() {
+	public Viewport() {
 	}
 
 	/**
@@ -43,7 +46,7 @@ public class Header extends CompositeModule {
 	 */
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(23, 3).appendSuper(super.hashCode()).toHashCode();
+		return new HashCodeBuilder(7, 19).appendSuper(super.hashCode()).toHashCode();
 	}
 
 	/**
@@ -55,9 +58,9 @@ public class Header extends CompositeModule {
 	 *      when using ORM like Hibernate
 	 */
 	public boolean equals(Object obj) {
-		if (!(obj instanceof Header))
+		if (!(obj instanceof Viewport))
 			return false;
-		Header other = (Header) obj;
+		Viewport other = (Viewport) obj;
 
 		return new EqualsBuilder().appendSuper(super.equals(other)).isEquals();
 	}

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/LayoutService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/LayoutService.java
@@ -2,7 +2,7 @@ package de.terrestris.shogun2.service;
 
 import org.springframework.stereotype.Service;
 
-import de.terrestris.shogun2.model.Layout;
+import de.terrestris.shogun2.model.layout.Layout;
 
 /**
  * Service class for the {@link Layout} model.

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/ModuleService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/ModuleService.java
@@ -2,7 +2,7 @@ package de.terrestris.shogun2.service;
 
 import org.springframework.stereotype.Service;
 
-import de.terrestris.shogun2.model.Module;
+import de.terrestris.shogun2.model.module.Module;
 
 /**
  * Service class for the {@link Module} model.

--- a/src/shogun2-init/src/main/java/de/terrestris/shogun2/init/ContentInitializer.java
+++ b/src/shogun2-init/src/main/java/de/terrestris/shogun2/init/ContentInitializer.java
@@ -21,13 +21,13 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import de.terrestris.shogun2.model.Application;
-import de.terrestris.shogun2.model.BorderLayout;
-import de.terrestris.shogun2.model.Header;
-import de.terrestris.shogun2.model.LayerTree;
-import de.terrestris.shogun2.model.Layout;
-import de.terrestris.shogun2.model.Module;
 import de.terrestris.shogun2.model.User;
-import de.terrestris.shogun2.model.Viewport;
+import de.terrestris.shogun2.model.layout.BorderLayout;
+import de.terrestris.shogun2.model.layout.Layout;
+import de.terrestris.shogun2.model.module.Header;
+import de.terrestris.shogun2.model.module.LayerTree;
+import de.terrestris.shogun2.model.module.Module;
+import de.terrestris.shogun2.model.module.Viewport;
 import de.terrestris.shogun2.security.acl.AclUtil;
 import de.terrestris.shogun2.service.InitializationService;
 

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/LayoutController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/LayoutController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import de.terrestris.shogun2.model.Layout;
+import de.terrestris.shogun2.model.layout.Layout;
 import de.terrestris.shogun2.service.LayoutService;
 
 /**

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/ModuleController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/ModuleController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import de.terrestris.shogun2.model.Module;
+import de.terrestris.shogun2.model.module.Module;
 import de.terrestris.shogun2.service.ModuleService;
 
 /**


### PR DESCRIPTION
This PR contains a simple refactoring of the model package structure. As we have a growing number of models, all module classes and all layout classes have been moved to separate (sub-)packages.