### PR TITLE
Introduce usergroups and roles

### DIFF
--- a/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/GenericHibernateDao.java
+++ b/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/GenericHibernateDao.java
@@ -149,7 +149,7 @@ public abstract class GenericHibernateDao<E extends PersistentObject, ID extends
 	 *
 	 * @return
 	 */
-	private Criteria createDistinctRootEntityCriteria(Criterion... criterion) {
+	protected Criteria createDistinctRootEntityCriteria(Criterion... criterion) {
 		Criteria criteria = getSession().createCriteria(clazz);
 		addCriterionsToCriteria(criteria, criterion);
 		criteria.setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY);

--- a/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/RoleDao.java
+++ b/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/RoleDao.java
@@ -1,0 +1,14 @@
+package de.terrestris.shogun2.dao;
+
+import org.springframework.stereotype.Repository;
+
+import de.terrestris.shogun2.model.Role;
+
+@Repository
+public class RoleDao extends GenericHibernateDao<Role, Integer> {
+
+	protected RoleDao() {
+		super(Role.class);
+	}
+
+}

--- a/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/UserGroupDao.java
+++ b/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/UserGroupDao.java
@@ -1,0 +1,34 @@
+package de.terrestris.shogun2.dao;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.hibernate.Criteria;
+import org.hibernate.HibernateException;
+import org.hibernate.criterion.Restrictions;
+import org.springframework.stereotype.Repository;
+
+import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.UserGroup;
+
+@Repository
+public class UserGroupDao extends GenericHibernateDao<UserGroup, Integer> {
+
+	protected UserGroupDao() {
+		super(UserGroup.class);
+	}
+
+	/**
+	 *
+	 */
+	@SuppressWarnings("unchecked")
+	public Set<UserGroup> findGroupsOfUser(User user) throws HibernateException {
+		Criteria criteria = createDistinctRootEntityCriteria();
+
+		criteria.createAlias("members", "m");
+		criteria.add(Restrictions.eq("m.id", user.getId()));
+
+		return new HashSet<UserGroup>(criteria.list());
+	}
+
+}

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Role.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Role.java
@@ -19,7 +19,7 @@ public class Role extends PersistentObject {
 
 	private static final long serialVersionUID = 1L;
 
-	@Column
+	@Column(unique=true, nullable=false)
 	private String name;
 
 	@Column
@@ -79,6 +79,7 @@ public class Role extends PersistentObject {
 		// two randomly chosen prime numbers
 		return new HashCodeBuilder(13, 53).appendSuper(super.hashCode())
 				.append(getName())
+				.append(getDescription())
 				.toHashCode();
 	}
 
@@ -97,7 +98,8 @@ public class Role extends PersistentObject {
 		Role other = (Role) obj;
 
 		return new EqualsBuilder().appendSuper(super.equals(other))
-				.append(getName(), other.getName()).isEquals();
+				.append(getName(), other.getName())
+				.append(getDescription(), other.getDescription()).isEquals();
 	}
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Role.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Role.java
@@ -1,0 +1,109 @@
+package de.terrestris.shogun2.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+/**
+ * @author Nils Bühner
+ *
+ */
+@Entity
+@Table
+public class Role extends PersistentObject {
+
+	private static final long serialVersionUID = 1L;
+
+	@Column
+	private String name;
+
+	@Column
+	private String description;
+
+	/**
+	 * Default Constructor
+	 */
+	public Role() {
+	}
+
+	/**
+	 * Constructor
+	 */
+	public Role(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @param name the name to set
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * @return the description
+	 */
+	public String getDescription() {
+		return description;
+	}
+
+	/**
+	 * @param description the description to set
+	 */
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	/**
+	 * @see java.lang.Object#hashCode()
+	 *
+	 *      According to
+	 *      http://stackoverflow.com/questions/27581/overriding-equals
+	 *      -and-hashcode-in-java it is recommended only to use getter-methods
+	 *      when using ORM like Hibernate
+	 */
+	@Override
+	public int hashCode() {
+		// two randomly chosen prime numbers
+		return new HashCodeBuilder(13, 53).appendSuper(super.hashCode())
+				.append(getName())
+				.toHashCode();
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 *
+	 *      According to
+	 *      http://stackoverflow.com/questions/27581/overriding-equals
+	 *      -and-hashcode-in-java it is recommended only to use getter-methods
+	 *      when using ORM like Hibernate
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof Role))
+			return false;
+		Role other = (Role) obj;
+
+		return new EqualsBuilder().appendSuper(super.equals(other))
+				.append(getName(), other.getName()).isEquals();
+	}
+
+	/**
+	 *
+	 */
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
+	}
+}

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/User.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/User.java
@@ -1,7 +1,13 @@
 package de.terrestris.shogun2.model;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -35,6 +41,17 @@ public class User extends Person {
 	@Column
 	private boolean active;
 
+	@ManyToMany
+	@JoinTable(
+		name = "USER_ROLE",
+		joinColumns = { @JoinColumn(name = "USER_ID") },
+		inverseJoinColumns = { @JoinColumn(name = "ROLE_ID") }
+	)
+	private Set<Role> roles = new HashSet<Role>();
+
+	/**
+	 * Default constructor
+	 */
 	public User() {
 	}
 
@@ -80,6 +97,20 @@ public class User extends Person {
 
 	public void setActive(boolean active) {
 		this.active = active;
+	}
+
+	/**
+	 * @return the roles
+	 */
+	public Set<Role> getRoles() {
+		return roles;
+	}
+
+	/**
+	 * @param roles the roles to set
+	 */
+	public void setRoles(Set<Role> roles) {
+		this.roles = roles;
 	}
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/UserGroup.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/UserGroup.java
@@ -1,0 +1,161 @@
+package de.terrestris.shogun2.model;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+/**
+ * @author Nils Bühner
+ *
+ */
+@Entity
+@Table
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+public class UserGroup extends PersistentObject {
+
+	private static final long serialVersionUID = 1L;
+
+	@Column
+	private String name;
+
+	@ManyToOne
+	private User owner;
+
+	@ManyToMany
+	@JoinTable(
+		name = "USERGROUP_USER",
+		joinColumns = { @JoinColumn(name = "USERGROUP_ID") },
+		inverseJoinColumns = { @JoinColumn(name = "USER_ID") }
+	)
+	private Set<User> members = new HashSet<User>();
+
+	@ManyToMany
+	@JoinTable(
+		name = "USERGROUP_ROLE",
+		joinColumns = { @JoinColumn(name = "USERGROUP_ID") },
+		inverseJoinColumns = { @JoinColumn(name = "ROLE_ID") }
+	)
+	private Set<Role> roles = new HashSet<Role>();
+
+	/**
+	 * Default Constructor
+	 */
+	public UserGroup() {
+	}
+
+	/**
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @param name
+	 *            the name to set
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * @return the owner
+	 */
+	public User getOwner() {
+		return owner;
+	}
+
+	/**
+	 * @param owner
+	 *            the owner to set
+	 */
+	public void setOwner(User owner) {
+		this.owner = owner;
+	}
+
+	/**
+	 * @return the members
+	 */
+	public Set<User> getMembers() {
+		return members;
+	}
+
+	/**
+	 * @param members the members to set
+	 */
+	public void setMembers(Set<User> members) {
+		this.members = members;
+	}
+
+	/**
+	 * @return the roles
+	 */
+	public Set<Role> getRoles() {
+		return roles;
+	}
+
+	/**
+	 * @param roles the roles to set
+	 */
+	public void setRoles(Set<Role> roles) {
+		this.roles = roles;
+	}
+
+	/**
+	 * @see java.lang.Object#hashCode()
+	 *
+	 *      According to
+	 *      http://stackoverflow.com/questions/27581/overriding-equals
+	 *      -and-hashcode-in-java it is recommended only to use getter-methods
+	 *      when using ORM like Hibernate
+	 */
+	@Override
+	public int hashCode() {
+		// two randomly chosen prime numbers
+		return new HashCodeBuilder(53, 19).appendSuper(super.hashCode())
+				.append(getName())
+				.append(getOwner())
+				.toHashCode();
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 *
+	 *      According to
+	 *      http://stackoverflow.com/questions/27581/overriding-equals
+	 *      -and-hashcode-in-java it is recommended only to use getter-methods
+	 *      when using ORM like Hibernate
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof UserGroup))
+			return false;
+		UserGroup other = (UserGroup) obj;
+
+		return new EqualsBuilder().appendSuper(super.equals(other))
+				.append(getName(), other.getName())
+				.append(getOwner(), other.getOwner())
+				.isEquals();
+	}
+
+	/**
+	 *
+	 */
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
+	}
+}

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/UserGroup.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/UserGroup.java
@@ -129,6 +129,8 @@ public class UserGroup extends PersistentObject {
 		return new HashCodeBuilder(53, 19).appendSuper(super.hashCode())
 				.append(getName())
 				.append(getOwner())
+				.append(getMembers())
+				.append(getRoles())
 				.toHashCode();
 	}
 
