### PR TITLE
REST exception and HTTP status code handling

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -222,7 +222,7 @@
                 </executions>
                 <configuration>
                     <excludes>
-                        <exclude>de/terrestris/shogun2/model/*.class</exclude>
+                        <exclude>de/terrestris/shogun2/model/**/*.class</exclude>
                         <exclude>de/terrestris/shogun2/paging/PagingResult.class</exclude>
                     </excludes>
                 </configuration>

--- a/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/GenericHibernateDao.java
+++ b/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/GenericHibernateDao.java
@@ -38,12 +38,42 @@ public abstract class GenericHibernateDao<E extends PersistentObject, ID extends
 	@Autowired
 	private SessionFactory sessionFactory;
 
-	public Session getSession() {
+	/**
+	 * Obtains the current session.
+	 *
+	 * @return
+	 */
+	private Session getSession() {
 		return sessionFactory.getCurrentSession();
 	}
 
+	/**
+	 * Return the real object from the database. Returns null if the object does
+	 * not exist.
+	 *
+	 * @param id
+	 *
+	 * @see http://www.mkyong.com/hibernate/different-between-session-get-and-session-load/
+	 *
+	 * @return The object from the database or null if it does not exist
+	 */
 	public E findById(ID id) {
 		return (E) getSession().get(clazz, id);
+	}
+
+	/**
+	 * Return a proxy of the object (without hitting the database). This should
+	 * only be used if it is assumed that the object really exists and where
+	 * non-existence would be an actual error.
+	 *
+	 * @param id
+	 *
+	 * @see http://www.mkyong.com/hibernate/different-between-session-get-and-session-load/
+	 *
+	 * @return
+	 */
+	public E loadById(ID id) {
+		return (E) getSession().load(clazz, id);
 	}
 
 	/**

--- a/src/shogun2-core/shogun2-model/pom.xml
+++ b/src/shogun2-core/shogun2-model/pom.xml
@@ -18,10 +18,20 @@
     <name>SHOGun2 Models</name>
 
     <dependencies>
+
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>shogun2-util</artifactId>
-            <version>${project.version}</version>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
 
         <dependency>

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/converter/PropertyValueConverter.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/converter/PropertyValueConverter.java
@@ -1,7 +1,7 @@
 /**
  *
  */
-package de.terrestris.shogun2.util.converter;
+package de.terrestris.shogun2.converter;
 
 import javax.persistence.AttributeConverter;
 

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/map/MapControl.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/map/MapControl.java
@@ -17,8 +17,8 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import de.terrestris.shogun2.converter.PropertyValueConverter;
 import de.terrestris.shogun2.model.PersistentObject;
-import de.terrestris.shogun2.util.converter.PropertyValueConverter;
 
 /**
  * This class represents an

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Module.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Module.java
@@ -22,9 +22,9 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import de.terrestris.shogun2.converter.PropertyValueConverter;
 import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.model.layout.Layout;
-import de.terrestris.shogun2.util.converter.PropertyValueConverter;
 
 /**
  * A module is the visual representation of a component in the GUI. A module can

--- a/src/shogun2-core/shogun2-model/src/test/java/de/terrestris/shogun2/converter/PropertyValueConverterTest.java
+++ b/src/shogun2-core/shogun2-model/src/test/java/de/terrestris/shogun2/converter/PropertyValueConverterTest.java
@@ -1,4 +1,4 @@
-package de.terrestris.shogun2.util.converter;
+package de.terrestris.shogun2.converter;
 
 import org.junit.Test;
 import static org.junit.Assert.*;

--- a/src/shogun2-core/shogun2-service/pom.xml
+++ b/src/shogun2-core/shogun2-service/pom.xml
@@ -26,6 +26,12 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>shogun2-util</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- Spring Security -->
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/AbstractCrudService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/AbstractCrudService.java
@@ -10,16 +10,16 @@ import de.terrestris.shogun2.model.PersistentObject;
 
 /**
  * This abstract service class provides basic CRUD functionality.
- * 
+ *
  * @author Nils Bühner
  * @see AbstractDaoService
- * 
+ *
  */
 public abstract class AbstractCrudService<E extends PersistentObject> extends
 		AbstractDaoService<E> {
 
 	/**
-	 * 
+	 *
 	 * @param e
 	 * @return
 	 */
@@ -30,6 +30,8 @@ public abstract class AbstractCrudService<E extends PersistentObject> extends
 	}
 
 	/**
+	 * Return the real object from the database. Returns null if the object does
+	 * not exist.
 	 * 
 	 * @param id
 	 * @return
@@ -40,7 +42,20 @@ public abstract class AbstractCrudService<E extends PersistentObject> extends
 	}
 
 	/**
+	 * Return a proxy of the object (without hitting the database). This should
+	 * only be used if it is assumed that the object really exists and where
+	 * non-existence would be an actual error.
 	 * 
+	 * @param id
+	 * @return
+	 */
+	@PostAuthorize("hasPermission(returnObject, 'READ')")
+	public E loadById(int id) {
+		return dao.loadById(id);
+	}
+
+	/**
+	 *
 	 * @return
 	 */
 	@PostFilter("hasPermission(filterObject, 'READ')")
@@ -49,7 +64,7 @@ public abstract class AbstractCrudService<E extends PersistentObject> extends
 	}
 
 	/**
-	 * 
+	 *
 	 * @param e
 	 */
 	@PreAuthorize("hasPermission(#e, 'DELETE')")

