### PR TITLE
Convert values of properties map

### DIFF
--- a/src/shogun2-core/shogun2-model/pom.xml
+++ b/src/shogun2-core/shogun2-model/pom.xml
@@ -17,13 +17,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>shogun2-util</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/Layout.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/Layout.java
@@ -14,7 +14,6 @@ import javax.persistence.FetchType;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
-import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Module.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Module.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -23,6 +24,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.model.layout.Layout;
+import de.terrestris.shogun2.util.converter.PropertyValueConverter;
 
 /**
  * A module is the visual representation of a component in the GUI. A module can
@@ -62,7 +64,8 @@ public abstract class Module extends PersistentObject {
 	@MapKeyColumn(name = "PROPERTY")
 	@Column(name = "VALUE")
 	@CollectionTable(name = "MODULE_PROPERTIES", joinColumns = @JoinColumn(name = "MODULE_ID") )
-	private Map<String, String> properties = new HashMap<String, String>();
+	@Convert(converter = PropertyValueConverter.class, attributeName="value")
+	private Map<String, Object> properties = new HashMap<String, Object>();
 
 	/**
 	 * Explicitly adding the default constructor as this is important, e.g. for
@@ -104,7 +107,7 @@ public abstract class Module extends PersistentObject {
 	/**
 	 * @return the properties
 	 */
