### PR TITLE
Handle role hierarchy

### DIFF
--- a/src/shogun2-init/src/main/java/de/terrestris/shogun2/init/ContentInitializer.java
+++ b/src/shogun2-init/src/main/java/de/terrestris/shogun2/init/ContentInitializer.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.jdbc.datasource.init.ScriptException;
+import org.springframework.security.acls.domain.AclAuthorizationStrategyImpl;
 import org.springframework.security.acls.domain.BasePermission;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -28,12 +29,7 @@ import de.terrestris.shogun2.security.acl.AclUtil;
 import de.terrestris.shogun2.service.InitializationService;
 
 /**
- * Class to initialize some kind of content.
- *
- * <b>ATTENTION:</b> This class is currently used to provide some demo content.
- * In future, certain entities (like some default {@link Layout}s or
- * {@link Module} s should be created on the base of (configurable) bean
- * definitions.
+ * Class to initialize an initial set of content based on bean definitions.
  *
  * @author Nils Bühner
  *
@@ -150,7 +146,7 @@ public class ContentInitializer {
 	 * Using the {@link Resource} annotation as
 	 * recommended on http://stackoverflow.com/a/22463219
 	 */
-	@Resource(name = "defaultRoles")
+	@Autowired(required = false)
 	private Set<Role> defaultRoles;
 
 	/**
@@ -160,7 +156,7 @@ public class ContentInitializer {
 	 * Using the {@link Resource} annotation as
 	 * recommended on http://stackoverflow.com/a/22463219
 	 */
-	@Resource(name = "defaultUsers")
+	@Autowired(required = false)
 	private Set<User> defaultUsers;
 
 	/**
@@ -170,7 +166,7 @@ public class ContentInitializer {
 	 * Using the {@link Resource} annotation as
 	 * recommended on http://stackoverflow.com/a/22463219
 	 */
-	@Resource(name = "defaultUserGroups")
+	@Autowired(required = false)
 	private Set<UserGroup> defaultUserGroups;
 
 	/**
@@ -178,7 +174,7 @@ public class ContentInitializer {
 	 * if {@link #createDefaultLayouts} is true.
 	 *
 	 */
-	@Resource(name = "defaultLayouts")
+	@Autowired(required = false)
 	private Set<Layout> defaultLayouts;
 
 	/**
@@ -186,7 +182,7 @@ public class ContentInitializer {
 	 * if {@link #createDefaultModules} is true.
 	 *
 	 */
-	@Resource(name = "defaultModules")
+	@Autowired(required = false)
 	private Set<Module> defaultModules;
 
 	/**
@@ -194,13 +190,12 @@ public class ContentInitializer {
 	 * if {@link #createDefaultApplications} is true.
 	 *
 	 */