--- a/src/shogun2-core/shogun2-service/src/test/java/de/terrestris/shogun2/service/AbstractExtDirectCrudServiceTest.java
+++ b/src/shogun2-core/shogun2-service/src/test/java/de/terrestris/shogun2/service/AbstractExtDirectCrudServiceTest.java
@@ -16,7 +16,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -46,6 +45,7 @@ import ch.ralscha.extdirectspring.bean.SortInfo;
 import de.terrestris.shogun2.dao.GenericHibernateDao;
 import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.paging.PagingResult;
+import de.terrestris.shogun2.util.test.TestUtil;
 
 /**
  * Test for the {@link AbstractCrudService}.
@@ -110,7 +110,7 @@ public abstract class AbstractExtDirectCrudServiceTest<E extends PersistentObjec
 				E po = (E) invocation.getArguments()[0];
 
 				// set id like the dao does
-				setIdOnPersistentObject(po, 1);
+				TestUtil.setIdOnPersistentObject(po, 1);
 
 				return po;
 			}
@@ -151,7 +151,7 @@ public abstract class AbstractExtDirectCrudServiceTest<E extends PersistentObjec
 		ReadableDateTime created = implToTest.getCreated();
 		ReadableDateTime modified = implToTest.getModified();
 
-		setIdOnPersistentObject(implToTest, id);
+		TestUtil.setIdOnPersistentObject(implToTest, id);
 
 		doAnswer(new Answer<E>() {
 			public E answer(InvocationOnMock invocation)
@@ -193,7 +193,7 @@ public abstract class AbstractExtDirectCrudServiceTest<E extends PersistentObjec
 
 		Integer existingId = 17;
 
-		setIdOnPersistentObject(implToTest, existingId);
+		TestUtil.setIdOnPersistentObject(implToTest, existingId);
 
 		// mock dao behavior
 		doReturn(implToTest).when(dao).findById(existingId);
@@ -249,8 +249,8 @@ public abstract class AbstractExtDirectCrudServiceTest<E extends PersistentObjec
 		E obj1 = (E) implToTest;
 		E obj2 = (E) BeanUtils.cloneBean(obj1);
 
-		setIdOnPersistentObject(obj1, id1);
-		setIdOnPersistentObject(obj2, id2);
+		TestUtil.setIdOnPersistentObject(obj1, id1);
+		TestUtil.setIdOnPersistentObject(obj2, id2);
 
 		persistedObjectList.add((E) obj1);
 		persistedObjectList.add((E) obj2);
@@ -309,7 +309,7 @@ public abstract class AbstractExtDirectCrudServiceTest<E extends PersistentObjec
 
 		Integer existingId = 17;
 
-		setIdOnPersistentObject(implToTest, existingId);
+		TestUtil.setIdOnPersistentObject(implToTest, existingId);
 
 		// mock dao behavior
 		doReturn(implToTest).when(dao).findById(existingId);
@@ -372,7 +372,7 @@ public abstract class AbstractExtDirectCrudServiceTest<E extends PersistentObjec
 				E po = (E) invocation.getArguments()[0];
 
 				// set id like the dao does
-				setIdOnPersistentObject(po, nextId);
+				TestUtil.setIdOnPersistentObject(po, nextId);
 				nextId++;
 
 				return po;
@@ -526,30 +526,8 @@ public abstract class AbstractExtDirectCrudServiceTest<E extends PersistentObjec
 			InvocationTargetException, NoSuchMethodException {
 		@SuppressWarnings("unchecked")
 		E obj = (E) BeanUtils.cloneBean(implToTest);
-		setIdOnPersistentObject(obj, id);
+		TestUtil.setIdOnPersistentObject(obj, id);
 		return obj;
 	}
 
-	/**
-	 * Helper method that uses reflection to set the (inaccessible) id field of
-	 * the given {@link PersistentObject}.
-	 * 
-	 * @param persistentObject
-	 *            The object with the inaccessible id field
-	 * @param id
-	 *            The id to set
-	 * @throws NoSuchFieldException
-	 * @throws IllegalAccessException
-	 */
-	private static final void setIdOnPersistentObject(
-			PersistentObject persistentObject, Integer id)
-			throws NoSuchFieldException, IllegalAccessException {
-		// use reflection to get the inaccessible final field 'id'
-		Field idField = PersistentObject.class.getDeclaredField("id");
-
-		// make the field accessible and set the value
-		idField.setAccessible(true);
-		idField.set(persistentObject, id);
-		idField.setAccessible(false);
-	}
 }

