### PR TITLE
Reset & update password

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -138,6 +138,12 @@
         <!-- Java Transaction API -->
         <jta.version>1.1</jta.version>
 
+        <!-- Java Servlet API -->
+        <javax-servlet-api.version>3.1.0</javax-servlet-api.version>
+
+        <!-- Apache HTTP Client -->
+        <apache-httpclient.version>4.5.1</apache-httpclient.version>
+
         <downloadSources>true</downloadSources>
         <downloadJavadocs>true</downloadJavadocs>
     </properties>
@@ -597,6 +603,18 @@
             </dependency>
 
             <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${apache-httpclient.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>${javax-servlet-api.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>javax.mail</groupId>
                 <artifactId>javax.mail-api</artifactId>
                 <version>${javax-mail-api.version}</version>
@@ -620,4 +638,3 @@
     </dependencyManagement>
 
 </project>
-

--- a/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/PasswordResetTokenDao.java
+++ b/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/PasswordResetTokenDao.java
@@ -1,0 +1,14 @@
+package de.terrestris.shogun2.dao;
+
+import org.springframework.stereotype.Repository;
+
+import de.terrestris.shogun2.model.token.PasswordResetToken;
+
+@Repository
+public class PasswordResetTokenDao extends GenericHibernateDao<PasswordResetToken, Integer> {
+
+	protected PasswordResetTokenDao() {
+		super(PasswordResetToken.class);
+	}
+
+}

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/token/PasswordResetToken.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/token/PasswordResetToken.java
@@ -1,0 +1,76 @@
+package de.terrestris.shogun2.model.token;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+
+@Entity
+@Table
+public class PasswordResetToken extends Token {
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * The password token should be valid for 48h.
+	 */
+	private static final int expiration = 48;
+
+	/**
+	 * Constructor
+	 */
+	public PasswordResetToken() {
+		super(expiration);
+	}
+
+	/**
+	 * @see java.lang.Object#hashCode()
+	 *
+	 *      According to
+	 *      http://stackoverflow.com/questions/27581/overriding-equals
+	 *      -and-hashcode-in-java it is recommended only to use getter-methods
+	 *      when using ORM like Hibernate
+	 */
+	@Override
+	public int hashCode() {
+		// two randomly chosen prime numbers
+		return new HashCodeBuilder(17, 37).
+				appendSuper(super.hashCode()).
+				toHashCode();
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 *
+	 *      According to
+	 *      http://stackoverflow.com/questions/27581/overriding-equals
+	 *      -and-hashcode-in-java it is recommended only to use getter-methods
+	 *      when using ORM like Hibernate
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof PasswordResetToken))
+			return false;
+		PasswordResetToken other = (PasswordResetToken) obj;
+
+		return new EqualsBuilder().
+				appendSuper(super.equals(other)).
+				isEquals();
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
+	}
+
+}

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/token/PasswordResetToken.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/token/PasswordResetToken.java
@@ -8,7 +8,13 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
-
+/**
+ *
+ * The PasswordResetToken class.
+ *
+ * @author Daniel Koch
+ *
+ */
 @Entity
 @Table
 public class PasswordResetToken extends Token {

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/token/Token.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/token/Token.java
@@ -122,7 +122,7 @@ public abstract class Token extends PersistentObject {
 	@Override
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(17, 37).
+		return new HashCodeBuilder(17, 29).
 				appendSuper(super.hashCode()).
 				append(getToken()).
 				append(getExpirationDate()).

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/token/Token.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/token/Token.java
@@ -1,0 +1,163 @@
+package de.terrestris.shogun2.model.token;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.Type;
+import org.joda.time.DateTime;
+import org.joda.time.ReadableDateTime;
+
+import de.terrestris.shogun2.model.PersistentObject;
+import de.terrestris.shogun2.model.User;
+
+/**
+ * Base class for all tokens.
+ *
+ * @author Daniel Koch
+ *
+ */
+@Entity
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+public abstract class Token extends PersistentObject {
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * The token validity period (in hours).
+	 *
+	 * The Default is to 24.
+	 *
+	 */
+	private static final int expiration = 24;
+
+	/**
+	 * The token string itself.
+	 */
+	private String token;
+
+	/**
+	 * The expiration date of the token. Will be set
+	 */
+	@Column(updatable = false)
+	@Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
+	private final ReadableDateTime expirationDate;
+
+	/**
+	 * The user who has requested the token. Hereby one user can have one
+	 * token and one token can be used by one user (at the same time) only.
+	 */
+	@OneToOne
+	@JoinColumn(name = "USER_ID")
+	private User user;
+
+	/**
+	 * Constructor
+	 */
+	protected Token(int expiration) {
+		// set the expiration date
+		this.expirationDate = DateTime.now().plusHours(expiration);
+	}
+
+	/**
+	 * @return the token
+	 */
+	public String getToken() {
+		return token;
+	}
+
+	/**
+	 * @param token the token to set
+	 */
+	public void setToken(String token) {
+		this.token = token;
+	}
+
+	/**
+	 * @return the user
+	 */
+	public User getUser() {
+		return user;
+	}
+
+	/**
+	 * @param user the user to set
+	 */
+	public void setUser(User user) {
+		this.user = user;
+	}
+
+	/**
+	 * @return the expiration
+	 */
+	public static int getExpiration() {
+		return expiration;
+	}
+
+	/**
+	 * @return the expirationDate
+	 */
+	public ReadableDateTime getExpirationDate() {
+		return expirationDate;
+	}
+
+	/**
+	 * @see java.lang.Object#hashCode()
+	 *
+	 *      According to
+	 *      http://stackoverflow.com/questions/27581/overriding-equals
+	 *      -and-hashcode-in-java it is recommended only to use getter-methods
+	 *      when using ORM like Hibernate
+	 */
+	@Override
+	public int hashCode() {
+		// two randomly chosen prime numbers
+		return new HashCodeBuilder(17, 37).
+				appendSuper(super.hashCode()).
+				append(getToken()).
+				append(getExpirationDate()).
+				append(getUser()).
+				toHashCode();
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 *
+	 *      According to
+	 *      http://stackoverflow.com/questions/27581/overriding-equals
+	 *      -and-hashcode-in-java it is recommended only to use getter-methods
+	 *      when using ORM like Hibernate
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof Token))
+			return false;
+		Token other = (Token) obj;
+
+		return new EqualsBuilder().
+				appendSuper(super.equals(other)).
+				append(getToken(), other.getToken()).
+				append(getExpirationDate(), other.getExpirationDate()).
+				append(getUser(), other.getUser()).
+				isEquals();
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
+	}
+
+}

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/PasswordResetTokenService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/PasswordResetTokenService.java
@@ -1,15 +1,28 @@
 package de.terrestris.shogun2.service;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.UUID;
 
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.log4j.Logger;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.criterion.SimpleExpression;
+import org.joda.time.DateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriUtils;
 
 import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.model.token.PasswordResetToken;
