### PR TITLE
Migrate the Layout from Module to CompositeModule

### DIFF
--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/Layout.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/Layout.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package de.terrestris.shogun2.model.layout;
 
@@ -23,16 +23,18 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.shogun2.model.PersistentObject;
+import de.terrestris.shogun2.model.module.CompositeModule;
 import de.terrestris.shogun2.model.module.Module;
 
 /**
- * This class represents the layout of a {@link Module} in a GUI. It provides
- * {@link #propertyHints}, which are (names) of <b>recommended</b> properties of
- * the corresponding {@link Module} and {@link #propertyMusts}, which are
- * (names) of <b>required</b> properties of the {@link Module}. The values of
- * such properties should be stored in
- * {@link Module#setProperties(java.util.Map)}
- * 
+ * This class represents the layout of a {@link CompositeModule} in a GUI.
+ * It provides {@link #propertyHints}, which are (names) of <b>recommended</b>
+ * properties for the children of the corresponding {@link CompositeModule} and
+ * {@link #propertyMusts}, which are (names) of <b>required</b> properties for
+ * the children of the {@link CompositeModule}. The values of such properties
+ * should be stored in the child {@link Module}s property map.
+ * ({@link Module#setProperties(java.util.Map)})
+ *
  * @author Nils Bühner
  *
  */
