### PR TITLE
Updated models LayerAppearance and WmsTileGrid

### DIFF
--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/appearance/LayerAppearance.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/appearance/LayerAppearance.java
@@ -1,15 +1,24 @@
 package de.terrestris.shogun2.model.layer.appearance;
 
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 
 import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.model.layer.Layer;
+import de.terrestris.shogun2.model.layer.util.Resolution;
 
 /**
  *
@@ -27,12 +36,53 @@ public class LayerAppearance extends PersistentObject{
 	 *
 	 */
 	private static final long serialVersionUID = 1L;
-	private String type;
+
+	/**
+	 *
+	 */
 	private String attribution;
+
+	/**
+	 *
+	 */
 	private String name;
-	private Double maxScale;
-	private Double minScale;
+
+	/**
+	 *
+	 */
+	@ManyToOne(fetch = FetchType.EAGER)
+	@Cascade(CascadeType.SAVE_UPDATE)
+	// The maxResolution will be serialized (JSON)
+	// as the simple resolution value
+	@JsonIdentityInfo(
+			generator = ObjectIdGenerators.PropertyGenerator.class,
+			property = "resolution"
+	)
+	@JsonIdentityReference(alwaysAsId = true)
+	private Resolution maxResolution;
+
+	/**
+	 *
+	 */
+	@ManyToOne(fetch = FetchType.EAGER)
+	@Cascade(CascadeType.SAVE_UPDATE)
+	// The maxResolution will be serialized (JSON)
+	// as the simple resolution value
+	@JsonIdentityInfo(
+			generator = ObjectIdGenerators.PropertyGenerator.class,
+			property = "resolution"
+	)
+	@JsonIdentityReference(alwaysAsId = true)
+	private Resolution minResolution;
+
+	/**
+	 *
+	 */
 	private Double opacity;
+
+	/**
+	 *
+	 */
 	private Boolean visible;
 
 	/**
@@ -46,35 +96,20 @@ public class LayerAppearance extends PersistentObject{
 	 * @param type
 	 * @param attribution
 	 * @param name
-	 * @param maxScale
-	 * @param minScale
+	 * @param maxResolution
+	 * @param minResolution
 	 * @param opacity
 	 * @param visible
 	 */