-	@Resource(name = "defaultApplications")
+	@Autowired(required = false)
 	private Set<Application> defaultApplications;
 
 	/**
 	 * The method called on initialization
 	 *
-	 * THIS WILL CURRENTLY PRODUCE SOME DEMO CONTENT
 	 */
 	public void initializeDatabaseContent() {
 
@@ -346,8 +341,10 @@ public class ContentInitializer {
 	}
 
 	/**
-	 * This method logs in the passed user. (The ACL system needs a user with
-	 * ROLE_ADMIN to write ACL entries to the database).
+	 * This method logs in the passed user. (The ACL system requires an
+	 * authenticated user with a satisfying authority (based on the config of
+	 * the {@link AclAuthorizationStrategyImpl}) to write ACL entries to the
+	 * database.
 	 *
 	 * @param user
 	 * @param rawPassword
@@ -363,7 +360,7 @@ public class ContentInitializer {
 	 * Logs out the current user
 	 */
 	private void logoutUser() {
-		SecurityContextHolder.getContext().setAuthentication(null);
+		SecurityContextHolder.clearContext();
 	}
 
 	/**

--- a/src/shogun2-init/src/main/java/de/terrestris/shogun2/init/ContentInitializer.java
+++ b/src/shogun2-init/src/main/java/de/terrestris/shogun2/init/ContentInitializer.java
@@ -3,7 +3,6 @@ package de.terrestris.shogun2.init;
 import java.sql.SQLException;
 import java.util.Set;
 
-import javax.annotation.Resource;
 import javax.sql.DataSource;
 
 import org.apache.log4j.Logger;
@@ -143,8 +142,6 @@ public class ContentInitializer {
 	 * A set of default roles that will be created
 	 * if {@link #createDefaultRoles} is true.
 	 *
-	 * Using the {@link Resource} annotation as
-	 * recommended on http://stackoverflow.com/a/22463219
 	 */
 	@Autowired(required = false)
 	private Set<Role> defaultRoles;
@@ -153,8 +150,6 @@ public class ContentInitializer {
 	 * A set of default users that will be created
 	 * if {@link #createDefaultUsers} is true.
 	 *
-	 * Using the {@link Resource} annotation as
-	 * recommended on http://stackoverflow.com/a/22463219
 	 */
 	@Autowired(required = false)
 	private Set<User> defaultUsers;
@@ -163,8 +158,6 @@ public class ContentInitializer {
 	 * A set of default userGroups that will be created
 	 * if {@link #createDefaultUserGroups} is true.
 	 *
-	 * Using the {@link Resource} annotation as
-	 * recommended on http://stackoverflow.com/a/22463219
 	 */
 	@Autowired(required = false)
 	private Set<UserGroup> defaultUserGroups;

--- a/src/shogun2-init/src/main/java/de/terrestris/shogun2/service/InitializationService.java
+++ b/src/shogun2-init/src/main/java/de/terrestris/shogun2/service/InitializationService.java
@@ -68,7 +68,7 @@ public class InitializationService {
 	 */
 	public Role createRole(Role role) {
 		roleDao.saveOrUpdate(role);
-		LOG.debug("Created the role " + role);
+		LOG.trace("Created the role " + role);
 		return role;
 	}
 
@@ -83,7 +83,7 @@ public class InitializationService {
 		final String pwHash = bcrypt.encode(user.getPassword());
 		user.setPassword(pwHash);
 		userDao.saveOrUpdate(user);
-		LOG.debug("Created the user " + user);
+		LOG.trace("Created the user " + user);
 		return user;
 	}
 
@@ -95,7 +95,7 @@ public class InitializationService {
 	 */
 	public UserGroup createUserGroup(UserGroup userGroup) {
 		userGroupDao.saveOrUpdate(userGroup);
-		LOG.debug("Created the user group " + userGroup);
+		LOG.trace("Created the user group " + userGroup);
 		return userGroup;
 	}
 
@@ -106,7 +106,7 @@ public class InitializationService {
 	 */
 	public Layout createLayout(Layout layout) {
 		layoutDao.saveOrUpdate(layout);
-		LOG.debug("Created the layout " + layout);
+		LOG.trace("Created the layout " + layout);
 		return layout;
 	}
 
@@ -117,7 +117,7 @@ public class InitializationService {
 	 */
 	public Module createModule(Module module) {
 		moduleDao.saveOrUpdate(module);
-		LOG.debug("Created the module " + module);
+		LOG.trace("Created the module " + module);
 		return module;
 	}
 
@@ -129,7 +129,7 @@ public class InitializationService {
 	 */
 	public Application createApplication(Application application) {
 		applicationDao.saveOrUpdate(application);
-		LOG.debug("Created the application " + application);
+		LOG.trace("Created the application " + application);
 		return application;
 	}
 

--- a/src/shogun2-init/src/main/java/de/terrestris/shogun2/service/InitializationService.java
+++ b/src/shogun2-init/src/main/java/de/terrestris/shogun2/service/InitializationService.java
@@ -2,7 +2,7 @@ package de.terrestris.shogun2.service;
 
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -58,7 +58,7 @@ public class InitializationService {
 	private ApplicationDao applicationDao;
 
 	@Autowired
-	private BCryptPasswordEncoder bcrypt;
+	private PasswordEncoder passwordEncoder;
 
 	/**
 	 * Used to create a role.
@@ -80,7 +80,7 @@ public class InitializationService {
 	 */
 	public User createUser(User user) {
 		// encode the raw password using bcrypt
-		final String pwHash = bcrypt.encode(user.getPassword());
+		final String pwHash = passwordEncoder.encode(user.getPassword());
 		user.setPassword(pwHash);
 		userDao.saveOrUpdate(user);
 		LOG.trace("Created the user " + user);

--- a/src/shogun2-security/src/test/java/de/terrestris/shogun2/security/Shogun2AuthenticationProviderTest.java
+++ b/src/shogun2-security/src/test/java/de/terrestris/shogun2/security/Shogun2AuthenticationProviderTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyCollectionOf;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -22,6 +23,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -51,6 +53,9 @@ public class Shogun2AuthenticationProviderTest {
 
 	@Mock
 	private UserGroupService userGroupService;
+
+	@Mock
+	private RoleHierarchyImpl roleHierarchy;
 
 	@InjectMocks
 	private Shogun2AuthenticationProvider authProvider;
@@ -111,10 +116,16 @@ public class Shogun2AuthenticationProviderTest {
 			}
 		}).when(userGroupService).findGroupsOfUser(userToAuth);
 
-		// 4. Call the authenticate method with the mocked object
+		// 4. Mock the roleHierarchy (return empty collection)
+		when(
+			roleHierarchy
+					.getReachableGrantedAuthorities(anyCollectionOf(GrantedAuthority.class)))
+			.thenReturn(new HashSet<GrantedAuthority>());
+
+		// 5. Call the authenticate method with the mocked object
 		Authentication authResult = authProvider.authenticate(authRequest);
 
-		// 5. Assert that the authResult is valid
+		// 6. Assert that the authResult is valid
 		assertNotNull(authResult);
 		assertThat(authResult, instanceOf(UsernamePasswordAuthenticationToken.class));
 		assertTrue(authResult.isAuthenticated());

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-security-acl.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-security-acl.xml
@@ -92,12 +92,15 @@ $symbol_escape = '\' )
     <bean id="aclAuthorizationStrategy" class="org.springframework.security.acls.domain.AclAuthorizationStrategyImpl">
         <constructor-arg>
             <list>
+                <!-- the authority needed to change ownership -->
                 <bean class="org.springframework.security.core.authority.SimpleGrantedAuthority">
                     <constructor-arg value="ROLE_ADMIN"/>
                 </bean>
+                <!-- the authority needed to modify auditing details -->
                 <bean class="org.springframework.security.core.authority.SimpleGrantedAuthority">
                     <constructor-arg value="ROLE_ADMIN"/>
                 </bean>
+                <!-- the authority needed to change other ACL and ACE details -->
                 <bean class="org.springframework.security.core.authority.SimpleGrantedAuthority">
                     <constructor-arg value="ROLE_ADMIN"/>
                 </bean>

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/log4j.properties
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/log4j.properties
@@ -6,7 +6,7 @@ ${symbol_pound} LOGGING PROPERTIES
 ${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}
 
 ${symbol_pound} Some example settings
-log4j.rootLogger=TRACE, stdout
+log4j.rootLogger=DEBUG, stdout
 ${symbol_pound}log4j.rootLogger=DEBUG, stdout
 ${symbol_pound}log4j.rootLogger=WARN, logfile
 ${symbol_pound}log4j.rootLogger=ERROR, logfile


### PR DESCRIPTION
Let the `Shogun2AuthenticationProvider` explicitly add all **reachable** roles of the role hierarchy (as granted authorities) to the auth result of a principal/user. This is necessary if we want to make use of one of these roles when configuring the `AclAuthorizationStrategyImpl`.

On top of that, some minor changes (like log level or comments) have been made.

Please review and merge. Thx