-	public Map<String, String> getProperties() {
+	public Map<String, Object> getProperties() {
 		return properties;
 	}
 
@@ -112,7 +115,7 @@ public abstract class Module extends PersistentObject {
 	 * @param properties
 	 *            the properties to set
 	 */
-	public void setProperties(Map<String, String> properties) {
+	public void setProperties(Map<String, Object> properties) {
 		this.properties = properties;
 	}
 

--- a/src/shogun2-util/pom.xml
+++ b/src/shogun2-util/pom.xml
@@ -17,6 +17,21 @@
 
     <dependencies>
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
@@ -25,6 +40,7 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/converter/PropertyValueConverter.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/converter/PropertyValueConverter.java
@@ -42,7 +42,9 @@ public class PropertyValueConverter implements AttributeConverter<Object, String
 		} else if ("false".equalsIgnoreCase(dbData)) {
 			return false;
 		} else if (NumberUtils.isParsable(dbData)) {
-			if (NumberUtils.isDigits(dbData)) {
+			if (NumberUtils.isDigits(dbData) ||
+					(dbData.startsWith("-") &&
+							NumberUtils.isDigits(dbData.substring(1)))) {
 				return Long.parseLong(dbData);
 			} else {
 				return Double.parseDouble(dbData);

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/converter/PropertyValueConverter.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/converter/PropertyValueConverter.java
@@ -1,0 +1,54 @@
+/**
+ *
+ */
+package de.terrestris.shogun2.util.converter;
+
+import javax.persistence.AttributeConverter;
+
+import org.apache.commons.lang3.math.NumberUtils;
+
+/**
+ * This converter can be used for the values of the type Map<String, Object>.
+ *
+ * The values of the map will be converted to strings to persist them in a
+ * string column in the database. A string value coming from the database will
+ * be converted to the best matching Java type.
+ *
+ * Currently {@link String}, {@link Long}, {@link Double} and {@link Boolean}
+ * values are supported.
+ *
+ * @author Nils Bühner
+ *
+ */
+public class PropertyValueConverter implements AttributeConverter<Object, String> {
+
+	/**
+	 * Converts an arbitrary object to it's string representation, that will be
+	 * stored in the database.
+	 */
+	@Override
+	public String convertToDatabaseColumn(Object attribute) {
+		return attribute.toString();
+	}
+
+	/**
+	 * Converts a string value from the database to the best matching java
+	 * primitive type.
+	 */
+	@Override
+	public Object convertToEntityAttribute(String dbData) {
+		if ("true".equalsIgnoreCase(dbData)) {
+			return true;
+		} else if ("false".equalsIgnoreCase(dbData)) {
+			return false;
+		} else if (NumberUtils.isParsable(dbData)) {
+			if (NumberUtils.isDigits(dbData)) {
+				return Long.parseLong(dbData);
+			} else {
+				return Double.parseDouble(dbData);
+			}
+		}
+		return dbData;
+	}
+
+}

--- a/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/converter/PropertyValueConverterTest.java
+++ b/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/converter/PropertyValueConverterTest.java
@@ -23,6 +23,7 @@ public class PropertyValueConverterTest {
 		String testValue = "test";
 		Object convertedValue = converter.convertToEntityAttribute(testValue);
 
+		assertTrue(convertedValue instanceof String);
 		assertTrue(testValue.equals(convertedValue));
 	}
 
@@ -33,10 +34,16 @@ public class PropertyValueConverterTest {
 	public void convertToEntityAttribute_convertsToLong() {
 
 		String testValue = "42";
+		String negativeTestValue = "-42";
+
 		Object convertedValue = converter.convertToEntityAttribute(testValue);
+		Object convertedNegativeValue = converter.convertToEntityAttribute(negativeTestValue);
 
 		assertTrue(convertedValue instanceof Long);
 		assertTrue(((Long)convertedValue) == 42);
+
+		assertTrue(convertedNegativeValue instanceof Long);
+		assertTrue(((Long)convertedNegativeValue) == -42);
 	}
 
 	/**
@@ -46,10 +53,16 @@ public class PropertyValueConverterTest {
 	public void convertToEntityAttribute_convertsToDouble() {
 
 		String testValue = "17.42";
+		String negativeTestValue = "-17.42";
+
 		Object convertedValue = converter.convertToEntityAttribute(testValue);
+		Object convertedNegativeValue = converter.convertToEntityAttribute(negativeTestValue);
 
 		assertTrue(convertedValue instanceof Double);
 		assertTrue(((Double)convertedValue) == 17.42);
+
+		assertTrue(convertedNegativeValue instanceof Double);
+		assertTrue(((Double)convertedNegativeValue) == -17.42);
 	}
 
 	/**
@@ -90,9 +103,13 @@ public class PropertyValueConverterTest {
 	public void convertToDatabaseColumn_convertsIntegerToString() {
 
 		int testValue = 42;
+		int negativeTestValue = -42;
+
 		String convertedValue = converter.convertToDatabaseColumn(testValue);
+		String convertedNegativeValue = converter.convertToDatabaseColumn(negativeTestValue);
 
 		assertTrue("42".equals(convertedValue));
+		assertTrue("-42".equals(convertedNegativeValue));
 	}
 
 	/**
@@ -102,9 +119,13 @@ public class PropertyValueConverterTest {
 	public void convertToDatabaseColumn_convertsDoubleToString() {
 
 		double testValue = 17.42;
+		double negativeTestValue = -17.42;
+
 		String convertedValue = converter.convertToDatabaseColumn(testValue);
+		String convertedNegativeValue = converter.convertToDatabaseColumn(negativeTestValue);
 
 		assertTrue("17.42".equals(convertedValue));
+		assertTrue("-17.42".equals(convertedNegativeValue));
 	}
 
 	/**

--- a/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/converter/PropertyValueConverterTest.java
+++ b/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/converter/PropertyValueConverterTest.java
@@ -1,0 +1,122 @@
+package de.terrestris.shogun2.util.converter;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * @author Nils Bühner
+ *
+ */
+public class PropertyValueConverterTest {
+
+	/**
+	 * The converter class to test.
+	 */
+	private final PropertyValueConverter converter = new PropertyValueConverter();
+
+	/**
+	 * Tests whether a string will remain a string.
+	 */
+	@Test
+	public void convertToEntityAttribute_convertsToString() {
+
+		String testValue = "test";
+		Object convertedValue = converter.convertToEntityAttribute(testValue);
+
+		assertTrue(testValue.equals(convertedValue));
+	}
+
+	/**
+	 * Tests whether an integer "string" will be converted to a Long value.
+	 */
+	@Test
+	public void convertToEntityAttribute_convertsToLong() {
+
+		String testValue = "42";
+		Object convertedValue = converter.convertToEntityAttribute(testValue);
+
+		assertTrue(convertedValue instanceof Long);
+		assertTrue(((Long)convertedValue) == 42);
+	}
+
+	/**
+	 * Tests whether an float/double "string" will be converted to a Double value.
+	 */
+	@Test
+	public void convertToEntityAttribute_convertsToDouble() {
+
+		String testValue = "17.42";
+		Object convertedValue = converter.convertToEntityAttribute(testValue);
+
+		assertTrue(convertedValue instanceof Double);
+		assertTrue(((Double)convertedValue) == 17.42);
+	}
+
+	/**
+	 * Tests whether an boolean "string" will be converted to a Boolean value.
+	 */
+	@Test
+	public void convertToEntityAttribute_convertsToBoolean() {
+
+		String testValue = "true";
+		String testValueCaseInsensitive = "faLSe";
+
+		Object convertedValue = converter.convertToEntityAttribute(testValue);
+		Object convertedValueCaseInsensitive = converter.convertToEntityAttribute(testValueCaseInsensitive);
+
+		assertTrue(convertedValue instanceof Boolean);
+		assertTrue(((Boolean)convertedValue) == true);
+
+		assertTrue(convertedValueCaseInsensitive instanceof Boolean);
+		assertTrue(((Boolean)convertedValueCaseInsensitive) == false);
+	}
+
+	/**
+	 * Tests whether a string will be converted to the correct string.
+	 */
+	@Test
+	public void convertToDatabaseColumn_convertsStringToString() {
+
+		String testValue = "test";
+		String convertedValue = converter.convertToDatabaseColumn(testValue);
+
+		assertTrue(testValue.equals(convertedValue));
+	}
+
+	/**
+	 * Tests whether an integer will be converted to the correct string.
+	 */
+	@Test
+	public void convertToDatabaseColumn_convertsIntegerToString() {
+
+		int testValue = 42;
+		String convertedValue = converter.convertToDatabaseColumn(testValue);
+
+		assertTrue("42".equals(convertedValue));
+	}
+
+	/**
+	 * Tests whether a double will be converted to the correct string.
+	 */
+	@Test
+	public void convertToDatabaseColumn_convertsDoubleToString() {
+
+		double testValue = 17.42;
+		String convertedValue = converter.convertToDatabaseColumn(testValue);
+
+		assertTrue("17.42".equals(convertedValue));
+	}
+
+	/**
+	 * Tests whether a boolean will be converted to the correct string.
+	 */
+	@Test
+	public void convertToDatabaseColumn_convertsBooleanToString() {
+
+		boolean testValue = true;
+		String convertedValue = converter.convertToDatabaseColumn(testValue);
+
+		assertTrue("true".equals(convertedValue));
+	}
+
+}


### PR DESCRIPTION
Until now, the `properties` map of the `Module` class was of type `Map<String, String>`. The JSON representation of such maps holds only string values - even for numbers or booleans:

```json
"properties": {
    "integervalue": "42",
    "doublevalue": "-17.42",
    "booleanvalue": "true",
    "stringvalue": "foo"
}
```

This PR changes the value type of the `properties` map to `Map<String, Object>` to allow the administration of arbitrary types (`Object`). As hibernate cannot handle such maps just like that, a JPA converter has been implemented (`PropertyValueConverter`). This converter will store all values as their string representation in the database. When such a string value is read from the database, the converter tries to parse it as the best matching Java Type, e.g.

`"foo" -> "foo"`
`"42" -> 42`
`"17.42" -> 17.42`
`"true" -> true`

This leads to the following JSON representation:

```json
"properties": {
    "integervalue": 42,
    "doublevalue": -17.42,
    "booleanvalue": true,
    "stringvalue": "foo"
}
```

Of course, this approach has some disadvantages:

* There will never be string values with digits only in our JSON (as they would be parsed as numbers)
* The strings "true" and "false" would always be converted to boolean values.

I would like to merge this PR as I don't think that this is a major problem for now. A client could still convert the primitives to strings, if necessary. If really needed, we could also think about a concept to allow "true" or "12345" strings  by introducing some kind of escape char, prefix or suffix.

This PR also contains tests for the `PropertyValueConverter`