### PR TITLE
Avoid LazyInitializationException with open session in view

### DIFF
--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Application.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Application.java
@@ -4,7 +4,6 @@ import java.util.Locale;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.ManyToOne;
@@ -79,7 +78,7 @@ public class Application extends PersistentObject {
 	/**
 	 *
 	 */
-	@ManyToOne(fetch = FetchType.EAGER)
+	@ManyToOne
 	@Cascade(CascadeType.SAVE_UPDATE)
 	private Viewport viewport;
 

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/Layer.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/Layer.java
@@ -1,7 +1,6 @@
 package de.terrestris.shogun2.model.layer;
 
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
@@ -39,11 +38,11 @@ public class Layer extends PersistentObject {
 	private String name;
 	private String type;
 
-	@ManyToOne(fetch = FetchType.EAGER)
+	@ManyToOne
 	@Cascade(CascadeType.SAVE_UPDATE)
 	private LayerDataSource source;
 
-	@ManyToOne(fetch = FetchType.EAGER)
+	@ManyToOne
 	@Cascade(CascadeType.SAVE_UPDATE)
 	private LayerAppearance appearance;
 

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/appearance/LayerAppearance.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/appearance/LayerAppearance.java
@@ -1,7 +1,6 @@
 package de.terrestris.shogun2.model.layer.appearance;
 
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
@@ -50,7 +49,7 @@ public class LayerAppearance extends PersistentObject{
 	/**
 	 *
 	 */
-	@ManyToOne(fetch = FetchType.EAGER)
+	@ManyToOne
 	@Cascade(CascadeType.SAVE_UPDATE)
 	// The maxResolution will be serialized (JSON)
 	// as the simple resolution value
@@ -64,7 +63,7 @@ public class LayerAppearance extends PersistentObject{
 	/**
 	 *
 	 */
-	@ManyToOne(fetch = FetchType.EAGER)
+	@ManyToOne
 	@Cascade(CascadeType.SAVE_UPDATE)
 	// The maxResolution will be serialized (JSON)
 	// as the simple resolution value

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/source/ImageWmsLayerDataSource.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/source/ImageWmsLayerDataSource.java
@@ -3,7 +3,6 @@ package de.terrestris.shogun2.model.layer.source;
 import java.util.List;
 
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
@@ -43,7 +42,7 @@ public class ImageWmsLayerDataSource extends LayerDataSource {
 	private int height;
 	private String version;
 
-	@ManyToMany(fetch = FetchType.EAGER)
+	@ManyToMany
 	@JoinTable(
 			name = "IMAGEWMSLAYERDATASRC_LAYERNAME",
 			joinColumns = { @JoinColumn(name = "IMAGEWMSLAYERDATASOURCE_ID") },
@@ -60,7 +59,7 @@ public class ImageWmsLayerDataSource extends LayerDataSource {
 	@JsonIdentityReference(alwaysAsId = true)
 	private List<GeoWebServiceLayerName> layerNames;
 
-	@ManyToMany(fetch = FetchType.EAGER)
+	@ManyToMany
 	@JoinTable(
 			name = "IMAGEWMSLAYERDATASOURCE_STYLE",
 			joinColumns = { @JoinColumn(name = "IMAGEWMSLAYERDATASOURCE_ID") },

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/source/TileWmsLayerDataSource.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/source/TileWmsLayerDataSource.java
@@ -3,7 +3,6 @@ package de.terrestris.shogun2.model.layer.source;
 import java.util.List;
 
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
@@ -45,7 +44,7 @@ public class TileWmsLayerDataSource extends LayerDataSource {
 	private int height;
 	private String version;
 
-	@ManyToMany(fetch = FetchType.EAGER)
+	@ManyToMany
 	@JoinTable(
 			name = "TILEWMSLAYERDATASRC_LAYERNAME",
 			joinColumns = { @JoinColumn(name = "TILEWMSLAYERDATASOURCE_ID") },
@@ -62,7 +61,7 @@ public class TileWmsLayerDataSource extends LayerDataSource {
 	@JsonIdentityReference(alwaysAsId = true)
 	private List<GeoWebServiceLayerName> layerNames;
 
-	@ManyToMany(fetch = FetchType.EAGER)
+	@ManyToMany
 	@JoinTable(
 			name = "TILEWMSLAYERDATASOURCE_STYLE",
 			joinColumns = { @JoinColumn(name = "TILEWMSLAYERDATASOURCE_ID") },
@@ -79,7 +78,7 @@ public class TileWmsLayerDataSource extends LayerDataSource {
 	@JsonIdentityReference(alwaysAsId = true)
 	private List<GeoWebServiceLayerStyle> layerStyles;
 
-	@ManyToOne(fetch = FetchType.EAGER)
+	@ManyToOne
 	@Cascade(CascadeType.SAVE_UPDATE)
 	private WmsTileGrid tileGrid;
 

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/source/XyzLayerDataSource.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/source/XyzLayerDataSource.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.JoinTable;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
@@ -43,7 +42,7 @@ public class XyzLayerDataSource extends LayerDataSource {
 	@OneToOne
 	private Extent extent;
 
-	@OneToMany(fetch = FetchType.EAGER)
+	@OneToMany
 	@JoinTable(name = "LAYERDATASOURCE_RESOLUTIONS")
 	private List<Resolution> resolutions = new ArrayList<Resolution>();
 

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/WmsTileGrid.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/WmsTileGrid.java
@@ -8,7 +8,6 @@ import java.awt.geom.Point2D.Double;
 import java.util.List;
 
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
@@ -63,7 +62,7 @@ public class WmsTileGrid extends PersistentObject {
 	 * by ol.source.Tile sources. When no origin or origins are configured,
 	 * the origin will be set to the top-left corner of the extent.
 	 */
-	@ManyToOne(fetch = FetchType.EAGER)
+	@ManyToOne
 	@Cascade(CascadeType.SAVE_UPDATE)
 	private Extent tileGridExtent;
 
@@ -75,7 +74,7 @@ public class WmsTileGrid extends PersistentObject {
 	/**
 	 * The tileGrid resolutions.
 	 */
-	@ManyToMany(fetch = FetchType.EAGER)
+	@ManyToMany()
 	@Cascade(CascadeType.SAVE_UPDATE)
 	@JoinTable(
 			name = "WMSTILEGRID_RESOLUTION",

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/AbsoluteLayout.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/AbsoluteLayout.java
@@ -11,7 +11,6 @@ import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.OrderColumn;
 import javax.persistence.Table;
@@ -54,7 +53,7 @@ public class AbsoluteLayout extends Layout {
 	/**
 	 * 
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(name = "ABSOLUTELAYOUT_COORDS", joinColumns = @JoinColumn(name = "LAYOUT_ID") )
 	@Column(name = "COORD")
 	@OrderColumn(name = "IDX")

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/BorderLayout.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/BorderLayout.java
@@ -10,7 +10,6 @@ import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.OrderColumn;
 import javax.persistence.Table;
@@ -53,7 +52,7 @@ public class BorderLayout extends Layout {
 	/**
 	 * 
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(name = "BORDERLAYOUT_REGIONS", joinColumns = @JoinColumn(name = "LAYOUT_ID") )
 	@Column(name = "REGION")
 	@OrderColumn(name = "IDX")

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/Layout.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/Layout.java
@@ -10,7 +10,6 @@ import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
@@ -56,7 +55,7 @@ public class Layout extends PersistentObject {
 	 * A set of property names that are <b>recommended</b> for the use in the
 	 * related child modules. {@link CompositeModule#getSubModules()}.
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(name = "LAYOUT_PROPERTYHINTS", joinColumns = @JoinColumn(name = "LAYOUT_ID") )
 	@Column(name = "PROPERTYNAME")
 	private Set<String> propertyHints = new HashSet<String>();
@@ -65,7 +64,7 @@ public class Layout extends PersistentObject {
 	 * A set of property names that are <b>required</b> for the use in the
 	 * related child modules. {@link CompositeModule#getSubModules()}.
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(name = "LAYOUT_PROPERTYMUSTS", joinColumns = @JoinColumn(name = "LAYOUT_ID") )
 	@Column(name = "PROPERTYNAME")
 	private Set<String> propertyMusts = new HashSet<String>();

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/map/MapConfig.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/map/MapConfig.java
@@ -4,7 +4,6 @@ import java.awt.geom.Point2D;
 import java.util.List;
 
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
@@ -58,14 +57,14 @@ public class MapConfig extends PersistentObject{
 	/**
 	 *
 	 */
-	@ManyToOne(fetch = FetchType.EAGER)
+	@ManyToOne
 	@Cascade(CascadeType.SAVE_UPDATE)
 	private Extent extent;
 
 	/**
 	 *
 	 */
-	@ManyToMany(fetch = FetchType.EAGER)
+	@ManyToMany
 	@Cascade(CascadeType.SAVE_UPDATE)
 	@JoinTable(
 			name = "MAPCONFIG_RESOLUTION",
@@ -90,7 +89,7 @@ public class MapConfig extends PersistentObject{
 	/**
 	 *
 	 */
-	@ManyToOne(fetch = FetchType.EAGER)
+	@ManyToOne
 	@Cascade(CascadeType.SAVE_UPDATE)
 	// The maxResolution will be serialized (JSON)
 	// as the simple resolution value
@@ -104,7 +103,7 @@ public class MapConfig extends PersistentObject{
 	/**
 	 *
 	 */
-	@ManyToOne(fetch = FetchType.EAGER)
+	@ManyToOne
 	@Cascade(CascadeType.SAVE_UPDATE)
 	// The minResolution will be serialized (JSON)
 	// as the simple resolution value

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/map/MapControl.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/map/MapControl.java
@@ -8,7 +8,6 @@ import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.MapKeyColumn;
 import javax.persistence.Table;
@@ -50,7 +49,7 @@ public class MapControl extends PersistentObject {
 	/**
 	 *
 	 */
-	@ElementCollection(fetch = FetchType.LAZY)
+	@ElementCollection
 	@MapKeyColumn(name = "MAPCTRLPROPERTY")
 	@Column(name = "VALUE")
 	@CollectionTable(

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/CompositeModule.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/CompositeModule.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
@@ -43,14 +42,14 @@ public class CompositeModule extends Module {
 	 * property hints/musts for the child modules of this
 	 * {@link CompositeModule}.
 	 */
-	@ManyToOne(fetch = FetchType.EAGER)
+	@ManyToOne
 	@Cascade(CascadeType.SAVE_UPDATE)
 	private Layout layout;
 
 	/**
 	 *
 	 */
-	@ManyToMany(fetch = FetchType.EAGER)
+	@ManyToMany
 	@Cascade(CascadeType.SAVE_UPDATE)
 	@JoinTable(
 			name = "MODULE_SUBMODULE",

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/CoordinateTransform.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/CoordinateTransform.java
@@ -10,7 +10,6 @@ import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.OrderColumn;
 import javax.persistence.Table;
@@ -39,7 +38,7 @@ public class CoordinateTransform extends Module {
 	/**
 	 * A list of EPSG-Codes that should be available in the module.
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(name = "COORDINATETRANSFORM_EPSG", joinColumns = @JoinColumn(name = "COORDTRANS_ID") )
 	@Column(name = "EPSG")
 	@OrderColumn(name = "IDX")

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Map.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Map.java
@@ -51,7 +51,7 @@ public class Map extends Module {
 	 * The MapConfig used by this Map. A MapConfig can be used by several maps
 	 * or overview maps.
 	 */
-	@ManyToOne(fetch = FetchType.EAGER)
+	@ManyToOne
 	@Cascade(CascadeType.SAVE_UPDATE)
 	private MapConfig mapConfig;
 
@@ -72,7 +72,7 @@ public class Map extends Module {
 	/**
 	 * The layers used within this Map.
 	 */
-	@ManyToMany(fetch = FetchType.EAGER)
+	@ManyToMany
 	@JoinTable(
 			name = "MAP_LAYERS",
 			joinColumns = { @JoinColumn(name = "MAP_ID") },

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Map.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Map.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Set;
 
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
@@ -58,9 +57,7 @@ public class Map extends Module {
 	/**
 	 * The controls used within this Map.
 	 */
-	@ManyToMany(
-			fetch = FetchType.EAGER
-	)
+	@ManyToMany
 	@JoinTable(
 			name = "MAP_MAPCONTROLS",
 			joinColumns = { @JoinColumn(name = "MAP_ID") },

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Module.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Module.java
@@ -11,7 +11,6 @@ import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
@@ -60,7 +59,7 @@ public class Module extends PersistentObject {
 	/**
 	 *
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@MapKeyColumn(name = "PROPERTY")
 	@Column(name = "VALUE")
 	@CollectionTable(name = "MODULE_PROPERTIES", joinColumns = @JoinColumn(name = "MODULE_ID") )

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/NominatimSearch.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/NominatimSearch.java
@@ -12,7 +12,6 @@ import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.OrderColumn;
 import javax.persistence.Table;
@@ -109,7 +108,7 @@ public class NominatimSearch extends Module {
 	/**
 	 * A list of EPSG-Codes the should be available in the module.
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(name = "NOMINATIM_VIEWBOXLBRT", joinColumns = @JoinColumn(name = "NOMINATIM_ID") )
 	@Column(name = "VIEWBOXINTEGER")
 	@OrderColumn(name = "IDX")

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/OverpassSearch.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/OverpassSearch.java
@@ -12,7 +12,6 @@ import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.OrderColumn;
 import javax.persistence.Table;
@@ -110,7 +109,7 @@ public class OverpassSearch extends Module {
 	/**
 	 * A list of EPSG-Codes the should be available in the module.
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(name = "OVERPASS_VIEWBOXLBRT", joinColumns = @JoinColumn(name = "OVERPASS_ID") )
 	@Column(name = "VIEWBOXINTEGER")
 	@OrderColumn(name = "IDX")

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/OverviewMap.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/OverviewMap.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToOne;
@@ -55,7 +54,7 @@ public class OverviewMap extends Module {
 	/**
 	 * The layers used within this OverviewMap.
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@JoinTable(
 			name = "OVERVIEWMAP_LAYERS",
 			joinColumns = { @JoinColumn(name = "OVERVIEWMAP_ID") },
@@ -67,7 +66,7 @@ public class OverviewMap extends Module {
 	/**
 	 *
 	 */
-	@ManyToOne(fetch = FetchType.EAGER)
+	@ManyToOne
 	@Cascade(CascadeType.SAVE_UPDATE)
 	@JsonIdentityInfo(
 			generator = ObjectIdGenerators.PropertyGenerator.class,

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/WfsSearch.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/WfsSearch.java
@@ -10,7 +10,6 @@ import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.OrderColumn;
 import javax.persistence.Table;
@@ -65,7 +64,7 @@ public class WfsSearch extends Module {
 	/**
 	 * The layers to search in.
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(name = "WFSSEARCH_LAYERS", joinColumns = @JoinColumn(name = "WFSSEARCH_ID") )
 	@Column(name = "LAYER")
 	@OrderColumn(name = "IDX")
@@ -81,7 +80,7 @@ public class WfsSearch extends Module {
 	 * The allowed data-types to match against in the describefeaturetype
 	 * response
 	 */
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection
 	@CollectionTable(name = "WFSSEARCH_FEATUREDATATYPES", joinColumns = @JoinColumn(name = "WFSSEARCH_ID") )
 	@Column(name = "FEATUREDATATYPES")
 	@OrderColumn(name = "IDX")

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
@@ -67,7 +67,7 @@
         <welcome-file>index.html</welcome-file>
     </welcome-file-list>
 
-        <!-- Spring Security -->
+    <!-- Spring Security -->
     <filter>
         <filter-name>springSecurityFilterChain</filter-name>
         <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
@@ -76,6 +76,17 @@
     <filter-mapping>
         <filter-name>springSecurityFilterChain</filter-name>
         <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+    <!-- Allow lazy loading in web views for JSON serializing -->
+    <filter>
+        <filter-name>openSessionInViewFilter</filter-name>
+        <filter-class>org.springframework.orm.hibernate5.support.OpenSessionInViewFilter</filter-class>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>openSessionInViewFilter</filter-name>
+        <url-pattern>*.action</url-pattern>
     </filter-mapping>
 
 </web-app>


### PR DESCRIPTION
Note: This PR is a duplicate of [#73](https://github.com/terrestris/shogun2/pull/73), but has resolved the merge conflicts.

Original description:
We were using the `FetchType.EAGER` configuration for (almost) all of our associations to ensure that we will not get a `LazyInitializationException` in the web layer, i.e. when Jackson serializes the Java objects to JSON.

Since version 4.2, Spring provides a `OpenSessionInViewFilter` that makes hibernate sessions available in the web/view layer, so that associated objects can be loaded lazily there.

http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/orm/hibernate5/support/OpenSessionInViewFilter.html

There is a controversial discussion whether this pattern is good practice or not:

* https://stackoverflow.com/questions/1103363/why-is-hibernate-open-session-in-view-considered-a-bad-practice
* http://blog.jhades.org/open-session-in-view-pattern-pros-and-cons/
* https://blog.frankel.ch/the-opensessioninview-antipattern

In my eyes, some of the criticisms do not apply to us. For example, we are not running SHOGun2 on *distributed* JVMs. As far as i understand, one of the main differences between loading `EAGER` and using an `OpenSessionInViewFilter` is the way the database is being queried: While associations with `EAGER` loading will be fetched with SQL joins, the `OpenSessionInViewFilter` approach will lead to `N + 1` select queries. This could become a performance issue, but in such a scenario one could still use *clever* `EAGER` annotations for certain associations to enhance the performance.

I would like to give the `OpenSessionInViewFilter` approach a chance, because it's simple, saves code, will preserve us from unexpected `LazyInitializationExceptions` and the performance of future business logic implementations in this project could benefit from the `LAZY` loading approach in the (transactional) service layer.

What's your opinion?