@@ -42,17 +44,18 @@ import de.terrestris.shogun2.model.module.Module;
 public class Layout extends PersistentObject {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 1L;
 
 	/**
-	 * 
+	 * The type of the layout, e.g. "border", "absolute", "hbox" or "vbox".
 	 */
 	private String type;
 
 	/**
-	 * 
+	 * A set of property names that are <b>recommended</b> for the use in the
+	 * related child modules. {@link CompositeModule#getSubModules()}.
 	 */
 	@ElementCollection(fetch = FetchType.EAGER)
 	@CollectionTable(name = "LAYOUT_PROPERTYHINTS", joinColumns = @JoinColumn(name = "LAYOUT_ID") )
@@ -60,7 +63,8 @@ public class Layout extends PersistentObject {
 	private Set<String> propertyHints = new HashSet<String>();
 
 	/**
-	 * 
+	 * A set of property names that are <b>required</b> for the use in the
+	 * related child modules. {@link CompositeModule#getSubModules()}.
 	 */
 	@ElementCollection(fetch = FetchType.EAGER)
 	@CollectionTable(name = "LAYOUT_PROPERTYMUSTS", joinColumns = @JoinColumn(name = "LAYOUT_ID") )
@@ -76,7 +80,7 @@ public class Layout extends PersistentObject {
 	}
 
 	/**
-	 * 
+	 *
 	 * @return
 	 */
 	public String getType() {
@@ -84,7 +88,7 @@ public class Layout extends PersistentObject {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param type
 	 */
 	public void setType(String type) {
@@ -131,8 +135,12 @@ public class Layout extends PersistentObject {
 	 */
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(13, 7).appendSuper(super.hashCode()).append(getType()).append(getPropertyHints())
-				.append(getPropertyMusts()).toHashCode();
+		return new HashCodeBuilder(13, 7)
+				.appendSuper(super.hashCode())
+				.append(getType())
+				.append(getPropertyHints())
+				.append(getPropertyMusts())
+				.toHashCode();
 	}
 
 	/**
@@ -148,18 +156,23 @@ public class Layout extends PersistentObject {
 			return false;
 		Layout other = (Layout) obj;
 
-		return new EqualsBuilder().appendSuper(super.equals(other)).append(getType(), other.getType())
+		return new EqualsBuilder()
+				.appendSuper(super.equals(other))
+				.append(getType(), other.getType())
 				.append(getPropertyHints(), other.getPropertyHints())
-				.append(getPropertyMusts(), other.getPropertyMusts()).isEquals();
+				.append(getPropertyMusts(), other.getPropertyMusts())
+				.isEquals();
 	}
 
 	/**
 	 *
 	 */
 	public String toString() {
-		return new ToStringBuilder(this, ToStringStyle.DEFAULT_STYLE).appendSuper(super.toString())
-				.append("type", getType()).append("propertyHints", getPropertyHints())
-				.append("propertyMusts", getPropertyMusts()).toString();
+		return new ToStringBuilder(this, ToStringStyle.DEFAULT_STYLE)
+				.appendSuper(super.toString())
+				.append("type", getType())
+				.append("propertyHints", getPropertyHints())
+				.append("propertyMusts", getPropertyMusts())
+				.toString();
 	}
-
 }

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/CompositeModule.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/CompositeModule.java
@@ -12,12 +12,15 @@ import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
+import javax.persistence.ManyToOne;
 import javax.persistence.OrderColumn;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+
+import de.terrestris.shogun2.model.layout.Layout;
 
 /**
  * This (abstract) class represents a composite {@link Module}, i.e. a module
@@ -35,6 +38,14 @@ public abstract class CompositeModule extends Module {
 	private static final long serialVersionUID = 1L;
 
 	/**
+	 * The {@link Layout} of this {@link CompositeModule}, that contains
+	 * property hints/musts for the child modules of this
+	 * {@link CompositeModule}.
+	 */
+	@ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+	private Layout layout;
+
+	/**
 	 *
 	 */
 	@ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
@@ -48,6 +59,20 @@ public abstract class CompositeModule extends Module {
 	 * Hibernate: http://goo.gl/3Cr1pw
 	 */
 	public CompositeModule() {
+	}
+
+	/**
+	 * @return the layout
+	 */
+	public Layout getLayout() {
+		return layout;
+	}
+
+	/**
+	 * @param layout the layout to set
+	 */
+	public void setLayout(Layout layout) {
+		this.layout = layout;
 	}
 
 	/**
@@ -91,7 +116,11 @@ public abstract class CompositeModule extends Module {
 	 */
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(17, 19).appendSuper(super.hashCode()).append(getSubModules()).toHashCode();
+		return new HashCodeBuilder(17, 19)
+				.appendSuper(super.hashCode())
+				.append(getLayout())
+				.append(getSubModules())
+				.toHashCode();
 	}
 
 	/**
@@ -107,7 +136,10 @@ public abstract class CompositeModule extends Module {
 			return false;
 		CompositeModule other = (CompositeModule) obj;
 
-		return new EqualsBuilder().appendSuper(super.equals(other)).append(getSubModules(), other.getSubModules())
+		return new EqualsBuilder()
+				.appendSuper(super.equals(other))
+				.append(getLayout(), other.getLayout())
+				.append(getSubModules(), other.getSubModules())
 				.isEquals();
 	}
 
@@ -115,7 +147,9 @@ public abstract class CompositeModule extends Module {
 	 *
 	 */
 	public String toString() {
-		return new ToStringBuilder(this, ToStringStyle.DEFAULT_STYLE).appendSuper(super.toString())
+		return new ToStringBuilder(this, ToStringStyle.DEFAULT_STYLE)
+				.appendSuper(super.toString())
+				.append("layout", getLayout())
 				.append("subModules", getSubModules()).toString();
 	}
 }

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Module.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Module.java
@@ -6,7 +6,6 @@ package de.terrestris.shogun2.model.module;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.persistence.CascadeType;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -15,7 +14,6 @@ import javax.persistence.FetchType;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.MapKeyColumn;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -56,12 +54,6 @@ public abstract class Module extends PersistentObject {
 	 * The class name (e.g. the xtype in ExtJS) of this module.
 	 */
 	private String xtype;
-
-	/**
-	 *
-	 */
-	@ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
-	private Layout layout;
 
 	/**
 	 *
@@ -110,22 +102,6 @@ public abstract class Module extends PersistentObject {
 	}
 
 	/**
-	 *
-	 * @return
-	 */
-	public Layout getLayout() {
-		return layout;
-	}
-
-	/**
-	 *
-	 * @param layout
-	 */
-	public void setLayout(Layout layout) {
-		this.layout = layout;
-	}
-
-	/**
 	 * @return the properties
 	 */
 	public Map<String, String> getProperties() {
@@ -151,8 +127,11 @@ public abstract class Module extends PersistentObject {
 	@Override
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(5, 7).appendSuper(super.hashCode()).append(getName()).append(getLayout())
-				.append(getProperties()).toHashCode();
+		return new HashCodeBuilder(5, 7)
+				.appendSuper(super.hashCode())
+				.append(getName())
+				.append(getProperties())
+				.toHashCode();
 	}
 
 	/**
@@ -172,7 +151,6 @@ public abstract class Module extends PersistentObject {
 		return new EqualsBuilder().appendSuper(super.equals(other))
 				.append(getName(), other.getName())
 				.append(getXtype(), other.getXtype())
-				.append(getLayout(), other.getLayout())
 				.append(getProperties(), other.getProperties())
 				.isEquals();
 	}
@@ -186,7 +164,6 @@ public abstract class Module extends PersistentObject {
 				.appendSuper(super.toString())
 				.append("name", getName())
 				.append("xtype", getXtype())
-				.append("layout", getLayout())
 				.append("properties", getProperties())
 				.toString();
 	}


### PR DESCRIPTION
As we discussed in our Codesprint last week, the `Layout` contains only information for instances of `CompositeModule`.

This PR migrates the `Layout` from the `Module` class to the `CompositeModule` class.

Please review and merge.