-	public LayerAppearance(String type, String attribution, String name, Double maxScale, Double minScale,
-			Double opacity, Boolean visible) {
+	public LayerAppearance(String attribution, String name, Resolution maxResolution,
+			Resolution minResolution, Double opacity, Boolean visible) {
 		super();
-		this.type = type;
 		this.attribution = attribution;
 		this.name = name;
-		this.maxScale = maxScale;
-		this.minScale = minScale;
+		this.maxResolution = maxResolution;
+		this.minResolution = minResolution;
 		this.opacity = opacity;
 		this.visible = visible;
-	}
-
-	/**
-	 * @return the type
-	 */
-	public String getType() {
-		return type;
-	}
-
-	/**
-	 * @param type the type to set
-	 */
-	public void setType(String type) {
-		this.type = type;
 	}
 
 	/**
@@ -106,31 +141,31 @@ public class LayerAppearance extends PersistentObject{
 	}
 
 	/**
-	 * @return the maxScale
+	 * @return the maxResolution
 	 */
-	public Double getMaxScale() {
-		return maxScale;
+	public Resolution getMaxResolution() {
+		return maxResolution;
 	}
 
 	/**
-	 * @param maxScale the maxScale to set
+	 * @param maxResolution the maxResolution to set
 	 */
-	public void setMaxScale(Double maxScale) {
-		this.maxScale = maxScale;
+	public void setMaxResolution(Resolution maxResolution) {
+		this.maxResolution = maxResolution;
 	}
 
 	/**
-	 * @return the minScale
+	 * @return the minResolution
 	 */
-	public Double getMinScale() {
-		return minScale;
+	public Resolution getMinResolution() {
+		return minResolution;
 	}
 
 	/**
-	 * @param minScale the minScale to set
+	 * @param minResolution the minResolution to set
 	 */
-	public void setMinScale(Double minScale) {
-		this.minScale = minScale;
+	public void setMinResolution(Resolution minResolution) {
+		this.minResolution = minResolution;
 	}
 
 	/**
@@ -169,15 +204,15 @@ public class LayerAppearance extends PersistentObject{
 	 *      -and-hashcode-in-java it is recommended only to use getter-methods
 	 *      when using ORM like Hibernate
 	 */
+	@Override
 	public int hashCode() {
 		// two randomly chosen prime numbers
 		return new HashCodeBuilder(31, 13).
 				appendSuper(super.hashCode()).
-				append(getType()).
 				append(getAttribution()).
 				append(getName()).
-				append(getMaxScale()).
-				append(getMinScale()).
+				append(getMaxResolution()).
+				append(getMinResolution()).
 				append(getOpacity()).
 				append(getVisible()).
 				toHashCode();
@@ -191,6 +226,7 @@ public class LayerAppearance extends PersistentObject{
 	 *      -and-hashcode-in-java it is recommended only to use getter-methods
 	 *      when using ORM like Hibernate
 	 */
+	@Override
 	public boolean equals(Object obj) {
 		if (!(obj instanceof LayerAppearance))
 			return false;
@@ -198,11 +234,10 @@ public class LayerAppearance extends PersistentObject{
 
 		return new EqualsBuilder().
 				appendSuper(super.equals(other)).
-				append(getType(), other.getType()).
 				append(getAttribution(), other.getAttribution()).
 				append(getName(), other.getName()).
-				append(getMaxScale(), other.getMaxScale()).
-				append(getMinScale(), other.getMinScale()).
+				append(getMaxResolution(), other.getMaxResolution()).
+				append(getMinResolution(), other.getMinResolution()).
 				append(getOpacity(), other.getOpacity()).
 				append(getVisible(), other.getVisible()).
 				isEquals();

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/WmsTileGrid.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/WmsTileGrid.java
@@ -47,6 +47,11 @@ public class WmsTileGrid extends PersistentObject {
 	private static final long serialVersionUID = 1L;
 
 	/**
+	 * The tileGrid type. Typically one of `TileGrid` or `WMTS`.
+	 */
+	private String type;
+
+	/**
 	 * The tile grid origin, i.e. where the x and y axes meet ([z, 0, 0]).
 	 * Tile coordinates increase left to right and upwards.
 	 * If not specified, extent or origins must be provided.
@@ -105,6 +110,20 @@ public class WmsTileGrid extends PersistentObject {
 		this.tileGridOrigin = tileGridOrigin;
 		this.tileGridExtent = tileGridExtent;
 		this.tileSize = tileSize;
+	}
+
+	/**
+	 * @return the type
+	 */
+	public String getType() {
+		return type;
+	}
+
+	/**
+	 * @param type the type to set
+	 */
+	public void setType(String type) {
+		this.type = type;
 	}
 
 	/**
@@ -176,6 +195,7 @@ public class WmsTileGrid extends PersistentObject {
 		// two randomly chosen prime numbers
 		return new HashCodeBuilder(43, 13).
 				appendSuper(super.hashCode()).
+				append(getType()).
 				append(getTileSize()).
 				append(getTileGridOrigin()).
 				append(getTileGridExtent()).
@@ -199,6 +219,7 @@ public class WmsTileGrid extends PersistentObject {
 
 		return new EqualsBuilder().
 				appendSuper(super.equals(other)).
+				append(getType(), other.getType()).
 				append(getTileGridExtent(), other.getTileGridExtent()).
 				append(getTileGridOrigin(), other.getTileGridOrigin()).
 				append(getTileSize(), other.getTileSize()).

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/WmsTileGrid.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/WmsTileGrid.java
@@ -5,10 +5,15 @@ package de.terrestris.shogun2.model.layer.util;
 
 import java.awt.geom.Point2D;
 import java.awt.geom.Point2D.Double;
+import java.util.List;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
+import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -17,6 +22,10 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 
 import de.terrestris.shogun2.model.PersistentObject;
 
@@ -57,6 +66,26 @@ public class WmsTileGrid extends PersistentObject {
 	 * default value: 256
 	 */
 	private Integer tileSize;
+
+	/**
+	 * The tileGrid resolutions.
+	 */
+	@ManyToMany(fetch = FetchType.EAGER)
+	@Cascade(CascadeType.SAVE_UPDATE)
+	@JoinTable(
+			name = "WMSTILEGRID_RESOLUTION",
+			joinColumns = { @JoinColumn(name = "WMSTILEGRID_ID") },
+			inverseJoinColumns = { @JoinColumn(name = "RESOLUTION_ID") }
+	)
+	@OrderColumn(name = "IDX")
+	// The List of resolutions will be serialized (JSON) as an array of resolution
+	// values
+	@JsonIdentityInfo(
+			generator = ObjectIdGenerators.PropertyGenerator.class,
+			property = "resolution"
+	)
+	@JsonIdentityReference(alwaysAsId = true)
+	private List<Resolution> tileGridResolutions;
 
 	/**
 	 *
@@ -121,6 +150,20 @@ public class WmsTileGrid extends PersistentObject {
 	}
 
 	/**
+	 * @return the tileGridResolutions
+	 */
+	public List<Resolution> getTileGridResolutions() {
+		return tileGridResolutions;
+	}
+
+	/**
+	 * @param tileGridResolutions the tileGridResolutions to set
+	 */
+	public void setTileGridResolutions(List<Resolution> tileGridResolutions) {
+		this.tileGridResolutions = tileGridResolutions;
+	}
+
+	/**
 	 * @see java.lang.Object#hashCode()
 	 *
 	 *      According to
@@ -136,6 +179,7 @@ public class WmsTileGrid extends PersistentObject {
 				append(getTileSize()).
 				append(getTileGridOrigin()).
 				append(getTileGridExtent()).
+				append(getTileGridResolutions()).
 				toHashCode();
 	}
 
@@ -158,6 +202,7 @@ public class WmsTileGrid extends PersistentObject {
 				append(getTileGridExtent(), other.getTileGridExtent()).
 				append(getTileGridOrigin(), other.getTileGridOrigin()).
 				append(getTileSize(), other.getTileSize()).
+				append(getTileGridResolutions(), other.getTileGridResolutions()).
 				isEquals();
 	}
 


### PR DESCRIPTION
Changes in module `LayerAppearance`: 
* The property `type` is removed because the layer type is already set in the `Layer` model.
* The properties `maxScale` and `minScale` are replaced with `maxResolution` and `minResolution` as the ol.layer hasn't support for scales in this context and we are now able to re-use any given `Resolution` entity here.

Changes in module `WmsTileGrid`:
* Property `tileGridResolutions` is added as it is required in the ol.tilegrid class.
* Add property `key` to explicitly set the ol.tilegrid type.