### PR TITLE
Module properties

### DIFF
--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Module.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Module.java
@@ -53,6 +53,11 @@ public abstract class Module extends PersistentObject {
 	private String name;
 
 	/**
+	 * The class name (e.g. the xtype in ExtJS) of this module.
+	 */
+	private String xtype;
+
+	/**
 	 *
 	 */
 	@ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
@@ -87,6 +92,21 @@ public abstract class Module extends PersistentObject {
 	 */
 	public void setName(String name) {
 		this.name = name;
+	}
+
+	/**
+	 * @return the xtype
+	 */
+	public String getXtype() {
+		return xtype;
+	}
+
+	/**
+	 * @param xtype
+	 *            the xtype to set
+	 */
+	public void setXtype(String xtype) {
+		this.xtype = xtype;
 	}
 
 	/**
@@ -128,6 +148,7 @@ public abstract class Module extends PersistentObject {
 	 *      -and-hashcode-in-java it is recommended only to use getter-methods
 	 *      when using ORM like Hibernate
 	 */
+	@Override
 	public int hashCode() {
 		// two randomly chosen prime numbers
 		return new HashCodeBuilder(5, 7).appendSuper(super.hashCode()).append(getName()).append(getLayout())
@@ -142,21 +163,31 @@ public abstract class Module extends PersistentObject {
 	 *      -and-hashcode-in-java it is recommended only to use getter-methods
 	 *      when using ORM like Hibernate
 	 */
+	@Override
 	public boolean equals(Object obj) {
 		if (!(obj instanceof Module))
 			return false;
 		Module other = (Module) obj;
 
-		return new EqualsBuilder().appendSuper(super.equals(other)).append(getName(), other.getName())
-				.append(getLayout(), other.getLayout()).append(getProperties(), other.getProperties()).isEquals();
+		return new EqualsBuilder().appendSuper(super.equals(other))
+				.append(getName(), other.getName())
+				.append(getXtype(), other.getXtype())
+				.append(getLayout(), other.getLayout())
+				.append(getProperties(), other.getProperties())
+				.isEquals();
 	}
 
 	/**
 	 *
 	 */
+	@Override
 	public String toString() {
-		return new ToStringBuilder(this, ToStringStyle.DEFAULT_STYLE).appendSuper(super.toString())
-				.append("name", getName()).append("layout", getLayout()).append("properties", getProperties())
+		return new ToStringBuilder(this, ToStringStyle.DEFAULT_STYLE)
+				.appendSuper(super.toString())
+				.append("name", getName())
+				.append("xtype", getXtype())
+				.append("layout", getLayout())
+				.append("properties", getProperties())
 				.toString();
 	}
 }

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-initialize-beans.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-initialize-beans.xml
@@ -1,6 +1,3 @@
-#set( $symbol_pound = '#' )
-#set( $symbol_dollar = '$' )
-#set( $symbol_escape = '\' )
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -73,6 +70,7 @@
 
     <bean id="headerModule" class="de.terrestris.shogun2.model.module.Header">
         <property name="name" value="Viewport Header" />
+        <property name="xtype" value="panel" />
         <property name="properties">
             <util:map>
                 <entry key="region" value="north" />

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-initialize-beans.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-initialize-beans.xml
@@ -1,3 +1,6 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
This PR introduces the property `xtype` to the model Module and may be used to store the the client side class name (or shorthand name in case of ExtJS).