### PR TITLE
Add property mapControlProperties

### DIFF
--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/map/MapControl.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/map/MapControl.java
@@ -1,6 +1,16 @@
 package de.terrestris.shogun2.model.map;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.MapKeyColumn;
 import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -9,6 +19,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.shogun2.model.PersistentObject;
+import de.terrestris.shogun2.util.converter.PropertyValueConverter;
 
 /**
  * This class represents an
@@ -39,6 +50,22 @@ public class MapControl extends PersistentObject {
 	/**
 	 *
 	 */
+	@ElementCollection(fetch = FetchType.LAZY)
+	@MapKeyColumn(name = "MAPCTRLPROPERTY")
+	@Column(name = "VALUE")
+	@CollectionTable(
+			name = "MAPCONTROL_MAPCTRLPROPERTIES",
+			joinColumns = @JoinColumn(name = "MAPCONTROL_ID")
+	)
+	@Convert(
+			converter = PropertyValueConverter.class,
+			attributeName = "value"
+	)
+	private Map<String, Object> mapControlProperties = new HashMap<String, Object>();
+
+	/**
+	 *
+	 */
 	public MapControl() {
 		super();
 	}
@@ -63,6 +90,20 @@ public class MapControl extends PersistentObject {
 	}
 
 	/**
+	 * @return the mapControlProperties
+	 */
+	public Map<String, Object> getMapControlProperties() {
+		return mapControlProperties;
+	}
+
+	/**
+	 * @param mapControlProperties the mapControlProperties to set
+	 */
+	public void setMapControlProperties(Map<String, Object> mapControlProperties) {
+		this.mapControlProperties = mapControlProperties;
+	}
+
+	/**
 	 * @see java.lang.Object#hashCode()
 	 *
 	 *      According to
@@ -70,12 +111,14 @@ public class MapControl extends PersistentObject {
 	 *      -and-hashcode-in-java it is recommended only to use getter-methods
 	 *      when using ORM like Hibernate
 	 */
+	@Override
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(7, 13).
-				appendSuper(super.hashCode()).
-				append(mapControlName).
-				toHashCode();
+		return new HashCodeBuilder(7, 13)
+				.appendSuper(super.hashCode())
+				.append(getMapControlName())
+				.append(getMapControlProperties())
+				.toHashCode();
 	}
 
 	/**
@@ -86,6 +129,7 @@ public class MapControl extends PersistentObject {
 	 *      -and-hashcode-in-java it is recommended only to use getter-methods
 	 *      when using ORM like Hibernate
 	 */
+	@Override
 	public boolean equals(Object obj) {
 		if (!(obj instanceof MapControl))
 			return false;
@@ -93,6 +137,7 @@ public class MapControl extends PersistentObject {
 
 		return new EqualsBuilder().
 				append(getMapControlName(), other.getMapControlName()).
+				append(getMapControlProperties(), other.getMapControlProperties()).
 				isEquals();
 	}
 


### PR DESCRIPTION
The `mapControlProperties` property may be used to set custom ol.control options (e.g. units).