### PR TITLE
Make use of hibernate @Cascade annotation

### DIFF
--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Application.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Application.java
@@ -2,7 +2,6 @@ package de.terrestris.shogun2.model;
 
 import java.util.Locale;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -15,6 +14,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
 
 import ch.rasc.extclassgenerator.Model;
 import de.terrestris.shogun2.model.module.Viewport;
@@ -75,7 +76,8 @@ public class Application extends PersistentObject {
 	/**
 	 * 
 	 */
-	@ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+	@ManyToOne(fetch = FetchType.EAGER)
+	@Cascade(CascadeType.SAVE_UPDATE)
 	private Viewport viewport;
 
 	/**
@@ -188,6 +190,7 @@ public class Application extends PersistentObject {
 	 * 
 	 *      Using Apache Commons String Builder.
 	 */
+	@Override
 	public String toString() {
 		return new ToStringBuilder(this, ToStringStyle.DEFAULT_STYLE).appendSuper(super.toString())
 				.append("name", getName()).append("description", getDescription()).append("language", getLanguage())

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/map/MapConfig.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/map/MapConfig.java
@@ -3,14 +3,12 @@ package de.terrestris.shogun2.model.map;
 import java.awt.geom.Point2D;
 import java.util.List;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
 import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 
@@ -18,6 +16,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
 
 import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.model.layer.util.Extent;
@@ -54,16 +54,15 @@ public class MapConfig extends PersistentObject{
 	/**
 	 *
 	 */
-	@OneToOne(cascade = CascadeType.ALL)
+	@ManyToOne(fetch = FetchType.EAGER)
+	@Cascade(CascadeType.SAVE_UPDATE)
 	private Extent extent;
 
 	/**
 	 *
 	 */
-	@ManyToMany(
-			fetch = FetchType.EAGER,
-			cascade = CascadeType.ALL
-	)
+	@ManyToMany(fetch = FetchType.EAGER)
+	@Cascade(CascadeType.SAVE_UPDATE)
 	@JoinTable(
 			name = "MAPCONFIG_RESOLUTION",
 			joinColumns = { @JoinColumn(name = "MAPCONFIG_ID") },
@@ -80,19 +79,15 @@ public class MapConfig extends PersistentObject{
 	/**
 	 *
 	 */
-	@ManyToOne(
-			fetch = FetchType.EAGER,
-			cascade = CascadeType.ALL
-	)
+	@ManyToOne(fetch = FetchType.EAGER)
+	@Cascade(CascadeType.SAVE_UPDATE)
 	private Resolution maxResolution;
 
 	/**
 	 *
 	 */
-	@ManyToOne(
-			fetch = FetchType.EAGER,
-			cascade = CascadeType.ALL
-	)
+	@ManyToOne(fetch = FetchType.EAGER)
+	@Cascade(CascadeType.SAVE_UPDATE)
 	private Resolution minResolution;
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/CompositeModule.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/CompositeModule.java
@@ -6,7 +6,6 @@ package de.terrestris.shogun2.model.module;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
@@ -19,6 +18,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
 
 import de.terrestris.shogun2.model.layout.Layout;
 
@@ -42,15 +43,20 @@ public abstract class CompositeModule extends Module {
 	 * property hints/musts for the child modules of this
 	 * {@link CompositeModule}.
 	 */
-	@ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+	@ManyToOne(fetch = FetchType.EAGER)
+	@Cascade(CascadeType.SAVE_UPDATE)
 	private Layout layout;
 
 	/**
 	 *
 	 */
-	@ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
-	@JoinTable(name = "MODULE_SUBMODULE", joinColumns = { @JoinColumn(name = "MODULE_ID") }, inverseJoinColumns = {
-			@JoinColumn(name = "SUBMODULE_ID") })
+	@ManyToMany(fetch = FetchType.EAGER)
+	@Cascade(CascadeType.SAVE_UPDATE)
+	@JoinTable(
+			name = "MODULE_SUBMODULE",
+			joinColumns = { @JoinColumn(name = "MODULE_ID") },
+			inverseJoinColumns = { @JoinColumn(name = "SUBMODULE_ID") }
+	)
 	@OrderColumn(name = "INDEX")
 	private List<Module> subModules = new ArrayList<Module>();
 
@@ -114,6 +120,7 @@ public abstract class CompositeModule extends Module {
 	 *      -and-hashcode-in-java it is recommended only to use getter-methods
 	 *      when using ORM like Hibernate
 	 */
+	@Override
 	public int hashCode() {
 		// two randomly chosen prime numbers
 		return new HashCodeBuilder(17, 19)
@@ -131,6 +138,7 @@ public abstract class CompositeModule extends Module {
 	 *      -and-hashcode-in-java it is recommended only to use getter-methods
 	 *      when using ORM like Hibernate
 	 */
+	@Override
 	public boolean equals(Object obj) {
 		if (!(obj instanceof CompositeModule))
 			return false;
@@ -146,6 +154,7 @@ public abstract class CompositeModule extends Module {
 	/**
 	 *
 	 */
+	@Override
 	public String toString() {
 		return new ToStringBuilder(this, ToStringStyle.DEFAULT_STYLE)
 				.appendSuper(super.toString())

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/OverviewMap.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/OverviewMap.java
@@ -6,7 +6,6 @@ package de.terrestris.shogun2.model.module;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.persistence.CascadeType;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -20,6 +19,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
@@ -66,10 +67,8 @@ public class OverviewMap extends Module {
 	/**
 	 *
 	 */
-	@ManyToOne(
-			fetch = FetchType.EAGER,
-			cascade = CascadeType.ALL
-	)
+	@ManyToOne(fetch = FetchType.EAGER)
+	@Cascade(CascadeType.SAVE_UPDATE)
 	@JsonIdentityInfo(
 			generator = ObjectIdGenerators.PropertyGenerator.class,
 			property = "name"


### PR DESCRIPTION
Global replacement of annotation `cascade = CascadeType.ALL` with `@Cascade(CascadeType.SAVE_UPDATE)` to prevent (really!) unwanted effects in relation entities while deleting a parent entity. For annotation details have a look in [here](http://vladmihalcea.com/2015/03/05/a-beginners-guide-to-jpa-and-hibernate-cascade-types/).