@@ -149,6 +151,8 @@ public class UserGroup extends PersistentObject {
 		return new EqualsBuilder().appendSuper(super.equals(other))
 				.append(getName(), other.getName())
 				.append(getOwner(), other.getOwner())
+				.append(getMembers(), other.getMembers())
+				.append(getRoles(), other.getRoles())
 				.isEquals();
 	}
 

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserGroupService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserGroupService.java
@@ -1,0 +1,25 @@
+package de.terrestris.shogun2.service;
+
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+
+import de.terrestris.shogun2.dao.UserGroupDao;
+import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.UserGroup;
+
+/**
+ * Service class for the {@link UserGroup} model.
+ * 
+ * @author Nils Bühner
+ * @see AbstractCrudService
+ * 
+ */
+@Service("userGroupService")
+public class UserGroupService extends AbstractCrudService<UserGroup> {
+
+	public Set<UserGroup> findGroupsOfUser(User user) {
+		return ((UserGroupDao) this.dao).findGroupsOfUser(user);
+	}
+
+}

--- a/src/shogun2-init/src/main/java/de/terrestris/shogun2/init/ContentInitializer.java
+++ b/src/shogun2-init/src/main/java/de/terrestris/shogun2/init/ContentInitializer.java
@@ -19,7 +19,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import de.terrestris.shogun2.model.Application;
+import de.terrestris.shogun2.model.Role;
 import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.UserGroup;
 import de.terrestris.shogun2.model.layout.Layout;
 import de.terrestris.shogun2.model.module.Module;
 import de.terrestris.shogun2.security.acl.AclUtil;
