### PR TITLE
Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,20 @@ before_script:
 
 script:
   - mvn --batch-mode --threads 2.0C --show-version clean test
+  - cd ../../
+  - mvn archetype:generate \
+    -DinteractiveMode=false \
+    -DarchetypeCatalog=local \
+    -DarchetypeGroupId=de.terrestris \
+    -DarchetypeArtifactId=shogun2-webapp-archetype \
+    -DgroupId=de.terrestris \
+    -DartifactId=shogun2-webapp-travis \
+    -Dversion=1.0-TRAVIS \
+    -Dpackage=de.terrestris.travis \
+    -Dwebapp-name=shogun2-webapp-travis
+  - cd shogun2-webapp-travis/
+  - mvn --batch-mode clean test
+  - cd ../shogun2/src/
 
 after_success:
   - mvn clean test jacoco:report coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,16 @@ before_script:
 script:
   - mvn --batch-mode --threads 2.0C --show-version clean test
   - cd ../../
-  - mvn archetype:generate \
-    -DinteractiveMode=false \
-    -DarchetypeCatalog=local \
-    -DarchetypeGroupId=de.terrestris \
-    -DarchetypeArtifactId=shogun2-webapp-archetype \
-    -DgroupId=de.terrestris \
-    -DartifactId=shogun2-webapp-travis \
-    -Dversion=1.0-TRAVIS \
-    -Dpackage=de.terrestris.travis \
+  - >
+    mvn archetype:generate
+    -DinteractiveMode=false
+    -DarchetypeCatalog=local
+    -DarchetypeGroupId=de.terrestris
+    -DarchetypeArtifactId=shogun2-webapp-archetype
+    -DgroupId=de.terrestris
+    -DartifactId=shogun2-webapp-travis
+    -Dversion=1.0-TRAVIS
+    -Dpackage=de.terrestris.travis
     -Dwebapp-name=shogun2-webapp-travis
   - cd shogun2-webapp-travis/
   - mvn --batch-mode clean test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 
+cache:
+  directories:
+  - $HOME/.m2
+
 sudo: false
 
 jdk:

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/pom.xml
@@ -20,7 +20,6 @@
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
         <maven-scm-plugin.version>1.9.4</maven-scm-plugin.version>
-        <jetty-maven-plugin.version>9.3.6.v20151106</jetty-maven-plugin.version>
 
         <downloadSources>true</downloadSources>
         <downloadJavadocs>false</downloadJavadocs>
@@ -35,6 +34,7 @@
             </activation>
             <properties>
                 <jdk.version>1.7</jdk.version>
+                <jetty-maven-plugin.version>9.2.14.v20151106</jetty-maven-plugin.version>
             </properties>
         </profile>
 
@@ -48,6 +48,7 @@
                 <jdk.version>1.8</jdk.version>
                 <!-- Make Javadocs work in 1.8. Credits go to http://stackoverflow.com/a/26806103 -->
                 <javadoc.opts>-Xdoclint:none</javadoc.opts>
+                <jetty-maven-plugin.version>9.3.6.v20151106</jetty-maven-plugin.version>
             </properties>
         </profile>
     </profiles>

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/pom.xml
@@ -20,6 +20,7 @@
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
         <maven-scm-plugin.version>1.9.4</maven-scm-plugin.version>
+        <jetty-maven-plugin.version>9.3.6.v20151106</jetty-maven-plugin.version>
 
         <downloadSources>true</downloadSources>
         <downloadJavadocs>false</downloadJavadocs>
@@ -53,6 +54,38 @@
 
     <build>
         <plugins>
+
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty-maven-plugin.version}</version>
+                <configuration>
+                    <httpConnector>
+                        <!-- The port number for the connector to listen on -->
+                        <port>8081</port>
+                        <!-- The timeout in milliseconds -->
+                        <idleTimeout>30000</idleTimeout>
+                    </httpConnector>
+                    <!-- The pause in seconds between sweeps of the webapp
+                         to check for changes and automatically hot redeploy
+                         if any are detected -->
+                    <scanIntervalSeconds>5</scanIntervalSeconds>
+                    <webAppConfig>
+                        <!-- Terminate the server on any startup exception -->
+                        <throwUnavailableOnStartupException>true</throwUnavailableOnStartupException>
+                    </webAppConfig>
+                </configuration>
+                <executions>
+                    <!-- Run the server on mvn:test -->
+                    <execution>
+                        <id>start-jetty</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR extends the travis configuration for this repository by:
* Cache the local maven repository on the travis/s3 cloud server.
* Build a shogun2 webapplication based on the shogun2-webapp-archetype.
* Add an internal jetty server that will be started on `mvn test`.
  * Note: The newest `jetty-maven-plugin` version has no support for Java 7, therefore a compatible version has to be set in the active profile.