### PR TITLE
Change class type for models Module and CompositeModule

### DIFF
--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/CompositeModule.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/CompositeModule.java
@@ -24,14 +24,14 @@ import org.hibernate.annotations.CascadeType;
 import de.terrestris.shogun2.model.layout.Layout;
 
 /**
- * This (abstract) class represents a composite {@link Module}, i.e. a module
+ * This class represents a (simple) composite {@link Module}, i.e. a module 
  * having children/submodules.
  *
  * @author Nils Bühner
  *
  */
 @Entity
-public abstract class CompositeModule extends Module {
+public class CompositeModule extends Module {
 
 	/**
 	 *

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Module.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Module.java
@@ -31,16 +31,16 @@ import de.terrestris.shogun2.util.converter.PropertyValueConverter;
  * be connected to a {@link Layout} and it stores basic properties (like
  * <i>border</i>, <i>height</i> , <i>width</i>, ...).
  *
- * This class is the abstract superclass of either simple (e.g.
- * {@link LayerTree}) or complex ({@link CompositeModule}) subclasses and can
- * thereby considered as a node in a tree structure of (sub-)modules.
+ * This class is the simple base class of either simple (e.g. {@link LayerTree})
+ * or complex ({@link CompositeModule}) subclasses and can thereby considered
+ * as a node in a tree structure of (sub-)modules.
  *
  * @author Nils Bühner
  *
  */
 @Entity
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
-public abstract class Module extends PersistentObject {
+public class Module extends PersistentObject {
 
 	/**
 	 *


### PR DESCRIPTION
This PR suggests to handle the models `Module` and `CompositeModule` as classes instead of abstract classes. Having this set, we will be able to use these as models for simple modules like a plain ExtJS panel.