### PR TITLE
Replace deprecated annotation

### DIFF
--- a/src/shogun2-core/shogun2-dao/src/test/java/de/terrestris/shogun2/dao/GenericHibernateDaoTest.java
+++ b/src/shogun2-core/shogun2-dao/src/test/java/de/terrestris/shogun2/dao/GenericHibernateDaoTest.java
@@ -22,9 +22,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.shogun2.model.Application;
@@ -55,7 +55,7 @@ class ConcreteDao extends GenericHibernateDao<Application, Integer> {
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath*:META-INF/spring/test-context-dao.xml" })
 @Transactional
-@TransactionConfiguration(defaultRollback = true)
+@Rollback(true)
 public class GenericHibernateDaoTest {
 
 	/**


### PR DESCRIPTION
The @TransactionConfiguration annotation is deprecated since spring 4.2.2 and has been replaced with the (recommended) @Rollback annotation.