### PR TITLE
Migrate to container-based infrastructure on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 
+sudo: false
+
 jdk:
   - oraclejdk7
   - oraclejdk8


### PR DESCRIPTION
This PR changes our `.travis.yml` to make use of container-based infrastructure on travis. It removes the warning `This job ran on our legacy infrastructure. Please read our docs on how to upgrade` (e.g. [here](https://travis-ci.org/terrestris/shogun2/jobs/88406745))

See also [this how-to](http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade).

Please review.