@@ -66,12 +68,28 @@ public class ContentInitializer {
 	private String cleanupAclTablesScriptPath;
 
 	/**
+	 * Flag symbolizing if a set of default {@link Role}s should be created
+	 * up on startup. This will only happen if {@link #shogunInitEnabled} is true.
+	 */
+	@Autowired
+	@Qualifier("createDefaultRoles")
+	private Boolean createDefaultRoles;
+
+	/**
 	 * Flag symbolizing if a set of default {@link User}s should be created
 	 * up on startup. This will only happen if {@link #shogunInitEnabled} is true.
 	 */
 	@Autowired
 	@Qualifier("createDefaultUsers")
 	private Boolean createDefaultUsers;
+
+	/**
+	 * Flag symbolizing if a set of default {@link UserGroup}s should be created
+	 * up on startup. This will only happen if {@link #shogunInitEnabled} is true.
+	 */
+	@Autowired
+	@Qualifier("createDefaultUserGroups")
+	private Boolean createDefaultUserGroups;
 
 	/**
 	 * Flag symbolizing if a set of default {@link Layout}s should be created
@@ -126,6 +144,16 @@ public class ContentInitializer {
 	protected AuthenticationProvider authenticationProvider;
 
 	/**
+	 * A set of default roles that will be created
+	 * if {@link #createDefaultRoles} is true.
+	 *
+	 * Using the {@link Resource} annotation as
+	 * recommended on http://stackoverflow.com/a/22463219
+	 */
+	@Resource(name = "defaultRoles")
+	private Set<Role> defaultRoles;
+
+	/**
 	 * A set of default users that will be created
 	 * if {@link #createDefaultUsers} is true.
 	 *
@@ -134,6 +162,16 @@ public class ContentInitializer {
 	 */
 	@Resource(name = "defaultUsers")
 	private Set<User> defaultUsers;
+
+	/**
+	 * A set of default userGroups that will be created
+	 * if {@link #createDefaultUserGroups} is true.
+	 *
+	 * Using the {@link Resource} annotation as
+	 * recommended on http://stackoverflow.com/a/22463219
+	 */
+	@Resource(name = "defaultUserGroups")
+	private Set<UserGroup> defaultUserGroups;
 
 	/**
 	 * A set of default layouts that will be created
@@ -186,8 +224,16 @@ public class ContentInitializer {
 				cleanupAclTables();
 			}
 
+			if(createDefaultRoles) {
+				createDefaultRoles();
+			}
+
 			if(createDefaultUsers) {
 				createDefaultUsers();
+			}
+
+			if(createDefaultUserGroups) {
+				createDefaultUserGroups();
 			}
 
 			if(createDefaultLayouts) {
@@ -224,6 +270,19 @@ public class ContentInitializer {
 	/**
 	 * Creates the {@link User}s defined in {@link #defaultUsers}
 	 */
+	private void createDefaultRoles() {
+		LOG.info("Creating a set of default roles.");
+
+		for (Role role : defaultRoles) {
+			initService.createRole(role);
+		}
+
+		LOG.info("Created a total of " + defaultRoles.size() + " default roles.");
+	}
+
+	/**
+	 * Creates the {@link User}s defined in {@link #defaultUsers}
+	 */
 	private void createDefaultUsers() {
 		LOG.info("Creating a set of default users.");
 
@@ -232,6 +291,19 @@ public class ContentInitializer {
 		}
 
 		LOG.info("Created a total of " + defaultUsers.size() + " default users.");
+	}
+
+	/**
+	 * Creates the {@link UserGroup}s defined in {@link #defaultUserGroups}
+	 */
+	private void createDefaultUserGroups() {
+		LOG.info("Creating a set of default user groups.");
+
+		for (UserGroup userGroup : defaultUserGroups) {
+			initService.createUserGroup(userGroup);
+		}
+
+		LOG.info("Created a total of " + defaultUserGroups.size() + " default user groups.");
 	}
 
 	/**

--- a/src/shogun2-init/src/main/java/de/terrestris/shogun2/service/InitializationService.java
+++ b/src/shogun2-init/src/main/java/de/terrestris/shogun2/service/InitializationService.java
@@ -9,10 +9,14 @@ import org.springframework.transaction.annotation.Transactional;
 import de.terrestris.shogun2.dao.ApplicationDao;
 import de.terrestris.shogun2.dao.LayoutDao;
 import de.terrestris.shogun2.dao.ModuleDao;
+import de.terrestris.shogun2.dao.RoleDao;
 import de.terrestris.shogun2.dao.UserDao;
+import de.terrestris.shogun2.dao.UserGroupDao;
 import de.terrestris.shogun2.init.ContentInitializer;
 import de.terrestris.shogun2.model.Application;
+import de.terrestris.shogun2.model.Role;
 import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.UserGroup;
 import de.terrestris.shogun2.model.layout.Layout;
 import de.terrestris.shogun2.model.module.Module;
 
@@ -36,7 +40,13 @@ public class InitializationService {
 			.getLogger(InitializationService.class);
 
 	@Autowired
+	private RoleDao roleDao;
+
+	@Autowired
 	private UserDao userDao;
+
+	@Autowired
+	private UserGroupDao userGroupDao;
 
 	@Autowired
 	private LayoutDao layoutDao;
@@ -51,6 +61,18 @@ public class InitializationService {
 	private BCryptPasswordEncoder bcrypt;
 
 	/**
+	 * Used to create a role.
+	 *
+	 * @param role
+	 * @return
+	 */
+	public Role createRole(Role role) {
+		roleDao.saveOrUpdate(role);
+		LOG.debug("Created the role " + role);
+		return role;
+	}
+
+	/**
 	 * Used to create a user.
 	 *
 	 * @param user
@@ -63,6 +85,18 @@ public class InitializationService {
 		userDao.saveOrUpdate(user);
 		LOG.debug("Created the user " + user);
 		return user;
+	}
+
+	/**
+	 * Used to create a user.
+	 *
+	 * @param userGroup
+	 * @return
+	 */
+	public UserGroup createUserGroup(UserGroup userGroup) {
+		userGroupDao.saveOrUpdate(userGroup);
+		LOG.debug("Created the user group " + userGroup);
+		return userGroup;
 	}
 
 	/**

--- a/src/shogun2-security/src/main/java/de/terrestris/shogun2/security/Shogun2AuthenticationProvider.java
+++ b/src/shogun2-security/src/main/java/de/terrestris/shogun2/security/Shogun2AuthenticationProvider.java
@@ -14,8 +14,12 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
 
+import de.terrestris.shogun2.model.Role;
 import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.UserGroup;
+import de.terrestris.shogun2.service.UserGroupService;
 import de.terrestris.shogun2.service.UserService;
 
 /**
@@ -34,14 +38,21 @@ public class Shogun2AuthenticationProvider implements AuthenticationProvider {
 	private UserService userService;
 
 	@Autowired
+	private UserGroupService userGroupService;
+
+	@Autowired
 	private PasswordEncoder passwordEncoder;
 
 	/**
+	 *
+	 * This method has to be {@link Transactional} to allow that associated entities
+	 * can be fetched lazily.
 	 *
 	 * @see org.springframework.security.authentication.AuthenticationProvider#
 	 *      authenticate(org.springframework.security.core.Authentication)
 	 */
 	@Override
+	@Transactional(value="transactionManager", readOnly=true)
 	public Authentication authenticate(Authentication authentication)
 			throws AuthenticationException {
 
@@ -56,9 +67,7 @@ public class Shogun2AuthenticationProvider implements AuthenticationProvider {
 
 		User user = userService.findByAccountName(accountName);
 
-		// prepare authorities
-		GrantedAuthority userAuthority = new SimpleGrantedAuthority("ROLE_USER");
-		GrantedAuthority adminAuthority = new SimpleGrantedAuthority("ROLE_ADMIN");
+		// prepare set of authorities
 		Set<GrantedAuthority> grantedAuthorities = new HashSet<GrantedAuthority>();
 
 		String encryptedPassword = null;
@@ -73,15 +82,28 @@ public class Shogun2AuthenticationProvider implements AuthenticationProvider {
 			// check if rawPassword matches the hash from db
 			if(passwordEncoder.matches(rawPassword, encryptedPassword)) {
 
-				// TODO: become smarter here by getting authority from
-				// user object/database here
-				if (accountName.equals("admin")) {
-					// TODO !
-					grantedAuthorities.add(adminAuthority);
-				} else {
-					// TODO !
-					grantedAuthorities.add(userAuthority);
+				// collect all roles of the user
+				Set<UserGroup> userGroups = userGroupService.findGroupsOfUser(user);
+
+				Set<Role> allUserRoles = new HashSet<Role>();
+
+				// user roles
+				if(user != null) {
+					allUserRoles.addAll(user.getRoles());
 				}
+
+				// userGroup roles
+				if(userGroups != null) {
+					for (UserGroup userGroup : userGroups) {
+						allUserRoles.addAll(userGroup.getRoles());
+					}
+				}
+
+				// create granted authorities for the security context
+				for (Role role : allUserRoles) {
+					grantedAuthorities.add(new SimpleGrantedAuthority(role.getName()));
+				}
+
 			} else {
 				LOG.warn("The given password for user '" + accountName + "' does not match.");
 				throw new BadCredentialsException(exceptionMessage);

--- a/src/shogun2-security/src/main/java/de/terrestris/shogun2/security/Shogun2AuthenticationProvider.java
+++ b/src/shogun2-security/src/main/java/de/terrestris/shogun2/security/Shogun2AuthenticationProvider.java
@@ -3,6 +3,7 @@ package de.terrestris.shogun2.security;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -129,7 +130,17 @@ public class Shogun2AuthenticationProvider implements AuthenticationProvider {
 
 		final boolean isAuthenticated = authResult.isAuthenticated();
 		final String authLog = isAuthenticated ? "could succesfully" : "could NOT";
-		LOG.debug("The User '" + accountName + "' " + authLog  + " be authenticated.");
+		LOG.debug("The user '" + accountName + "' " + authLog  + " be authenticated.");
+
+		if(isAuthenticated) {
+			Set<String> grantedRoles = new HashSet<String>();
+			for (GrantedAuthority auth : grantedAuthorities) {
+				grantedRoles.add(auth.getAuthority());
+			}
+			LOG.debug("The user '" + accountName
+					+ "' got the following roles: "
+					+ StringUtils.join(grantedRoles, ", "));
+		}
 
 		return authResult;
 	}

--- a/src/shogun2-security/src/test/java/de/terrestris/shogun2/security/Shogun2AuthenticationProviderTest.java
+++ b/src/shogun2-security/src/test/java/de/terrestris/shogun2/security/Shogun2AuthenticationProviderTest.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package de.terrestris.shogun2.security;
 
 import static org.hamcrest.Matchers.instanceOf;
@@ -11,6 +8,9 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.junit.Before;
@@ -30,7 +30,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import de.terrestris.shogun2.model.Role;
 import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.UserGroup;
+import de.terrestris.shogun2.service.UserGroupService;
 import de.terrestris.shogun2.service.UserService;
 
 /**
@@ -43,6 +46,9 @@ public class Shogun2AuthenticationProviderTest {
 
 	@Mock
 	private UserService userService;
+
+	@Mock
+	private UserGroupService userGroupService;
 
 	@InjectMocks
 	private Shogun2AuthenticationProvider authProvider;
@@ -57,53 +63,74 @@ public class Shogun2AuthenticationProviderTest {
 		authProvider.setPasswordEncoder(passwordEncoder);
 	}
 
+	/**
+	 * Tests whether the authenticate method authenticates a user correctly and
+	 * assigns roles from the user object, but also from the userGroups the user
+	 * is member of.
+	 */
 	@Test
-	public void authenticate_shouldAssignRoleUser() {
+	public void authenticate_shouldAuthenticateAndAssignRolesFromUserAndUserGroups() {
 
 		// 1. Mock an authentication request object
 		final String shogun2UserName = "user";
-		final String shogun2UserPass = "user";
+		final String shogun2UserPass = "password";
 		final String encryptedPassword = passwordEncoder.encode(shogun2UserPass);
 		final User userToAuth = new User("firstName", "lastName", shogun2UserName, encryptedPassword);
+
+		final Role adminRole = new Role("ROLE_ADMIN");
+		final Role userRole = new Role("ROLE_USER");
+
+		// grant admin role to the user
+		userToAuth.getRoles().add(adminRole);
 
 		Authentication authRequest = mock(Authentication.class);
 		when(authRequest.getName()).thenReturn(shogun2UserName);
 		when(authRequest.getCredentials()).thenReturn(shogun2UserPass);
 
-		// 2. Mock the userDao
-		doAnswer(new Answer<User>() {
+		// 2. Mock the userService
+		when(userService.findByAccountName(shogun2UserName)).thenReturn(userToAuth);
 
-			public User answer(InvocationOnMock invocation)
+		// 3. Mock the userGroupService
+		doAnswer(new Answer<Set<UserGroup>>() {
+
+			public Set<UserGroup> answer(InvocationOnMock invocation)
 					throws NoSuchFieldException, SecurityException,
 					IllegalArgumentException, IllegalAccessException {
 
-				return userToAuth;
-			}
-		}).when(userService).findByAccountName(shogun2UserName);
+				Set<UserGroup> userGroups = new HashSet<UserGroup>();
 
-		// 2. Call the authenticate method with the mocked object
-//		Shogun2AuthenticationProvider authProvider = new Shogun2AuthenticationProvider();
+				UserGroup defaultUserGroup = new UserGroup();
+
+				// add ROLE_USER to the group
+				defaultUserGroup.getRoles().add(userRole);
+
+				userGroups.add(defaultUserGroup);
+
+				return userGroups;
+			}
+		}).when(userGroupService).findGroupsOfUser(userToAuth);
+
+		// 4. Call the authenticate method with the mocked object
 		Authentication authResult = authProvider.authenticate(authRequest);
 
-		// 3. Assert that the authResult is valid (e.g. that ROLE_USER has been
-		// assigned)
-		String expectedRoleName = "ROLE_USER";
-		GrantedAuthority expectedRole = new SimpleGrantedAuthority(
-				expectedRoleName);
-
+		// 5. Assert that the authResult is valid
 		assertNotNull(authResult);
-		assertThat(authResult,
-				instanceOf(UsernamePasswordAuthenticationToken.class));
+		assertThat(authResult, instanceOf(UsernamePasswordAuthenticationToken.class));
 		assertTrue(authResult.isAuthenticated());
 
 		assertThat(authResult.getPrincipal(), instanceOf(User.class));
 		assertEquals(userToAuth, authResult.getPrincipal());
 		assertTrue(passwordEncoder.matches(shogun2UserPass, authResult.getCredentials().toString()));
 
+		// assert that the user now has the ROLE_ADMIN (from user object) and
+		// ROLE_USER (from the default user group)
+		GrantedAuthority adminAuthority = new SimpleGrantedAuthority(adminRole.getName());
+		GrantedAuthority userAuthority = new SimpleGrantedAuthority(userRole.getName());
+
 		// thx to http://stackoverflow.com/a/12167781
 		assertThat(authResult.getAuthorities(),
 				IsIterableContainingInAnyOrder
-						.<GrantedAuthority> containsInAnyOrder(expectedRole));
+						.<GrantedAuthority> containsInAnyOrder(adminAuthority, userAuthority));
 	}
 
 }

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/__artifactId__-init.properties
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/__artifactId__-init.properties
@@ -22,9 +22,17 @@ init.createAclTablesScriptPath=classpath:META-INF/sql/create_acl_schema.sql
 ${symbol_pound} The path to the SQL script, that cleans up the ACL database
 init.cleanupAclTablesScriptPath=META-INF/sql/cleanup_acl_db.sql
 
+${symbol_pound} Whether the set of default roles should be created or not.
+${symbol_pound} This will only have effect if shogunInitEnabled is true.
+init.createDefaultRoles=true
+
 ${symbol_pound} Whether the set of default users should be created or not.
 ${symbol_pound} This will only have effect if shogunInitEnabled is true.
 init.createDefaultUsers=true
+
+${symbol_pound} Whether the set of default userGroups should be created or not.
+${symbol_pound} This will only have effect if shogunInitEnabled is true.
+init.createDefaultUserGroups=true
 
 ${symbol_pound} Whether the set of default layouts should be created or not.
 ${symbol_pound} This will only have effect if shogunInitEnabled is true.

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-init.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-init.xml
@@ -40,9 +40,19 @@
     <bean id="contentInitializer" class="${package}.init.ProjectContentInitializer"
         init-method="initializeDatabaseContent" />
 
+    <!-- Flag enabling/disabling the creation of default roles on startup -->
+    <bean id="createDefaultRoles" class="java.lang.Boolean">
+        <constructor-arg value="${init.createDefaultRoles}"></constructor-arg>
+    </bean>
+
     <!-- Flag enabling/disabling the creation of default users on startup -->
     <bean id="createDefaultUsers" class="java.lang.Boolean">
         <constructor-arg value="${symbol_dollar}{init.createDefaultUsers}"></constructor-arg>
+    </bean>
+
+    <!-- Flag enabling/disabling the creation of default userGroups on startup -->
+    <bean id="createDefaultUserGroups" class="java.lang.Boolean">
+        <constructor-arg value="${init.createDefaultUserGroups}"></constructor-arg>
     </bean>
 
     <!-- Flag enabling/disabling the creation of default layouts on startup -->

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-initialize-beans.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-initialize-beans.xml
@@ -10,6 +10,22 @@
                            http://www.springframework.org/schema/util
                            http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!-- Define roles -->
+    <bean id="adminRole" class="de.terrestris.shogun2.model.Role">
+        <property name="name" value="ROLE_ADMIN"/>
+        <property name="description" value="Administrator Role"/>
+    </bean>
+    <bean id="userRole" class="de.terrestris.shogun2.model.Role">
+        <property name="name" value="ROLE_USER"/>
+        <property name="description" value="User Role"/>
+    </bean>
+
+    <!-- The Set<Role> of defaultRoles -->
+    <util:set id="defaultRoles" value-type="de.terrestris.shogun2.model.Role">
+        <ref bean="adminRole" />
+        <ref bean="userRole" />
+    </util:set>
+
     <!-- Define users -->
     <bean id="adminUser" class="de.terrestris.shogun2.model.User">
         <property name="firstName" value="First Name"/>
@@ -18,11 +34,52 @@
         <!-- This will be encrypted when the init service saves the user. -->
         <property name="password" value="shogun2"/>
         <property name="active" value="true"/>
+        <property name="roles">
+            <util:set id="adminUserRoles">
+                <ref bean="adminRole"/>
+            </util:set>
+        </property>
     </bean>
 
     <!-- The Set<User> of defaultUsers -->
     <util:set id="defaultUsers" value-type="de.terrestris.shogun2.model.User">
         <ref bean="adminUser" />
+    </util:set>
+
+    <!-- Define userGroups -->
+    <bean id="adminUserGroup" class="de.terrestris.shogun2.model.UserGroup">
+        <property name="name" value="Admin User Group"/>
+        <property name="owner" ref="adminUser"/>
+        <property name="members">
+            <util:set id="adminUserGroupMembers">
+                <ref bean="adminUser"/>
+            </util:set>
+        </property>
+        <property name="roles">
+            <util:set id="adminUserGroupRoles">
+                <ref bean="adminRole"/>
+            </util:set>
+        </property>
+    </bean>
+    <bean id="defaultUserGroup" class="de.terrestris.shogun2.model.UserGroup">
+        <property name="name" value="Default User Group"/>
+        <property name="owner" ref="adminUser"/>
+        <property name="members">
+            <util:set id="defaultUserGroupMembers">
+                <ref bean="adminUser"/>
+            </util:set>
+        </property>
+        <property name="roles">
+            <util:set id="defaultUserGroupRoles">
+                <ref bean="userRole"/>
+            </util:set>
+        </property>
+    </bean>
+
+    <!-- The Set<UserGroup> of defaultUserGroups -->
+    <util:set id="defaultUserGroups" value-type="de.terrestris.shogun2.model.UserGroup">
+        <ref bean="adminUserGroup" />
+        <ref bean="defaultUserGroup" />
     </util:set>
 
     <!-- The Border layout -->


### PR DESCRIPTION
This PR introduces two new models:

* `Role` (to hold information for the Spring Security context, e.g. `ROLE_ADMIN` or `ROLE_USER`)
* `UserGroup` (as a collection of `User`s)

`User`s will now have a set of `Role`s. `UserGroup`s will also have  as set of `Role`s.

The `Shogun2AuthenticationProvider` has been "finalized" by collecting the role information (from user and user groups) and converting it to `GrantedAuthorities` for the Spring Security Context.

On top of that, two (expection) tests for the `Shogun2AuthenticationProvider` have been added. The `webapp-archetype` has also been extended to make use of the new models.

Please review and merge! Thx.