+import de.terrestris.shogun2.util.application.Shogun2ServletContext;
+import de.terrestris.shogun2.util.mail.MailPublisher;
 
 /**
  *
@@ -24,6 +37,42 @@ public class PasswordResetTokenService extends AbstractCrudService<PasswordReset
 	 */
 	private static final Logger LOG =
 			Logger.getLogger(PasswordResetTokenService.class);
+
+	/**
+	 *
+	 */
+	@Autowired
+	private Shogun2ServletContext contextUtil;
+
+	/**
+	 *
+	 */
+	@Autowired
+	private UserService userService;
+
+	/**
+	 *
+	 */
+	@Autowired
+	private MailPublisher mailPublisher;
+
+	/**
+	 * The autowired PasswordEncoder
+	 */
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+
+	/**
+	 *
+	 */
+	@Autowired
+	private SimpleMailMessage resetPasswordMailMessageTemplate;
+
+	/**
+	 *
+	 */
+	@Autowired
+	private String changePasswordPath;
 
 	/**
 	 *
@@ -54,6 +103,143 @@ public class PasswordResetTokenService extends AbstractCrudService<PasswordReset
 				dao.findByUniqueCriteria(criteria);
 
 		return passwordResetToken;
+	}
+
+	/**
+	 *
+	 * @param request
+	 * @param email
+	 * @return
+	 * @throws UsernameNotFoundException
+	 * @throws Exception
+	 * @throws URISyntaxException
+	 */
+	public Boolean sendResetPasswordMail(HttpServletRequest request, String email) throws
+			UsernameNotFoundException, Exception, URISyntaxException {
+
+		Boolean success = false;
+
+		// get the user by the provided email address
+		User user = userService.findByEmail(email);
+
+		if (user == null) {
+			throw new UsernameNotFoundException("Could not find user "
+					+ "with the provided email: " + email);
+		}
+
+		// generate and save the unique reset-password token for the user
+		PasswordResetToken resetPasswordToken = generateResetPasswordToken(user);
+
+		// create the reset-password URI that will be send to the user
+		URI resetPasswordURI = createResetPasswordURI(request,
+				resetPasswordToken);
+
+		// create a thread safe "copy" of the template message
+		SimpleMailMessage resetPwdMsg = new SimpleMailMessage(
+				resetPasswordMailMessageTemplate);
+
+		// prepare a personalized mail with the given token
+		resetPwdMsg.setTo(email);
+		resetPwdMsg.setText(
+				String.format(
+						resetPwdMsg.getText(),
+						user.getFirstName(),
+						user.getLastName(),
+						UriUtils.decode(resetPasswordURI.toString(), "UTF-8")
+				)
+		);
+
+		// and send the mail
+		mailPublisher.sendMail(resetPwdMsg);
+
+		// we did it!
+		success = true;
+
+		return success;
+	}
+
+	/**
+	 *
+	 * @param password
+	 * @param id
+	 * @param token
+	 * @return
+	 * @throws Exception
+	 */
+	public Boolean changePassword(String password, int id, String token)
+			throws Exception {
+
+		Boolean success = false;
+
+		// try to find the provided token
+		PasswordResetToken passwordResetToken = findByIdAndToken(id, token);
+
+		if (passwordResetToken == null) {
+			throw new Exception("The provided token is not valid.");
+		}
+
+		DateTime expirationDate = (DateTime) passwordResetToken
+				.getExpirationDate();
+
+		// check if the token expire date is valid
+		if (expirationDate.isBeforeNow()) {
+			throw new Exception("The provided token is expired.");
+		}
+
+		// the provided token seems to be valid, the user's password can be
+		// be changed
+
+		// get the user by the provided token
+		User user = passwordResetToken.getUser();
+
+		if (user == null) {
+			throw new Exception("Could not find the user for the "
+					+ "provided token.");
+		}
+
+		// finally update the password (encrypted)
+		try {
+			user.setPassword(passwordEncoder.encode(password));
+			userService.updateExistingUser(user);
+			LOG.debug("Successfully updated the password.");
+		} catch(Exception e) {
+			throw new Exception("Could not update the password: "
+					+ e.getMessage());
+		}
+
+		// delete the token
+		dao.delete(passwordResetToken);
+
+		// we did it!
+		success = true;
+
+		return success;
+	}
+
+	/**
+	 *
+	 * @param request
+	 * @param resetPasswordToken
+	 * @return
+	 * @throws URISyntaxException
+	 */
+	public URI createResetPasswordURI(HttpServletRequest request,
+			PasswordResetToken resetPasswordToken) throws URISyntaxException {
+
+		// get the webapp URI
+		URI appURI = contextUtil.getApplicationURIFromRequest(request);
+
+		// build the change-password URI send to the user
+		URI tokenURI = new URIBuilder()
+				.setScheme(appURI.getScheme())
+				.setHost(appURI.getHost())
+				.setPort(appURI.getPort())
+				.setPath(appURI.getPath() + changePasswordPath)
+				.setParameter("id", String.valueOf(resetPasswordToken.getId()))
+				.setParameter("token", resetPasswordToken.getToken())
+				.build();
+
+		return tokenURI;
 	}
 
 	/**
@@ -94,6 +280,91 @@ public class PasswordResetTokenService extends AbstractCrudService<PasswordReset
 		}
 
 		return passwordResetToken;
+	}
+
+	/**
+	 * @return the contextUtil
+	 */
+	public Shogun2ServletContext getContextUtil() {
+		return contextUtil;
+	}
+
+	/**
+	 * @param contextUtil the contextUtil to set
+	 */
+	public void setContextUtil(Shogun2ServletContext contextUtil) {
+		this.contextUtil = contextUtil;
+	}
+
+	/**
+	 * @return the userService
+	 */
+	public UserService getUserService() {
+		return userService;
+	}
+
+	/**
+	 * @param userService the userService to set
+	 */
+	public void setUserService(UserService userService) {
+		this.userService = userService;
+	}
+
+	/**
+	 * @return the mailPublisher
+	 */
+	public MailPublisher getMailPublisher() {
+		return mailPublisher;
+	}
+
+	/**
+	 * @param mailPublisher the mailPublisher to set
+	 */
+	public void setMailPublisher(MailPublisher mailPublisher) {
+		this.mailPublisher = mailPublisher;
+	}
+
+	/**
+	 * @return the passwordEncoder
+	 */
+	public PasswordEncoder getPasswordEncoder() {
+		return passwordEncoder;
+	}
+
+	/**
+	 * @param passwordEncoder the passwordEncoder to set
+	 */
+	public void setPasswordEncoder(PasswordEncoder passwordEncoder) {
+		this.passwordEncoder = passwordEncoder;
+	}
+
+	/**
+	 * @return the resetPasswordMailMessageTemplate
+	 */
+	public SimpleMailMessage getResetPasswordMailMessageTemplate() {
+		return resetPasswordMailMessageTemplate;
+	}
+
+	/**
+	 * @param resetPasswordMailMessageTemplate the resetPasswordMailMessageTemplate to set
+	 */
+	public void setResetPasswordMailMessageTemplate(
+			SimpleMailMessage resetPasswordMailMessageTemplate) {
+		this.resetPasswordMailMessageTemplate = resetPasswordMailMessageTemplate;
+	}
+
+	/**
+	 * @return the changePasswordPath
+	 */
+	public String getChangePasswordPath() {
+		return changePasswordPath;
+	}
+
+	/**
+	 * @param changePasswordPath the changePasswordPath to set
+	 */
+	public void setChangePasswordPath(String changePasswordPath) {
+		this.changePasswordPath = changePasswordPath;
 	}
 
 }

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/PasswordResetTokenService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/PasswordResetTokenService.java
@@ -1,0 +1,89 @@
+package de.terrestris.shogun2.service;
+
+import java.util.UUID;
+
+import org.apache.log4j.Logger;
+import org.hibernate.criterion.Criterion;
+import org.hibernate.criterion.Restrictions;
+import org.hibernate.criterion.SimpleExpression;
+import org.springframework.stereotype.Service;
+
+import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.token.PasswordResetToken;
+
+/**
+ *
+ * @author Daniel Koch
+ *
+ */
+@Service("passwordResetService")
+public class PasswordResetTokenService extends AbstractCrudService<PasswordResetToken> {
+
+	/**
+	 * The Logger
+	 */
+	private static final Logger LOG =
+			Logger.getLogger(PasswordResetTokenService.class);
+
+	/**
+	 *
+	 * @param user
+	 * @return
+	 */
+	public PasswordResetToken findByUser(User user) {
+
+		SimpleExpression eqEmail = Restrictions.eq("user", user);
+		PasswordResetToken passwordResetToken =
+				dao.findByUniqueCriteria(eqEmail);
+
+		return passwordResetToken;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public PasswordResetToken findByIdAndToken(int id, String token) {
+
+		Criterion criteria = Restrictions.and(
+				Restrictions.eq("id", id),
+				Restrictions.eq("token", token)
+		);
+
+		PasswordResetToken passwordResetToken = 
+				dao.findByUniqueCriteria(criteria);
+
+		return passwordResetToken;
+	}
+
+	/**
+	 *
+	 * @param user
+	 * @return
+	 */
+	public PasswordResetToken generateResetPasswordToken(User user) {
+
+		PasswordResetToken passwordResetToken;
+
+		String token = UUID.randomUUID().toString();
+
+		// check if the user has an open reset request / not used token
+		passwordResetToken = findByUser(user);
+
+		// if so, delete it
+		if (passwordResetToken != null) {
+			LOG.debug("User has an open request already, delete it first");
+			dao.delete(passwordResetToken);
+		}
+
+		// and create a blank new one
+		passwordResetToken = new PasswordResetToken();
+		passwordResetToken.setUser(user);
+		passwordResetToken.setToken(token);
+
+		dao.saveOrUpdate(passwordResetToken);
+
+		return passwordResetToken;
+	}
+
+}

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserService.java
@@ -1,26 +1,13 @@
 package de.terrestris.shogun2.service;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
-import javax.servlet.http.HttpServletRequest;
-
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.log4j.Logger;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.criterion.SimpleExpression;
-import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.web.util.UriUtils;
 
 import de.terrestris.shogun2.model.User;
-import de.terrestris.shogun2.model.token.PasswordResetToken;
-import de.terrestris.shogun2.util.application.Shogun2ServletContext;
-import de.terrestris.shogun2.util.mail.MailPublisher;
 
 /**
  * Service class for the {@link User} model.
@@ -43,36 +30,6 @@ public class UserService extends AbstractExtDirectCrudService<User> {
 	 */
 	@Autowired
 	private PasswordEncoder passwordEncoder;
-
-	/**
-	 *
-	 */
-	@Autowired
-	private Shogun2ServletContext contextUtil;
-
-	/**
-	 *
-	 */
-	@Autowired
-	private PasswordResetTokenService passwordResetTokenService;
-
-	/**
-	 *
-	 */
-	@Autowired
-	private MailPublisher mailPublisher;
-
-	/**
-	 *
-	 */
-	@Autowired
-	private SimpleMailMessage resetPasswordMailMessageTemplate;
-
-	/**
-	 *
-	 */
-	@Autowired
-	private String changePasswordPath;
 
 	/**
 	 * Returns the user for the given (unique) account name.
@@ -134,138 +91,20 @@ public class UserService extends AbstractExtDirectCrudService<User> {
 
 	/**
 	 *
-	 * @param request
-	 * @param email
 	 * @return
 	 */
-	public Boolean resetPassword(HttpServletRequest request, String email) throws
-			UsernameNotFoundException, Exception, URISyntaxException {
+	public User updateExistingUser(User user) {
 
-		Boolean success = false;
-
-		// get the user by the provided email address
-		User user = findByEmail(email);
-
-		if (user == null) {
-			throw new UsernameNotFoundException("Could not find user "
-					+ "with the provided email: " + email);
+		if(user.getId() == null) {
+			// to be sure that we are in the
+			// "update" case, the id must not be null
+			return user;
 		}
 
-		// generate and save the unique reset-password token for the user
-		PasswordResetToken resetPasswordToken = passwordResetTokenService
-				.generateResetPasswordToken(user);
+		dao.saveOrUpdate(user);
 
-		// create the reset-password URI that will be send to the user
-		URI resetPasswordURI = createResetPasswordURI(request,
-				resetPasswordToken);
+		return user;
 
-		// create a thread safe "copy" of the template message
-		SimpleMailMessage resetPwdMsg = new SimpleMailMessage(
-				resetPasswordMailMessageTemplate);
-
-		// prepare a personalized mail with the given token
-		resetPwdMsg.setTo(email);
-		resetPwdMsg.setText(
-				String.format(
-						resetPwdMsg.getText(),
-						user.getFirstName(),
-						user.getLastName(),
-						UriUtils.decode(resetPasswordURI.toString(), "UTF-8")
-				)
-		);
-
-		// and send the mail
-		mailPublisher.sendMail(resetPwdMsg);
-
-		// we did it!
-		success = true;
-
-		return success;
-	}
-
-	/**
-	 *
-	 * @param password
-	 * @param id
-	 * @param token
-	 * @return
-	 * @throws Exception
-	 */
-	public Boolean changePassword(String password, int id, String token)
-			throws Exception {
-
-		Boolean success = false;
-
-		// try to find the provided token
-		PasswordResetToken passwordResetToken =
-				passwordResetTokenService.findByIdAndToken(id, token);
-
-		if (passwordResetToken == null) {
-			throw new Exception("The provided token is not valid.");
-		}
-
-		DateTime expirationDate = (DateTime) passwordResetToken
-				.getExpirationDate();
-
-		// check if the token expire date is valid
-		if (expirationDate.isBeforeNow()) {
-			throw new Exception("The provided token is expired.");
-		}
-
-		// the provided token seems to be valid, the user's password can be
-		// be changed
-
-		// get the user by the provided token
-		User user = passwordResetToken.getUser();
-
-		if (user == null) {
-			throw new Exception("Could not find the user for the "
-					+ "provided token.");
-		}
-
-		// finally update the password (encrypted)
-		try {
-			user.setPassword(passwordEncoder.encode(password));
-			dao.saveOrUpdate(user);
-			LOG.debug("Successfully updated the password.");
-		} catch(Exception e) {
-			throw new Exception("Could not update the password: "
-					+ e.getMessage());
-		}
-
-		// TODO: delete the token
-//		passwordResetTokenService.delete(passwordResetToken);
-
-		// we did it!
-		success = true;
-
-		return success;
-	}
-
-	/**
-	 *
-	 * @param request
-	 * @param resetPasswordToken
-	 * @return
-	 * @throws URISyntaxException
-	 */
-	public URI createResetPasswordURI(HttpServletRequest request,
-			PasswordResetToken resetPasswordToken) throws URISyntaxException {
-
-		// get the webapp URI
-		URI appURI = contextUtil.getApplicationURIFromRequest(request);
-
-		// build the change-password URI send to the user
-		URI tokenURI = new URIBuilder()
-				.setScheme(appURI.getScheme())
-				.setHost(appURI.getHost())
-				.setPort(appURI.getPort())
-				.setPath(appURI.getPath() + changePasswordPath)
-				.setParameter("id", String.valueOf(resetPasswordToken.getId()))
-				.setParameter("token", resetPasswordToken.getToken())
-				.build();
-
-		return tokenURI;
 	}
 
 	/**
@@ -280,78 +119,6 @@ public class UserService extends AbstractExtDirectCrudService<User> {
 	 */
 	public void setPasswordEncoder(PasswordEncoder passwordEncoder) {
 		this.passwordEncoder = passwordEncoder;
-	}
-
-	/**
-	 * @return the contextUtil
-	 */
-	public Shogun2ServletContext getContextUtil() {
-		return contextUtil;
-	}
-
-	/**
-	 * @param contextUtil the contextUtil to set
-	 */
-	public void setContextUtil(Shogun2ServletContext contextUtil) {
-		this.contextUtil = contextUtil;
-	}
-
-	/**
-	 * @return the passwordResetTokenService
-	 */
-	public PasswordResetTokenService getPasswordResetTokenService() {
-		return passwordResetTokenService;
-	}
-
-	/**
-	 * @param passwordResetTokenService the passwordResetTokenService to set
-	 */
-	public void setPasswordResetTokenService(
-			PasswordResetTokenService passwordResetTokenService) {
-		this.passwordResetTokenService = passwordResetTokenService;
-	}
-
-	/**
-	 * @return the mailPublisher
-	 */
-	public MailPublisher getMailPublisher() {
-		return mailPublisher;
-	}
-
-	/**
-	 * @param mailPublisher the mailPublisher to set
-	 */
-	public void setMailPublisher(MailPublisher mailPublisher) {
-		this.mailPublisher = mailPublisher;
-	}
-
-	/**
-	 * @return the resetPasswordMailMessageTemplate
-	 */
-	public SimpleMailMessage getResetPasswordMailMessageTemplate() {
-		return resetPasswordMailMessageTemplate;
-	}
-
-	/**
-	 * @param resetPasswordMailMessageTemplate the resetPasswordMailMessageTemplate to set
-	 */
-	public void setResetPasswordMailMessageTemplate(
-			SimpleMailMessage resetPasswordMailMessageTemplate) {
-		this.resetPasswordMailMessageTemplate = resetPasswordMailMessageTemplate;
-	}
-
-	/**
-	 * @return the changePasswordPath
-	 */
-	public String getChangePasswordPath() {
-		return changePasswordPath;
-	}
-
-	/**
-	 * @param changePasswordPath the changePasswordPath to set
-	 */
-	public void setChangePasswordPath(String changePasswordPath) {
-		this.changePasswordPath = changePasswordPath;
 	}
 
 }

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserService.java
@@ -1,16 +1,26 @@
 package de.terrestris.shogun2.service;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.log4j.Logger;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.criterion.SimpleExpression;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.SimpleMailMessage;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriUtils;
 
 import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.model.token.PasswordResetToken;
+import de.terrestris.shogun2.util.application.Shogun2ServletContext;
+import de.terrestris.shogun2.util.mail.MailPublisher;
 
 /**
  * Service class for the {@link User} model.
@@ -38,7 +48,31 @@ public class UserService extends AbstractExtDirectCrudService<User> {
 	 *
 	 */
 	@Autowired
+	private Shogun2ServletContext contextUtil;
+
+	/**
+	 *
+	 */
+	@Autowired
 	private PasswordResetTokenService passwordResetTokenService;
+
+	/**
+	 *
+	 */
+	@Autowired
+	private MailPublisher mailPublisher;
+
+	/**
+	 *
+	 */
+	@Autowired
+	private SimpleMailMessage resetPasswordMailMessageTemplate;
+
+	/**
+	 *
+	 */
+	@Autowired
+	private String changePasswordPath;
 
 	/**
 	 * Returns the user for the given (unique) account name.
@@ -100,53 +134,65 @@ public class UserService extends AbstractExtDirectCrudService<User> {
 
 	/**
 	 *
+	 * @param request
 	 * @param email
 	 * @return
 	 */
-	public Boolean resetPassword(String email) throws
-			UsernameNotFoundException, Exception {
+	public Boolean resetPassword(HttpServletRequest request, String email) throws
+			UsernameNotFoundException, Exception, URISyntaxException {
 
 		Boolean success = false;
 
-		// get the user (by the provided email address)
-		User user = this.findByEmail(email);
+		// get the user by the provided email address
+		User user = findByEmail(email);
 
 		if (user == null) {
 			throw new UsernameNotFoundException("Could not find user "
-					+ "with email: " + email);
+					+ "with the provided email: " + email);
 		}
 
-		// generate and save the unique reset password token for the user
+		// generate and save the unique reset-password token for the user
 		PasswordResetToken resetPasswordToken = passwordResetTokenService
 				.generateResetPasswordToken(user);
 
-		if (resetPasswordToken == null) {
-			throw new Exception("Error while resetting the password");
-		}
+		// create the reset-password URI that will be send to the user
+		URI resetPasswordURI = createResetPasswordURI(request,
+				resetPasswordToken);
 
+		// create a thread safe "copy" of the template message
+		SimpleMailMessage resetPwdMsg = new SimpleMailMessage(
+				resetPasswordMailMessageTemplate);
+
+		// prepare a personalized mail with the given token
+		resetPwdMsg.setTo(email);
+		resetPwdMsg.setText(
+				String.format(
+						resetPwdMsg.getText(),
+						user.getFirstName(),
+						user.getLastName(),
+						UriUtils.decode(resetPasswordURI.toString(), "UTF-8")
+				)
+		);
+
+		// and send the mail
+		mailPublisher.sendMail(resetPwdMsg);
+
+		// we did it!
 		success = true;
-
-		// send mail to user with the given token
-//		resetPasswordMailMessageTemplate.setTo(email);
-//		resetPasswordMailMessageTemplate.setText(
-//				String.format(
-//						resetPasswordMailMessageTemplate.getText(),
-//						"Username",
-//						"http://activate-token.com" + resetPasswordToken.getToken()
-//				)
-//		);
-//		mailPublisher.sendMail(resetPasswordMailMessageTemplate);
 
 		return success;
 	}
 
 	/**
 	 *
+	 * @param password
 	 * @param id
 	 * @param token
 	 * @return
+	 * @throws Exception
 	 */
-	public Boolean changePassword(int id, String token) {
+	public Boolean changePassword(String password, int id, String token)
+			throws Exception {
 
 		Boolean success = false;
 
@@ -154,20 +200,72 @@ public class UserService extends AbstractExtDirectCrudService<User> {
 		PasswordResetToken passwordResetToken =
 				passwordResetTokenService.findByIdAndToken(id, token);
 
-		// TODO or throw exception?
 		if (passwordResetToken == null) {
-			LOG.error("Could not find the passwordResetToken");
+			throw new Exception("The provided token is not valid.");
 		}
 
-		DateTime expirationDate = (DateTime) passwordResetToken.getExpirationDate();
+		DateTime expirationDate = (DateTime) passwordResetToken
+				.getExpirationDate();
 
-		if (expirationDate.isAfterNow()) {
-			LOG.error("Token is expired!");
+		// check if the token expire date is valid
+		if (expirationDate.isBeforeNow()) {
+			throw new Exception("The provided token is expired.");
 		}
 
-		//TODO let the user change the password!
+		// the provided token seems to be valid, the user's password can be
+		// be changed
+
+		// get the user by the provided token
+		User user = passwordResetToken.getUser();
+
+		if (user == null) {
+			throw new Exception("Could not find the user for the "
+					+ "provided token.");
+		}
+
+		// finally update the password (encrypted)
+		try {
+			user.setPassword(passwordEncoder.encode(password));
+			dao.saveOrUpdate(user);
+			LOG.debug("Successfully updated the password.");
+		} catch(Exception e) {
+			throw new Exception("Could not update the password: "
+					+ e.getMessage());
+		}
+
+		// TODO: delete the token
+//		passwordResetTokenService.delete(passwordResetToken);
+
+		// we did it!
+		success = true;
 
 		return success;
+	}
+
+	/**
+	 *
+	 * @param request
+	 * @param resetPasswordToken
+	 * @return
+	 * @throws URISyntaxException
+	 */
+	public URI createResetPasswordURI(HttpServletRequest request,
+			PasswordResetToken resetPasswordToken) throws URISyntaxException {
+
+		// get the webapp URI
+		URI appURI = contextUtil.getApplicationURIFromRequest(request);
+
+		// build the change-password URI send to the user
+		URI tokenURI = new URIBuilder()
+				.setScheme(appURI.getScheme())
+				.setHost(appURI.getHost())
+				.setPort(appURI.getPort())
+				.setPath(appURI.getPath() + changePasswordPath)
+				.setParameter("id", String.valueOf(resetPasswordToken.getId()))
+				.setParameter("token", resetPasswordToken.getToken())
+				.build();
+
+		return tokenURI;
 	}
 
 	/**
@@ -185,6 +283,20 @@ public class UserService extends AbstractExtDirectCrudService<User> {
 	}
 
 	/**
+	 * @return the contextUtil
+	 */
+	public Shogun2ServletContext getContextUtil() {
+		return contextUtil;
+	}
+
+	/**
+	 * @param contextUtil the contextUtil to set
+	 */
+	public void setContextUtil(Shogun2ServletContext contextUtil) {
+		this.contextUtil = contextUtil;
+	}
+
+	/**
 	 * @return the passwordResetTokenService
 	 */
 	public PasswordResetTokenService getPasswordResetTokenService() {
@@ -197,6 +309,49 @@ public class UserService extends AbstractExtDirectCrudService<User> {
 	public void setPasswordResetTokenService(
 			PasswordResetTokenService passwordResetTokenService) {
 		this.passwordResetTokenService = passwordResetTokenService;
+	}
+
+	/**
+	 * @return the mailPublisher
+	 */
+	public MailPublisher getMailPublisher() {
+		return mailPublisher;
+	}
+
+	/**
+	 * @param mailPublisher the mailPublisher to set
+	 */
+	public void setMailPublisher(MailPublisher mailPublisher) {
+		this.mailPublisher = mailPublisher;
+	}
+
+	/**
+	 * @return the resetPasswordMailMessageTemplate
+	 */
+	public SimpleMailMessage getResetPasswordMailMessageTemplate() {
+		return resetPasswordMailMessageTemplate;
+	}
+
+	/**
+	 * @param resetPasswordMailMessageTemplate the resetPasswordMailMessageTemplate to set
+	 */
+	public void setResetPasswordMailMessageTemplate(
+			SimpleMailMessage resetPasswordMailMessageTemplate) {
+		this.resetPasswordMailMessageTemplate = resetPasswordMailMessageTemplate;
+	}
+
+	/**
+	 * @return the changePasswordPath
+	 */
+	public String getChangePasswordPath() {
+		return changePasswordPath;
+	}
+
+	/**
+	 * @param changePasswordPath the changePasswordPath to set
+	 */
+	public void setChangePasswordPath(String changePasswordPath) {
+		this.changePasswordPath = changePasswordPath;
 	}
 
 }

--- a/src/shogun2-security/src/test/resources/META-INF/spring/test-context-acl.xml
+++ b/src/shogun2-security/src/test/resources/META-INF/spring/test-context-acl.xml
@@ -19,7 +19,12 @@
     </jdbc:initialize-database>
 
     <context:component-scan base-package="de.terrestris.shogun2.security,
-        de.terrestris.shogun2.service, de.terrestris.shogun2.dao" />
+            de.terrestris.shogun2.dao" />
+
+    <context:component-scan base-package="de.terrestris.shogun2.service" use-default-filters="false">
+        <context:include-filter type="aspectj" expression="de.terrestris.shogun2.service..ApplicationService*"/>
+        <context:include-filter type="aspectj" expression="de.terrestris.shogun2.service..PersonService*"/>
+    </context:component-scan>
 
     <context:property-placeholder location="classpath*:META-INF/*.properties" />
 

--- a/src/shogun2-util/pom.xml
+++ b/src/shogun2-util/pom.xml
@@ -70,6 +70,16 @@
             <artifactId>greenmail</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/application/Shogun2ServletContext.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/application/Shogun2ServletContext.java
@@ -1,0 +1,53 @@
+package de.terrestris.shogun2.util.application;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.http.client.utils.URIBuilder;
+import org.springframework.stereotype.Component;
+
+/**
+ *
+ * @author Daniel Koch
+ *
+ */
+@Component
+public class Shogun2ServletContext {
+
+	/**
+	 * Returns the full webapplication URI from a given request.
+	 *
+	 * Example:
+	 *
+	 * The following GET-request:
+	 *      http://localhost:8080/mapmavin/user/resetPassword.action
+	 * will result in
+	 *      http://localhost:8080/mapmavin/
+	 *
+	 * @param request
+	 * @return
+	 * @throws URISyntaxException
+	 */
+	public URI getApplicationURIFromRequest(HttpServletRequest request)
+			throws URISyntaxException {
+
+		URI appURI = null;
+
+		String scheme = request.getScheme();
+		String host = request.getServerName();
+		int port = request.getServerPort();
+		String path = request.getContextPath();
+
+		appURI = new URIBuilder()
+				.setScheme(scheme)
+				.setHost(host)
+				.setPort(port)
+				.setPath(path)
+				.build();
+
+		return appURI;
+	}
+
+}

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/mail/MailPublisher.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/mail/MailPublisher.java
@@ -2,7 +2,6 @@ package de.terrestris.shogun2.util.mail;
 
 import java.io.File;
 
-import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
 import org.apache.log4j.Logger;
@@ -51,9 +50,10 @@ public class MailPublisher {
 	 * @param bcc A list of blind carbon copy mail recipient addresses.
 	 * @param subject The mail subject.
 	 * @param msg The mail message text.
+	 * @throws Exception 
 	 */
 	public void sendMail(String from, String replyTo, String[] to, String[] cc,
-			String[] bcc, String subject, String msg) {
+			String[] bcc, String subject, String msg) throws Exception {
 
 		SimpleMailMessage simpleMailMassage = new SimpleMailMessage();
 
@@ -88,12 +88,11 @@ public class MailPublisher {
 	 *             content type ("text/plain").
 	 * @param attachmentFilename The attachment file name.
 	 * @param attachmentFile The file resource to be applied to the mail.
-	 *
-	 * @throws MessagingException
+	 * @throws Exception 
 	 */
 	public void sendMimeMail(String from, String replyTo, String[] to, String[] cc,
 			String[] bcc, String subject, String msg, Boolean html,
-			String attachmentFilename, File attachmentFile) throws MessagingException {
+			String attachmentFilename, File attachmentFile) throws Exception {
 
 		Boolean multipart = false;
 
@@ -143,28 +142,30 @@ public class MailPublisher {
 	/**
 	 *
 	 * @param mailMessage
+	 * @throws Exception 
 	 */
-	public void sendMail(SimpleMailMessage mailMessage) {
+	public void sendMail(SimpleMailMessage mailMessage) throws Exception {
 		LOG.debug("Requested to send a mail");
 		try {
 			mailSender.send(mailMessage);
 			LOG.debug("Successfully send mail.");
 		} catch(MailException e) {
-			LOG.error("Could not send the mail: " + e.getMessage());
+			throw new Exception("Could not send the mail: " + e.getMessage());
 		}
 	}
 
 	/**
 	 *
 	 * @param mimeMessage
+	 * @throws Exception 
 	 */
-	public void sendMail(MimeMessage mimeMessage) {
+	public void sendMail(MimeMessage mimeMessage) throws Exception {
 		LOG.debug("Requested to send a mail");
 		try {
 			mailSender.send(mimeMessage);
 			LOG.debug("Successfully send mail.");
 		} catch(MailException e) {
-			LOG.error("Could not send the mail: " + e.getMessage());
+			throw new Exception("Could not send the mail: " + e.getMessage());
 		}
 	}
 

--- a/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/application/Shogun2ServletContextTest.java
+++ b/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/application/Shogun2ServletContextTest.java
@@ -1,0 +1,67 @@
+package de.terrestris.shogun2.util.application;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+public class Shogun2ServletContextTest {
+
+	/**
+	 * The mockup request
+	 */
+	private MockHttpServletRequest request;
+
+	/**
+	 * The class to test.
+	 */
+	private Shogun2ServletContext shogun2ServletContext = new Shogun2ServletContext();
+
+	/**
+	 *
+	 */
+	@Before
+	public void setUp() {
+		request = new MockHttpServletRequest();
+	}
+
+	/**
+	 *
+	 */
+	@After
+	public void clean() {
+		request.close();
+	}
+
+	@Test
+	public void getApplicationURIFromRequest_returnsAppURIonly() throws URISyntaxException {
+
+		String scheme = "http";
+		String host = "localhost";
+		int port = 8080;
+		String path = "/webapp";
+
+		Map<String, String> params = new HashMap<String, String>();
+		params.put("key1", "val1");
+		params.put("key2", "val2");
+
+		// mock the request
+		request.setScheme(scheme);
+		request.setServerName(host);
+		request.setServerPort(port);
+		request.setContextPath(path);
+		request.setParameters(params);
+
+		URI uri = shogun2ServletContext.getApplicationURIFromRequest(request);
+
+		assertEquals(scheme + "://" + host + ":" + port + path, uri.toString());
+
+	}
+}

--- a/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/mail/MailPublisherTest.java
+++ b/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/mail/MailPublisherTest.java
@@ -77,7 +77,7 @@ public class MailPublisherTest {
 	 * @throws MessagingException
 	 */
 	@Test
-	public void sendMail_minimal_configuration() throws MessagingException {
+	public void sendMail_minimal_configuration() throws Exception, MessagingException {
 
 		String from = "from@shogun2.de";
 		String[] to = {"to@shogun2.de"};
@@ -109,7 +109,7 @@ public class MailPublisherTest {
 	 * @throws MessagingException
 	 */
 	@Test
-	public void sendMail_replyTo() throws MessagingException {
+	public void sendMail_replyTo() throws Exception, MessagingException {
 
 		String from = "from@shogun2.de";
 		String[] to = {"to@shogun2.de"};
@@ -141,7 +141,7 @@ public class MailPublisherTest {
 	 * @throws MessagingException
 	 */
 	@Test
-	public void sendMail_cc() throws MessagingException {
+	public void sendMail_cc() throws Exception, MessagingException {
 
 		String from = "from@shogun2.de";
 		String[] to = {"to@shogun2.de"};
@@ -174,7 +174,7 @@ public class MailPublisherTest {
 	 * @throws MessagingException
 	 */
 	@Test
-	public void sendMail_bcc() throws MessagingException {
+	public void sendMail_bcc() throws Exception, MessagingException {
 
 		String from = "from@shogun2.de";
 		String[] to = {};
@@ -207,7 +207,7 @@ public class MailPublisherTest {
 	 *
 	 */
 	@Test
-	public void sendMail_template() throws MessagingException {
+	public void sendMail_template() throws Exception, MessagingException {
 
 		String to = "to@shogun2.de";
 
@@ -252,7 +252,7 @@ public class MailPublisherTest {
 	 *
 	 */
 	@Test
-	public void sendMimeMail_minimal_configuration() throws MessagingException {
+	public void sendMimeMail_minimal_configuration() throws Exception, MessagingException {
 
 		String from = "from@shogun2.de";
 		String[] to = {"to@shogun2.de"};
@@ -289,7 +289,7 @@ public class MailPublisherTest {
 	 * @throws MessagingException
 	 */
 	@Test
-	public void sendMimeMail_replyTo() throws MessagingException {
+	public void sendMimeMail_replyTo() throws Exception, MessagingException {
 
 		String from = "from@shogun2.de";
 		String[] to = {"to@shogun2.de"};
@@ -322,7 +322,7 @@ public class MailPublisherTest {
 	 * @throws MessagingException
 	 */
 	@Test
-	public void sendMimeMail_cc() throws MessagingException {
+	public void sendMimeMail_cc() throws Exception, MessagingException {
 
 		String from = "from@shogun2.de";
 		String[] to = {"to@shogun2.de"};
@@ -356,7 +356,7 @@ public class MailPublisherTest {
 	 * @throws MessagingException
 	 */
 	@Test
-	public void sendMimeMail_bcc() throws MessagingException {
+	public void sendMimeMail_bcc() throws Exception, MessagingException {
 
 		String from = "from@shogun2.de";
 		String[] to = {};
@@ -391,7 +391,7 @@ public class MailPublisherTest {
 	 * @throws MessagingException
 	 */
 	@Test
-	public void sendMimeMail_html() throws MessagingException {
+	public void sendMimeMail_html() throws Exception, MessagingException {
 
 		String from = "from@shogun2.de";
 		String[] to = {"to@shogun2.de"};
@@ -421,7 +421,7 @@ public class MailPublisherTest {
 	 * @throws IOException
 	 */
 	@Test
-	public void sendMimeMail_attachment() throws MessagingException, IOException {
+	public void sendMimeMail_attachment() throws Exception, MessagingException, IOException {
 
 		String from = "from@shogun2.de";
 		String[] to = {"to@shogun2.de"};

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/UserController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/UserController.java
@@ -1,0 +1,86 @@
+package de.terrestris.shogun2.web;
+
+import java.util.Map;
+
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import de.terrestris.shogun2.service.UserService;
+
+/**
+ *
+ * @author Daniel Koch
+ *
+ */
+@Controller
+@RequestMapping("/user")
+public class UserController extends AbstractWebController {
+
+	/**
+	 * The Logger
+	 */
+	private static final Logger LOG =
+			Logger.getLogger(UserController.class);
+
+	/**
+	 *
+	 */
+	@Autowired
+	private UserService userService;
+
+	/**
+	 *
+	 * @param email
+	 * @return
+	 */
+	@RequestMapping(value = "/resetPassword.action", method = RequestMethod.GET)
+	public @ResponseBody Map<String, Object> resetPassword(
+			@RequestParam(value = "email") String email) {
+
+		LOG.info("Requested to reset a password.");
+
+		try {
+			Boolean success = userService.resetPassword(email);
+			if (success) {
+				return this.getModelMapSuccess("Your password has been reset. "
+						+ "Please check your mails!");
+			} else {
+				return this.getModelMapError("Could not reset the password.");
+			}
+		} catch(Exception e) {
+			LOG.error("Could not reset the password: " + e.getMessage());
+			return this.getModelMapError(e.getMessage());
+		}
+	}
+
+	/**
+	 *
+	 * @param id
+	 * @param token
+	 * @return
+	 */
+	@RequestMapping(value = "/changePassword.action", method = RequestMethod.GET)
+	public @ResponseBody Map<String, Object> changePassword(
+			@RequestParam(value = "id") int id,
+			@RequestParam(value = "token") String token) {
+
+		LOG.info("Requested to change a password.");
+
+		try {
+			Boolean success = userService.changePassword(id, token);
+			if (success) {
+				return this.getModelMapSuccess("Your password has been changed!");
+			} else {
+				return this.getModelMapError("Could not change the password.");
+			}
+		} catch(Exception e) {
+			LOG.error("Could not change the password: " + e.getMessage());
+			return this.getModelMapError(e.getMessage());
+		}
+	}
+}

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/UserController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/UserController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import de.terrestris.shogun2.service.PasswordResetTokenService;
 import de.terrestris.shogun2.service.UserService;
 
 /**
@@ -37,6 +38,12 @@ public class UserController extends AbstractWebController {
 
 	/**
 	 *
+	 */
+	@Autowired
+	private PasswordResetTokenService passwordResetTokenService;
+
+	/**
+	 *
 	 * @param email
 	 * @return
 	 */
@@ -47,7 +54,8 @@ public class UserController extends AbstractWebController {
 		LOG.info("Requested to reset a password.");
 
 		try {
-			Boolean success = userService.resetPassword(request, email);
+			Boolean success = passwordResetTokenService
+					.sendResetPasswordMail(request, email);
 			if (success) {
 				return this.getModelMapSuccess("Your password has been reset. "
 						+ "Please check your mails!");
@@ -75,7 +83,8 @@ public class UserController extends AbstractWebController {
 		LOG.info("Requested to change a password.");
 
 		try {
-			Boolean success = userService.changePassword(password, id, token);
+			Boolean success = passwordResetTokenService
+					.changePassword(password, id, token);
 			if (success) {
 				return this.getModelMapSuccess("Your password has been changed!");
 			} else {

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/UserController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/UserController.java
@@ -2,6 +2,8 @@ package de.terrestris.shogun2.web;
 
 import java.util.Map;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -38,14 +40,14 @@ public class UserController extends AbstractWebController {
 	 * @param email
 	 * @return
 	 */
-	@RequestMapping(value = "/resetPassword.action", method = RequestMethod.GET)
-	public @ResponseBody Map<String, Object> resetPassword(
+	@RequestMapping(value = "/resetPassword.action", method = RequestMethod.POST)
+	public @ResponseBody Map<String, Object> resetPassword(HttpServletRequest request,
 			@RequestParam(value = "email") String email) {
 
 		LOG.info("Requested to reset a password.");
 
 		try {
-			Boolean success = userService.resetPassword(email);
+			Boolean success = userService.resetPassword(request, email);
 			if (success) {
 				return this.getModelMapSuccess("Your password has been reset. "
 						+ "Please check your mails!");
@@ -64,15 +66,16 @@ public class UserController extends AbstractWebController {
 	 * @param token
 	 * @return
 	 */
-	@RequestMapping(value = "/changePassword.action", method = RequestMethod.GET)
+	@RequestMapping(value = "/changePassword.action", method = RequestMethod.POST)
 	public @ResponseBody Map<String, Object> changePassword(
+			@RequestParam(value = "password") String password,
 			@RequestParam(value = "id") int id,
 			@RequestParam(value = "token") String token) {
 
 		LOG.info("Requested to change a password.");
 
 		try {
-			Boolean success = userService.changePassword(id, token);
+			Boolean success = userService.changePassword(password, id, token);
 			if (success) {
 				return this.getModelMapSuccess("Your password has been changed!");
 			} else {

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/__artifactId__.properties
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/__artifactId__.properties
@@ -44,22 +44,22 @@ Note: This email has been automatically generated. Please \n      \
       receive a response.
 
 ${symbol_pound} The mail template being used if the user has requested a new password
-+mail.resetPasswordMailMessageTemplateSubject=[${artifactId}] Please reset your password
-+mail.resetPasswordMailMessageTemplateText=\
-+Dear %s %s,\n\
-+\n\
-+You have requested to have your password reset for your account at ${artifactId}.com.\n\
-+\n\
-+Use the following link within the next 48 hours to reset your password:\n\
-+\n\
-+%s \n\
-+\n\
-+If you have received this email in error, you can safely ignore this email.\n\
-+\n\
-+Yours,\n\
-+The ${artifactId} Team\n\
-+\n\
-+Note: This email has been automatically generated. Please \n      \
-+      do not reply to this email address as all responses \n      \
-+      are directed to an unattended mailbox and will not \n      \
-+      receive a response.
+mail.resetPasswordMailMessageTemplateSubject=[${artifactId}] Please reset your password
+mail.resetPasswordMailMessageTemplateText=\
+Dear %s %s,\n\
+\n\
+You have requested to have your password reset for your account at ${artifactId}.com.\n\
+\n\
+Use the following link within the next 48 hours to reset your password:\n\
+\n\
+%s \n\
+\n\
+If you have received this email in error, you can safely ignore this email.\n\
+\n\
+Yours,\n\
+The ${artifactId} Team\n\
+\n\
+Note: This email has been automatically generated. Please \n      \
+      do not reply to this email address as all responses \n      \
+      are directed to an unattended mailbox and will not \n      \
+      receive a response.

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/__artifactId__.properties
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/__artifactId__.properties
@@ -5,6 +5,9 @@ ${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${sym
 ${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound} Application Configuration ${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}
 ${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}
 
+${symbol_pound} The relative URL to your change-password client component
+login.changePasswordPath=/login/#passwordchange
+
 ${symbol_pound} The Mail Server
 mail.server.host=mail.${artifactId}.de
 mail.server.port=587
@@ -17,8 +20,8 @@ mail.server.password=
 ${symbol_pound} The default mail sender address
 mail.defaultSender=noreply@${artifactId}.de
 
-${symbol_pound} A mail template being used as confirmation mail after registration
-mail.registrationMailTemplateSubject=Activate your account on ${artifactId}.com
+${symbol_pound} The mail template being used as confirmation mail after registration
+mail.registrationMailTemplateSubject=[${artifactId}] Activate your account
 mail.registrationMailTemplateText=\
 Dear %s,\n\
 \n\
@@ -39,3 +42,24 @@ Note: This email has been automatically generated. Please \n      \
       do not reply to this email address as all responses \n      \
       are directed to an unattended mailbox and will not \n      \
       receive a response.
+
+${symbol_pound} The mail template being used if the user has requested a new password
++mail.resetPasswordMailMessageTemplateSubject=[${artifactId}] Please reset your password
++mail.resetPasswordMailMessageTemplateText=\
++Dear %s %s,\n\
++\n\
++You have requested to have your password reset for your account at ${artifactId}.com.\n\
++\n\
++Use the following link within the next 48 hours to reset your password:\n\
++\n\
++%s \n\
++\n\
++If you have received this email in error, you can safely ignore this email.\n\
++\n\
++Yours,\n\
++The ${artifactId} Team\n\
++\n\
++Note: This email has been automatically generated. Please \n      \
++      do not reply to this email address as all responses \n      \
++      are directed to an unattended mailbox and will not \n      \
++      receive a response.

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-security.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-security.xml
@@ -25,6 +25,11 @@
              GET requests CSRF has to be disabled -->
         <csrf disabled="false"/>
 
+        <!-- URL security -->
+        <intercept-url pattern="/login/**" access="permitAll" />
+        <intercept-url pattern="/user/register.action" access="permitAll" />
+        <intercept-url pattern="/user/resetPassword.action" access="permitAll" />
+        <intercept-url pattern="/user/changePassword.action" access="permitAll" />
         <intercept-url pattern="/**" access="hasRole('ROLE_USER')" />
 
     </http>

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context.xml
@@ -57,11 +57,23 @@
         <constructor-arg value="${mail.defaultSender}"></constructor-arg>
     </bean>
 
-    <!-- A simple mail message template -->
+    <!-- The registration-success mail message template -->
     <bean id="registrationMailMessageTemplate" class="org.springframework.mail.SimpleMailMessage">
         <property name="from" value="${mail.defaultSender}" />
         <property name="subject" value="${mail.registrationMailTemplateSubject}" />
         <property name="text" value="${mail.registrationMailTemplateText}" />
+    </bean>
+
+    <!-- The reset-password mail message template -->
+    <bean id="resetPasswordMailMessageTemplate" class="org.springframework.mail.SimpleMailMessage">
+        <property name="from" value="${mail.defaultSender}" />
+        <property name="subject" value="${mail.resetPasswordMailMessageTemplateSubject}" />
+        <property name="text" value="${mail.resetPasswordMailMessageTemplateText}" />
+    </bean>
+
+    <!-- The (relative) URL to your change password client component -->
+    <bean id="changePasswordPath" class="java.lang.String">
+        <constructor-arg value="${login.changePasswordPath}"></constructor-arg>
     </bean>
 
 </beans>


### PR DESCRIPTION
The logic presented in this PR allows any registered SHOGun2-User to reset their password manually.

This is done by the following workflow:

* A user requests a password-reset by sending their account-email to the interface `resetPassword.action`, e.g.

   `http://localhost:8080/shogun2/user/resetPassword.action?email=user@shogun2.de`

* If the mail really exists, a new `PasswordResetToken` containing a unique token, expire date and user reference is being generated and persisted.

* A special link for updating the password including this token and id will be send to the user, e.g.:

  `http://localhost:8080/shogun2/login/#passwordchange?id={{token-id}}&token={{token}}`

* The user will be redirected to a (client-)page to update their password if they follow the link.

* The client sends a request to the `changePassword.action` with the provided token, token-id and password, e.g.:

   `http://localhost:8080/shogun2/user/changePassword.action?password={{newPassword}}&id={{tokenId}}&token={{token}}`

* If the token is valid (token exists and is not expired) the user will be authorized to change their password and the token will be deleted.