--- a/src/shogun2-util/pom.xml
+++ b/src/shogun2-util/pom.xml
@@ -18,19 +18,16 @@
     <name>SHOGun2 Utilities</name>
 
     <dependencies>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>shogun2-model</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
         </dependency>
 
         <dependency>

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/test/TestUtil.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/test/TestUtil.java
@@ -1,0 +1,31 @@
+package de.terrestris.shogun2.util.test;
+
+import java.lang.reflect.Field;
+
+import de.terrestris.shogun2.model.PersistentObject;
+
+public class TestUtil {
+
+	/**
+	 * Helper method that uses reflection to set the (inaccessible) id field of
+	 * the given {@link PersistentObject}.
+	 * 
+	 * @param persistentObject
+	 *            The object with the inaccessible id field
+	 * @param id
+	 *            The id to set
+	 * @throws NoSuchFieldException
+	 * @throws IllegalAccessException
+	 */
+	public static final void setIdOnPersistentObject(
+			PersistentObject persistentObject, Integer id)
+			throws NoSuchFieldException, IllegalAccessException {
+		// use reflection to get the inaccessible final field 'id'
+		Field idField = PersistentObject.class.getDeclaredField("id");
+
+		// make the field accessible and set the value
+		idField.setAccessible(true);
+		idField.set(persistentObject, id);
+		idField.setAccessible(false);
+	}
+}

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
@@ -40,8 +40,15 @@ public abstract class AbstractRestController<E extends PersistentObject> {
 	 */
 	@RequestMapping(method = RequestMethod.GET)
 	public ResponseEntity<List<E>> findAll() {
-		return new ResponseEntity<List<E>>(this.service.findAll(),
-				HttpStatus.OK);
+		final List<E> resultList = this.service.findAll();
+
+		if (resultList != null && !resultList.isEmpty()) {
+			LOG.trace("Found a total of " + resultList.size()
+					+ " entities of type "
+					+ resultList.get(0).getClass().getSimpleName());
+		}
+
+		return new ResponseEntity<List<E>>(resultList, HttpStatus.OK);
 	}
 
 	/**
@@ -55,6 +62,8 @@ public abstract class AbstractRestController<E extends PersistentObject> {
 
 		try {
 			E entity = this.service.findById(id);
+			LOG.trace("Found " + entity.getClass().getSimpleName()
+					+ " with ID " + entity.getId());
 			return new ResponseEntity<E>(entity, HttpStatus.OK);
 		} catch (Exception e) {
 			LOG.error("Error finding entity with id " + id + ": "
@@ -87,6 +96,7 @@ public abstract class AbstractRestController<E extends PersistentObject> {
 
 		try {
 			entity = this.service.saveOrUpdate(entity);
+			LOG.trace("Created " + simpleClassName + " with ID " + entity.getId());
 			return new ResponseEntity<E>(entity, HttpStatus.CREATED);
 		} catch (Exception e) {
 			LOG.error(errorMessagePrefix + e.getMessage());
@@ -110,6 +120,7 @@ public abstract class AbstractRestController<E extends PersistentObject> {
 		if (payloadId == id) {
 			try {
 				E updated = this.service.saveOrUpdate(entity);
+				LOG.trace("Updated " + simpleClassName + " with ID " + id);
 				return new ResponseEntity<E>(updated, HttpStatus.OK);
 			} catch (Exception e) {
 				LOG.error("Error updating " + simpleClassName + ":"
@@ -147,7 +158,7 @@ public abstract class AbstractRestController<E extends PersistentObject> {
 			final String proxyClassName = entityToDelete.getClass().getSimpleName();
 			final String simpleClassName = StringUtils.substringBefore(proxyClassName, "_$$_");
 
-			LOG.debug("Deleted " + simpleClassName + " with ID " + id);
+			LOG.trace("Deleted " + simpleClassName + " with ID " + id);
 			return new ResponseEntity<E>(HttpStatus.NO_CONTENT);
 		} catch (Exception e) {
 			LOG.error("Error deleting entity with ID " + id + ": "

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
@@ -17,6 +17,7 @@ import de.terrestris.shogun2.service.AbstractCrudService;
 /**
  * @author Kai Volland
  * @author Daniel Koch
+ * @author Nils Bühner
  *
  */
 @RequestMapping(value = "/rest")
@@ -32,7 +33,7 @@ public abstract class AbstractRestController<E extends PersistentObject> {
 	private AbstractCrudService<E> service;
 
 	/**
-	 * Find all Entities.
+	 * Find all entities.
 	 *
 	 * @return
 	 */
@@ -49,9 +50,16 @@ public abstract class AbstractRestController<E extends PersistentObject> {
 	 * @return
 	 */
 	@RequestMapping(value = "/{id}", method = RequestMethod.GET)
-	public ResponseEntity<E> get(@PathVariable int id) {
-		E entity = this.service.findById(id);
-		return new ResponseEntity<E>(entity, HttpStatus.OK);
+	public ResponseEntity<E> findById(@PathVariable Integer id) {
+
+		try {
+			E entity = this.service.findById(id);
+			return new ResponseEntity<E>(entity, HttpStatus.OK);
+		} catch (Exception e) {
+			LOG.error("Error finding entity with id " + id + ": "
+					+ e.getMessage());
+			return new ResponseEntity<E>(HttpStatus.NOT_FOUND);
+		}
 	}
 
 	/**

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
@@ -102,17 +102,23 @@ public abstract class AbstractRestController<E extends PersistentObject> {
 	 */
 	@RequestMapping(value = "/{id}", method = RequestMethod.PUT)
 	public ResponseEntity<E> update(@PathVariable int id, @RequestBody E entity) {
-		if (entity.getId() == id) {
+
+		final String simpleClassName = entity.getClass().getSimpleName();
+		final Integer payloadId = entity.getId();
+
+		if (payloadId == id) {
 			try {
 				E updated = this.service.saveOrUpdate(entity);
-				LOG.debug("Updated entity: " + updated);
 				return new ResponseEntity<E>(updated, HttpStatus.OK);
 			} catch (Exception e) {
-				LOG.error("There is no " + entity.getClass() + " with id " + id);
+				LOG.error("Error updating " + simpleClassName + ":"
+						+ e.getMessage());
 				return new ResponseEntity<E>(HttpStatus.NOT_FOUND);
 			}
 		} else {
-			LOG.error("Can't update " + id + " with body" + entity);
+			LOG.error("Error updating " + simpleClassName
+					+ ": Requested to update entity with ID " + id
+					+ ", but payload ID is " + payloadId);
 			return new ResponseEntity<E>(HttpStatus.BAD_REQUEST);
 		}
 	}

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/ApplicationRestController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/ApplicationRestController.java
@@ -7,10 +7,11 @@ import de.terrestris.shogun2.model.Application;
 
 /**
  * @author Kai Volland
+ * @author Nils Bühner
  *
  */
 @RestController
-@RequestMapping("/application")
+@RequestMapping("/applications")
 public class ApplicationRestController extends
 		AbstractRestController<Application> {
 

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/UserRestController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/UserRestController.java
@@ -7,10 +7,11 @@ import de.terrestris.shogun2.model.User;
 
 /**
  * @author Kai Volland
+ * @author Nils Bühner
  *
  */
 @RestController
-@RequestMapping("/user")
+@RequestMapping("/users")
 public class UserRestController extends
 		AbstractRestController<User> {
 

--- a/src/shogun2-web/src/test/java/de/terrestris/shogun2/rest/AbstractRestControllerTest.java
+++ b/src/shogun2-web/src/test/java/de/terrestris/shogun2/rest/AbstractRestControllerTest.java
@@ -2,11 +2,9 @@ package de.terrestris.shogun2.rest;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -18,13 +16,18 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.service.AbstractCrudService;
+import de.terrestris.shogun2.util.json.Shogun2JsonObjectMapper;
 import de.terrestris.shogun2.util.test.TestUtil;
 
 /**
@@ -37,25 +40,42 @@ public class AbstractRestControllerTest {
 
 	/**
 	 * A private model class for that exists only to test the
-	 * {@link AbstractRestController}.
+	 * {@link AbstractRestController}. This inner class has to be static,
+	 * otherwise Jackson will not be able to de-/serialize.
 	 *
 	 */
-	private class TestModel extends PersistentObject {
+	private static class TestModel extends PersistentObject {
 		private static final long serialVersionUID = 1L;
 		private String testValue;
+
+		private TestModel() {
+		}
+
 		@SuppressWarnings("unused")
-		public String getTestValue() {return testValue;}
-		public void setTestValue(String testValue) {this.testValue = testValue;}
+		public String getTestValue() {
+			return testValue;
+		}
+
+		public void setTestValue(String testValue) {
+			this.testValue = testValue;
+		}
 	}
 
 	/**
-	 * A private REST controller for the {@link TestModel}. This class
-	 * only exists in the scope of this test and is used to test the
+	 * A private REST controller for the {@link TestModel}. This class only
+	 * exists in the scope of this test and is used to test the
 	 * {@link AbstractRestController}.
 	 */
 	@RestController
 	@RequestMapping("/tests")
-	private class TestModelRestController extends AbstractRestController<TestModel> {}
+	private class TestModelRestController extends
+			AbstractRestController<TestModel> {
+	}
+
+	/**
+	 * Object mapper used to write JSON
+	 */
+	private final ObjectMapper objectMapper = new Shogun2JsonObjectMapper();
 
 	/**
 	 * Spring MVC test support
@@ -102,21 +122,20 @@ public class AbstractRestControllerTest {
 		String firstValue = "value 1";
 		String secondValue = "value 2";
 
-		TestModel first = new TestModel();
-		first.setTestValue(firstValue);
+		TestModel first = buildTestInstanceWithValue(firstValue);
 
-		TestModel second = new TestModel();
-		second.setTestValue(secondValue);
+		TestModel second = buildTestInstanceWithValue(secondValue);
 
 		when(serviceMock.findAll()).thenReturn(Arrays.asList(first, second));
 
 		// Test GET method
 		mockMvc.perform(get("/tests"))
-			.andExpect(status().isOk())
-			.andExpect(content().contentType("application/json;charset=UTF-8"))
-			.andExpect(jsonPath("$", hasSize(2)))
-			.andExpect(jsonPath("$[0].testValue", is(firstValue)))
-			.andExpect(jsonPath("$[1].testValue", is(secondValue)));
+				.andExpect(status().isOk())
+				.andExpect(
+						content().contentType("application/json;charset=UTF-8"))
+				.andExpect(jsonPath("$", hasSize(2)))
+				.andExpect(jsonPath("$[0].testValue", is(firstValue)))
+				.andExpect(jsonPath("$[1].testValue", is(secondValue)));
 
 		verify(serviceMock, times(1)).findAll();
 		verifyNoMoreInteractions(serviceMock);
@@ -125,16 +144,16 @@ public class AbstractRestControllerTest {
 	/**
 	 * Tests whether the REST findById interface will return an expected entity
 	 * and a HTTP Status Code 200 (OK).
+	 *
 	 * @throws Exception
 	 *
 	 */
 	@Test
 	public void findById_shouldReturn_EntityAndOK() throws Exception {
 		int id = 42;
-		String value = "value";
+		String value = "find value";
 
-		TestModel testInstance = new TestModel();
-		testInstance.setTestValue(value);
+		TestModel testInstance = buildTestInstanceWithValue(value);
 
 		TestUtil.setIdOnPersistentObject(testInstance, id);
 
@@ -142,13 +161,300 @@ public class AbstractRestControllerTest {
 
 		// Test GET method with ID
 		mockMvc.perform(get("/tests/" + id))
-			.andExpect(status().isOk())
-			.andExpect(content().contentType("application/json;charset=UTF-8"))
-			.andExpect(jsonPath("$.id", is(id)))
-			.andExpect(jsonPath("$.testValue", is(value)));
+				.andExpect(status().isOk())
+				.andExpect(
+						content().contentType("application/json;charset=UTF-8"))
+				.andExpect(jsonPath("$.id", is(id)))
+				.andExpect(jsonPath("$.testValue", is(value)));
 
 		verify(serviceMock, times(1)).findById(id);
 		verifyNoMoreInteractions(serviceMock);
+	}
+
+	/**
+	 * Tests whether the REST findById interface will return HTTP Status Code
+	 * 404 (NOT FOUND), if an exception occured.
+	 *
+	 * @throws Exception
+	 *
+	 */
+	@Test
+	public void findById_shouldReturn_NotFound() throws Exception {
+		int id = 42;
+
+		when(serviceMock.findById(id)).thenThrow(new RuntimeException());
+
+		// Test GET method with ID
+		mockMvc.perform(get("/tests/" + id)).andExpect(status().isNotFound());
+
+		verify(serviceMock, times(1)).findById(id);
+		verifyNoMoreInteractions(serviceMock);
+	}
+
+	/**
+	 * Tests whether the REST save/create interface will work as expected, i.e.
+	 * return the created entity and a HTTP Status Code 201 (CREATED).
+	 *
+	 * @throws Exception
+	 *
+	 */
+	@Test
+	public void save_shouldReturn_EntityAndCreated() throws Exception {
+		int id = 42;
+		String value = "save value";
+
+		TestModel withoutId = buildTestInstanceWithValue(value);
+		TestModel withId = buildTestInstanceWithIdAndValue(id, value);
+
+		when(serviceMock.saveOrUpdate(any(TestModel.class))).thenReturn(withId);
+
+		// Test POST method with JSON payload
+		mockMvc.perform(
+				post("/tests").contentType(MediaType.APPLICATION_JSON).content(
+						asJson(withoutId)))
+				.andExpect(status().isCreated())
+				.andExpect(
+						content().contentType("application/json;charset=UTF-8"))
+				.andExpect(jsonPath("$.id", is(id)))
+				.andExpect(jsonPath("$.testValue", is(value)));
+
+		verify(serviceMock, times(1)).saveOrUpdate(any(TestModel.class));
+		verifyNoMoreInteractions(serviceMock);
+	}
+
+	/**
+	 * Tests whether the REST save/create interface (POST) return a HTTP Status
+	 * Code 400 (BAD REQUEST), if the payload already has an ID, which is not
+	 * allowed in the create/save case.
+	 *
+	 * @throws Exception
+	 *
+	 */
+	@Test
+	public void save_shouldReturn_BadRequestDueToGivenId() throws Exception {
+		int id = 42;
+		String value = "save value";
+
+		TestModel withId = buildTestInstanceWithIdAndValue(id, value);
+
+		// Test POST method with JSON payload
+		mockMvc.perform(
+				post("/tests").contentType(MediaType.APPLICATION_JSON).content(
+						asJson(withId))).andExpect(status().isBadRequest());
+
+		verify(serviceMock, times(0)).saveOrUpdate(any(TestModel.class));
+		verifyNoMoreInteractions(serviceMock);
+	}
+
+	/**
+	 * Tests whether the REST save/create (POST) interface return a HTTP Status
+	 * Code 400 (BAD REQUEST), if a {@link RuntimeException} occured on
+	 * saveOrUpdate.
+	 *
+	 * @throws Exception
+	 *
+	 */
+	@Test
+	public void save_shouldReturn_BadRequestDueToRuntimeException()
+			throws Exception {
+		String value = "save value";
+
+		TestModel payload = buildTestInstanceWithValue(value);
+
+		when(serviceMock.saveOrUpdate(any(TestModel.class))).thenThrow(
+				new RuntimeException());
+
+		// Test POST method with JSON payload
+		mockMvc.perform(
+				post("/tests").contentType(MediaType.APPLICATION_JSON).content(
+						asJson(payload))).andExpect(status().isBadRequest());
+
+		verify(serviceMock, times(1)).saveOrUpdate(any(TestModel.class));
+		verifyNoMoreInteractions(serviceMock);
+	}
+
+	/**
+	 * Tests whether the REST update (PUT) interface will work as expected, i.e.
+	 * return the updated entity and a HTTP Status Code 200 (OK).
+	 *
+	 * @throws Exception
+	 *
+	 */
+	@Test
+	public void update_shouldReturn_EntityAndOK() throws Exception {
+		int id = 42;
+		String updatedValue = "updated value";
+
+		TestModel updatedObject = buildTestInstanceWithIdAndValue(id,
+				updatedValue);
+
+		when(serviceMock.saveOrUpdate(any(TestModel.class))).thenReturn(
+				updatedObject);
+
+		// Test PUT method with JSON payload
+		mockMvc.perform(
+				put("/tests/" + id).contentType(MediaType.APPLICATION_JSON)
+						.content(asJson(updatedObject)))
+				.andExpect(status().isOk())
+				.andExpect(
+						content().contentType("application/json;charset=UTF-8"))
+				.andExpect(jsonPath("$.id", is(id)))
+				.andExpect(jsonPath("$.testValue", is(updatedValue)));
+
+		verify(serviceMock, times(1)).saveOrUpdate(any(TestModel.class));
+		verifyNoMoreInteractions(serviceMock);
+	}
+
+	/**
+	 * Tests whether the REST update (PUT) interface will return a HTTP Status
+	 * Code 400 (BAD REQUEST), if the uri ID path variable does not match the ID
+	 * value of the payload JSON.
+	 *
+	 * @throws Exception
+	 *
+	 */
+	@Test
+	public void update_shouldReturn_BadRequestIfIdsDoNotMatch()
+			throws Exception {
+		int uriId = 17;
+		int payloadId = 42;
+		String updatedValue = "updated value";
+
+		TestModel updatedObject = buildTestInstanceWithIdAndValue(payloadId,
+				updatedValue);
+
+		// Test PUT method with JSON payload
+		mockMvc.perform(
+				put("/tests/" + uriId).contentType(MediaType.APPLICATION_JSON)
+						.content(asJson(updatedObject))).andExpect(
+				status().isBadRequest());
+
+		verify(serviceMock, times(0)).saveOrUpdate(any(TestModel.class));
+		verifyNoMoreInteractions(serviceMock);
+	}
+
+	/**
+	 * Tests whether the REST update (PUT) interface will return a HTTP Status
+	 * Code 404 (NOT FOUND), if a {@link RuntimeException} occured on
+	 * saveOrUpdate.
+	 *
+	 * @throws Exception
+	 *
+	 */
+	@Test
+	public void update_shouldReturn_NotFoundDueToRuntimeException()
+			throws Exception {
+		int id = 42;
+		String updatedValue = "updated value";
+
+		TestModel updatedObject = buildTestInstanceWithIdAndValue(id,
+				updatedValue);
+
+		when(serviceMock.saveOrUpdate(any(TestModel.class))).thenThrow(
+				new RuntimeException());
+
+		// Test PUT method with JSON payload
+		mockMvc.perform(
+				put("/tests/" + id).contentType(MediaType.APPLICATION_JSON)
+						.content(asJson(updatedObject))).andExpect(
+				status().isNotFound());
+
+		verify(serviceMock, times(1)).saveOrUpdate(any(TestModel.class));
+		verifyNoMoreInteractions(serviceMock);
+	}
+
+	/**
+	 * Tests whether the REST delete (DELETE) interface will work as expected,
+	 * i.e. HTTP Status Code 204 (NO CONTENT).
+	 *
+	 * @throws Exception
+	 *
+	 */
+	@Test
+	public void delete_shouldWorkAsExpectedAndReturn_NoContent()
+			throws Exception {
+		int id = 42;
+		String value = "deleted value";
+
+		TestModel entityToDelete = buildTestInstanceWithIdAndValue(id, value);
+
+		when(serviceMock.loadById(id)).thenReturn(entityToDelete);
+		doNothing().when(serviceMock).delete(entityToDelete);
+
+		// Test DELETE method
+		mockMvc.perform(delete("/tests/" + id)).andExpect(
+				status().isNoContent());
+
+		verify(serviceMock, times(1)).loadById(id);
+		verify(serviceMock, times(1)).delete(entityToDelete);
+		verifyNoMoreInteractions(serviceMock);
+	}
+
+	/**
+	 * Tests whether the REST delete (DELETE) interface will return a HTTP
+	 * Status Code 404 (NOT FOUND).
+	 *
+	 * @throws Exception
+	 *
+	 */
+	@Test
+	public void delete_shouldReturn_NotFoundDueToRuntimeException()
+			throws Exception {
+		int id = 42;
+		String value = "deleted value";
+
+		TestModel entityToDelete = buildTestInstanceWithIdAndValue(id, value);
+
+		when(serviceMock.loadById(id)).thenReturn(entityToDelete);
+		doThrow(new RuntimeException()).when(serviceMock).delete(entityToDelete);
+
+		// Test DELETE method
+		mockMvc.perform(delete("/tests/" + id)).andExpect(
+				status().isNotFound());
+
+		verify(serviceMock, times(1)).loadById(id);
+		verify(serviceMock, times(1)).delete(entityToDelete);
+		verifyNoMoreInteractions(serviceMock);
+	}
+
+	/**
+	 * Helper method to build a test instance without ID, but a value.
+	 *
+	 * @param value
+	 * @return
+	 */
+	private TestModel buildTestInstanceWithValue(String value) {
+		TestModel tm = new TestModel();
+		tm.setTestValue(value);
+		return tm;
+	}
+
+	/**
+	 * Helper method to build a test instance with ID and value
+	 *
+	 * @param value
+	 * @return
+	 * @throws IllegalAccessException
+	 * @throws NoSuchFieldException
+	 */
+	private TestModel buildTestInstanceWithIdAndValue(int id, String value)
+			throws Exception {
+		TestModel tm = buildTestInstanceWithValue(value);
+
+		TestUtil.setIdOnPersistentObject(tm, id);
+
+		return tm;
+	}
+
+	/**
+	 * Helper method to get the JSON representation of a given {@link TestModel}
+	 *
+	 * @param object
+	 * @return JSON representation of the passed object
+	 * @throws JsonProcessingException
+	 */
+	private String asJson(TestModel object) throws JsonProcessingException {
+		return objectMapper.writeValueAsString(object);
 	}
 
 }

--- a/src/shogun2-web/src/test/java/de/terrestris/shogun2/rest/AbstractRestControllerTest.java
+++ b/src/shogun2-web/src/test/java/de/terrestris/shogun2/rest/AbstractRestControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.service.AbstractCrudService;
+import de.terrestris.shogun2.util.test.TestUtil;
 
 /**
  *
@@ -53,7 +54,7 @@ public class AbstractRestControllerTest {
 	 * {@link AbstractRestController}.
 	 */
 	@RestController
-	@RequestMapping("/test")
+	@RequestMapping("/tests")
 	private class TestModelRestController extends AbstractRestController<TestModel> {}
 
 	/**
@@ -92,7 +93,7 @@ public class AbstractRestControllerTest {
 	/**
 	 * Tests whether the REST findAll interface will return all entities and a
 	 * HTTP Status Code 200 (OK).
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test
@@ -110,7 +111,7 @@ public class AbstractRestControllerTest {
 		when(serviceMock.findAll()).thenReturn(Arrays.asList(first, second));
 
 		// Test GET method
-		mockMvc.perform(get("/test"))
+		mockMvc.perform(get("/tests"))
 			.andExpect(status().isOk())
 			.andExpect(content().contentType("application/json;charset=UTF-8"))
 			.andExpect(jsonPath("$", hasSize(2)))
@@ -120,4 +121,34 @@ public class AbstractRestControllerTest {
 		verify(serviceMock, times(1)).findAll();
 		verifyNoMoreInteractions(serviceMock);
 	}
+
+	/**
+	 * Tests whether the REST findById interface will return an expected entity
+	 * and a HTTP Status Code 200 (OK).
+	 * @throws Exception
+	 *
+	 */
+	@Test
+	public void findById_shouldReturn_EntityAndOK() throws Exception {
+		int id = 42;
+		String value = "value";
+
+		TestModel testInstance = new TestModel();
+		testInstance.setTestValue(value);
+
+		TestUtil.setIdOnPersistentObject(testInstance, id);
+
+		when(serviceMock.findById(id)).thenReturn(testInstance);
+
+		// Test GET method with ID
+		mockMvc.perform(get("/tests/" + id))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType("application/json;charset=UTF-8"))
+			.andExpect(jsonPath("$.id", is(id)))
+			.andExpect(jsonPath("$.testValue", is(value)));
+
+		verify(serviceMock, times(1)).findById(id);
+		verifyNoMoreInteractions(serviceMock);
+	}
+
 }

--- a/src/shogun2-web/src/test/java/de/terrestris/shogun2/rest/AbstractRestControllerTest.java
+++ b/src/shogun2-web/src/test/java/de/terrestris/shogun2/rest/AbstractRestControllerTest.java
@@ -27,6 +27,8 @@ import de.terrestris.shogun2.service.ApplicationService;
 /**
  *
  * @author Kai Volland
+ * @author Nils Bühner
+ * 
  * @param <E>
  */
 public class AbstractRestControllerTest<E> {
@@ -65,7 +67,7 @@ public class AbstractRestControllerTest<E> {
 		when(applicationServiceMock.findAll()).thenReturn(
 				Arrays.asList(first, second));
 
-		mockMvc.perform(get("/application"))
+		mockMvc.perform(get("/applications"))
 			.andExpect(status().isOk())
 			.andExpect(
 				content().contentType("application/json;charset=UTF-8"))


### PR DESCRIPTION
I adapted the following aspects of the current REST implementation:

* Logging
* Use plural (e.g. `applications` instead of `application`) for the REST web interface as this is the most common way
* Return more meaningful HTTP status codes (see below)

I added a `loadById` method to the DAO and service, which is nice to have, e.g. to load (a proxy) of an object when deleting by id. This is more performant than using `findById`, which immediately accesses the database.

| Path  | HTTP method  | HTTP Status Code(s)  |
|---|---|---|
| `rest/{entity}`  | GET  | `200 OK` (with filled or empty array) |
| `rest/{entity}/{id}`  | GET  | `200 OK`<br>`404 NOT FOUND`, if entity not found or access is denied  |
|  `rest/{entity}` | POST  | `200 OK`<br>`400 BAD REQUEST` in case of exception |
|  `rest/{entity}/{id}` | PUT  | `200 OK`<br>`404 NOT FOUND` in case of exception (e.g. if object with `{id}` does not exist)<br>`400 BAD REQUEST`, if `{id}` does not match the ID in the payload |
|  `rest/{entity}/{id}` | DELETE  | `204 NO CONTENT` (i.e. empty response) in case of successful deletion<br>`404 NOT FOUND` in case of exception (e.g. if object with `{id}` does not exist) |

Maybe i will push some more tests if you wait with merging ;-)