### PR TITLE
Change cmd to generate/submit code coverage data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
   - mvn --batch-mode --threads 2.0C --show-version clean test
 
 after_success:
-  - mvn clean cobertura:cobertura coveralls:cobertura
+  - mvn clean cobertura:cobertura coveralls:report
 
 after_script:
   - cd ..


### PR DESCRIPTION
It seems that since 0d3b0970712974a418bb37f9c7d5cd2daf34d41f we do no longer have coverage reports on coveralls. This PR changes the cmd to use for submitting the coverage data.

Please review.