### PR TITLE
Enable user registration

### DIFF
--- a/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/RegistrationTokenDao.java
+++ b/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/RegistrationTokenDao.java
@@ -1,0 +1,14 @@
+package de.terrestris.shogun2.dao;
+
+import org.springframework.stereotype.Repository;
+
+import de.terrestris.shogun2.model.token.RegistrationToken;
+
+@Repository
+public class RegistrationTokenDao extends GenericHibernateDao<RegistrationToken, Integer> {
+
+	protected RegistrationTokenDao() {
+		super(RegistrationToken.class);
+	}
+
+}

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/token/RegistrationToken.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/token/RegistrationToken.java
@@ -11,7 +11,7 @@ import de.terrestris.shogun2.model.User;
 /**
  *
  * A {@link Token} instance that has a one-to-one relation to a {@link User}
- * that wants to reset the password.
+ * that wants to register.
  *
  * @author Daniel Koch
  * @author Nils Bühner
@@ -19,7 +19,7 @@ import de.terrestris.shogun2.model.User;
  */
 @Entity
 @Table
-public class PasswordResetToken extends UserToken {
+public class RegistrationToken extends UserToken {
 
 	/**
 	 *
@@ -29,20 +29,20 @@ public class PasswordResetToken extends UserToken {
 	/**
 	 * Default constructor
 	 */
-	public PasswordResetToken() {
+	public RegistrationToken() {
 	}
 
 	/**
 	 * Constructor that uses the default expiration time.
 	 */
-	public PasswordResetToken(User user) {
+	public RegistrationToken(User user) {
 		super(user);
 	}
 
 	/**
 	 * Constructor that uses the passed values
 	 */
-	public PasswordResetToken(User user, int expirationInMinutes) {
+	public RegistrationToken(User user, int expirationInMinutes) {
 		super(user, expirationInMinutes);
 	}
 

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/token/UserToken.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/token/UserToken.java
@@ -1,0 +1,126 @@
+package de.terrestris.shogun2.model.token;
+
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import de.terrestris.shogun2.model.User;
+
+/**
+ *
+ * A {@link UserToken} instance that has a one-to-one relation to a {@link User}
+ * .
+ *
+ * @author Daniel Koch
+ * @author Nils Bühner
+ *
+ */
+@Entity
+public abstract class UserToken extends Token {
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * The default expiration in minutes
+	 */
+	private static final int DEFAULT_EXPIRATION_MINUTES = 60;
+
+	/**
+	 * The user who has requested the token. Hereby one user can have one
+	 * token and one token can be used by one user (at the same time) only.
+	 */
+	@OneToOne
+	@JoinColumn(name = "USER_ID")
+	private final User user;
+
+	/**
+	 * Default constructor
+	 */
+	protected UserToken() {
+		this(null);
+	}
+
+	/**
+	 * Constructor. Uses the {@link #DEFAULT_EXPIRATION_MINUTES} value.
+	 *
+	 * @param The user.
+	 */
+	protected UserToken(User user) {
+		this(user, DEFAULT_EXPIRATION_MINUTES);
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param user The user
+	 * @param expirationInMinutes The expiration period in minutes
+	 */
+	protected UserToken(User user, int expirationInMinutes) {
+		// call super constructor
+		super(expirationInMinutes);
+
+		// set the user
+		this.user = user;
+	}
+
+	/**
+	 * @return the user
+	 */
+	public User getUser() {
+		return user;
+	}
+
+	/**
+	 * @see java.lang.Object#hashCode()
+	 *
+	 *      According to
+	 *      http://stackoverflow.com/questions/27581/overriding-equals
+	 *      -and-hashcode-in-java it is recommended only to use getter-methods
+	 *      when using ORM like Hibernate
+	 */
+	@Override
+	public int hashCode() {
+		// two randomly chosen prime numbers
+		return new HashCodeBuilder(17, 37).
+				appendSuper(super.hashCode()).
+				append(getUser()).
+				toHashCode();
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 *
+	 *      According to
+	 *      http://stackoverflow.com/questions/27581/overriding-equals
+	 *      -and-hashcode-in-java it is recommended only to use getter-methods
+	 *      when using ORM like Hibernate
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof UserToken))
+			return false;
+		UserToken other = (UserToken) obj;
+
+		return new EqualsBuilder().
+				appendSuper(super.equals(other)).
+				append(getUser(), other.getUser()).
+				isEquals();
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
+	}
+
+}

--- a/src/shogun2-core/shogun2-service/pom.xml
+++ b/src/shogun2-core/shogun2-service/pom.xml
@@ -32,10 +32,15 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Spring Security -->
+        <!-- Spring -->
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
         </dependency>
 
         <!-- JUnit -->

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/AbstractUserTokenService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/AbstractUserTokenService.java
@@ -65,16 +65,17 @@ public abstract class AbstractUserTokenService<E extends UserToken> extends Abst
 	}
 
 	/**
-	 * If the passed token is null or expired, this method will throw an
-	 * {@link Exception}.
+	 * If the passed token is null or expired or if there is no user associated
+	 * with the token, this method will throw an {@link Exception}.
 	 *
 	 * @param userToken
-	 * @throws Exception if the token is not valid (e.g. because it is expired)
+	 * @throws Exception
+	 *             if the token is not valid (e.g. because it is expired)
 	 */
 	protected void validateToken(UserToken userToken) throws Exception {
 
 		if (userToken == null) {
-			throw new Exception("The provided does not exist.");
+			throw new Exception("The provided token does not exist.");
 		}
 
 		DateTime expirationDate = (DateTime) userToken
@@ -86,6 +87,11 @@ public abstract class AbstractUserTokenService<E extends UserToken> extends Abst
 		if (expirationDate.isBeforeNow()) {
 			throw new Exception("The token '" + tokenValue + "' expired on '"
 					+ expirationDate + "'");
+		}
+
+		// check if user is associated
+		if (userToken.getUser() == null) {
+			throw new Exception("There is no user associated with this token.");
 		}
 
 	}

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/AbstractUserTokenService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/AbstractUserTokenService.java
@@ -1,0 +1,172 @@
+package de.terrestris.shogun2.service;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.ParameterizedType;
+
+import org.apache.log4j.Logger;
+import org.hibernate.criterion.Criterion;
+import org.hibernate.criterion.Restrictions;
+import org.hibernate.criterion.SimpleExpression;
+import org.joda.time.DateTime;
+
+import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.token.PasswordResetToken;
+import de.terrestris.shogun2.model.token.UserToken;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author Nils Bühner
+ *
+ */
+public abstract class AbstractUserTokenService<E extends UserToken> extends AbstractCrudService<E> {
+
+	/**
+	 * The Logger
+	 */
+	private static final Logger LOG =
+			Logger.getLogger(AbstractUserTokenService.class);
+
+	/**
+	 * An expiry threshold in minutes for the creation of a new
+	 * {@link PasswordResetToken}. I.e. if a token is requested for a
+	 * {@link User} and an there is an existing token that expires within the
+	 * minutes configured in this constant, the existing token will be deleted
+	 * and a new one will be created.
+	 */
+	private static final int EXPIRY_THRESHOLD_MINUTES = 5;
+
+	/**
+	 *
+	 * @param user
+	 * @return
+	 */
+	public E findByUser(User user) {
+
+		SimpleExpression eqUser = Restrictions.eq("user", user);
+
+		E userToken = dao.findByUniqueCriteria(eqUser);
+
+		return userToken;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public E findByTokenValue(String token) {
+
+		Criterion criteria = Restrictions.eq("token", token);
+
+		E userToken = dao.findByUniqueCriteria(criteria);
+
+		return userToken;
+	}
+
+	/**
+	 * If the passed token is null or expired, this method will throw an
+	 * {@link Exception}.
+	 *
+	 * @param userToken
+	 * @throws Exception if the token is not valid (e.g. because it is expired)
+	 */
+	protected void validateToken(UserToken userToken) throws Exception {
+
+		if (userToken == null) {
+			throw new Exception("The provided does not exist.");
+		}
+
+		DateTime expirationDate = (DateTime) userToken
+				.getExpirationDate();
+
+		String tokenValue = userToken.getToken();
+
+		// check if the token expire date is valid
+		if (expirationDate.isBeforeNow()) {
+			throw new Exception("The token '" + tokenValue + "' expired on '"
+					+ expirationDate + "'");
+		}
+
+	}
+
+	/**
+	 * Returns a valid (i.e. non-expired) {@link UserToken} for the
+	 * given user. If the user already owns a valid token, it will be returned.
+	 * If the user has an invalid/expired token, it will be deleted and a new
+	 * one will be generated and returned by this method.
+	 *
+	 * @param user
+	 *            The user that needs a token.
+	 * @return A valid user token.
+	 * @throws SecurityException
+	 * @throws NoSuchMethodException
+	 * @throws InvocationTargetException
+	 * @throws IllegalArgumentException
+	 * @throws IllegalAccessException
+	 * @throws InstantiationException
+	 */
+	protected E getValidTokenForUser(User user) throws NoSuchMethodException,
+			SecurityException, InstantiationException, IllegalAccessException,
+			IllegalArgumentException, InvocationTargetException {
+
+		// check if the user has an open reset request / not used token
+		E userToken = findByUser(user);
+
+		// if there is already an existing token for the user...
+		if (userToken != null) {
+
+			if (userToken.expiresWithin(EXPIRY_THRESHOLD_MINUTES)) {
+				LOG.debug("User already has an expired token (or at least a "
+						+ "token that expires within the next "
+						+ EXPIRY_THRESHOLD_MINUTES + " minutes). This token "
+								+ "will be deleted.");
+
+				// delete the expired token
+				dao.delete(userToken);
+			} else {
+				LOG.debug("Returning existing token for user '"
+						+ user.getAccountName() + "'");
+				// return the existing and valid token
+				return userToken;
+			}
+
+		}
+
+		userToken = buildConcreteUserTokenInstance(user);
+
+		// persist the user token
+		dao.saveOrUpdate(userToken);
+
+		final String tokenType = userToken.getClass().getSimpleName();
+		LOG.debug("Successfully created a user token of type '" + tokenType
+				+ "' for user '" + user.getAccountName() + "'");
+
+		return userToken;
+	}
+
+	/**
+	 * Uses Java reflection to build a new instance of the correct concrete
+	 * {@link UserToken} (subclass) type.
+	 *
+	 * @param user
+	 * @return
+	 * @throws NoSuchMethodException
+	 * @throws InstantiationException
+	 * @throws IllegalAccessException
+	 * @throws InvocationTargetException
+	 */
+	@SuppressWarnings("unchecked")
+	private E buildConcreteUserTokenInstance(User user)
+			throws NoSuchMethodException, InstantiationException,
+			IllegalAccessException, InvocationTargetException {
+
+		Class<E> concreteUserTokenClass = (Class<E>) ((ParameterizedType) this
+				.getClass().getGenericSuperclass()).getActualTypeArguments()[0];
+
+		Constructor<E> c = concreteUserTokenClass.getConstructor(User.class);
+
+		return c.newInstance(user);
+	}
+
+}

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/PasswordResetTokenService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/PasswordResetTokenService.java
@@ -95,7 +95,7 @@ public class PasswordResetTokenService extends AbstractUserTokenService<Password
 		}
 
 		// generate and save the unique reset-password token for the user
-		PasswordResetToken resetPasswordToken = getValidTokenForUser(user);
+		PasswordResetToken resetPasswordToken = getValidTokenForUser(user, null);
 
 		// create the reset-password URI that will be send to the user
 		URI resetPasswordURI = createResetPasswordURI(request,

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/PasswordResetTokenService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/PasswordResetTokenService.java
@@ -159,7 +159,7 @@ public class PasswordResetTokenService extends AbstractCrudService<PasswordReset
 	 * @param token
 	 * @throws Exception
 	 */
-	public void changePassword(String rawPassword, String token) throws Exception {
+	public void validateTokenAndUpdatePassword(String rawPassword, String token) throws Exception {
 
 		// try to find the provided token
 		PasswordResetToken passwordResetToken = findByTokenValue(token);

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/PasswordResetTokenService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/PasswordResetTokenService.java
@@ -139,11 +139,6 @@ public class PasswordResetTokenService extends AbstractUserTokenService<Password
 		// get the user of the provided token
 		User user = passwordResetToken.getUser();
 
-		if (user == null) {
-			throw new Exception("Could not find the user for the "
-					+ "provided token.");
-		}
-
 		// finally update the password (encrypted)
 		userService.updatePassword(user, rawPassword);
 

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/RegistrationTokenService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/RegistrationTokenService.java
@@ -9,9 +9,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.log4j.Logger;
-import org.hibernate.criterion.Criterion;
-import org.hibernate.criterion.Restrictions;
-import org.hibernate.criterion.SimpleExpression;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.mail.SimpleMailMessage;
@@ -55,35 +52,6 @@ public class RegistrationTokenService extends AbstractUserTokenService<Registrat
 	@Autowired
 	@Qualifier("registrationMailMessageTemplate")
 	private SimpleMailMessage registrationMailMessageTemplate;
-
-	/**
-	 *
-	 * @param user
-	 * @return
-	 */
-	public RegistrationToken findByUser(User user) {
-
-		SimpleExpression eqUser = Restrictions.eq("user", user);
-
-		RegistrationToken registrationToken =
-				dao.findByUniqueCriteria(eqUser);
-
-		return registrationToken;
-	}
-
-	/**
-	 *
-	 * @return
-	 */
-	public RegistrationToken findByTokenValue(String token) {
-
-		Criterion criteria = Restrictions.eq("token", token);
-
-		RegistrationToken registrationToken =
-				dao.findByUniqueCriteria(criteria);
-
-		return registrationToken;
-	}
 
 	/**
 	 * @throws InvocationTargetException

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/RegistrationTokenService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/RegistrationTokenService.java
@@ -126,8 +126,6 @@ public class RegistrationTokenService extends AbstractUserTokenService<Registrat
 		// and send the mail
 		mailPublisher.sendMail(registrationActivationMsg);
 
-		LOG.debug("Sent activation mail to " + email);
-
 	}
 
 	/**
@@ -148,6 +146,8 @@ public class RegistrationTokenService extends AbstractUserTokenService<Registrat
 				.setPath(appURI.getPath() + REGISTER_ACTIVATION_URL)
 				.setParameter("token", registrationToken.getToken())
 				.build();
+
+		LOG.trace("Created the following URI for account activation: " + tokenURI);
 
 		return tokenURI;
 	}

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/RegistrationTokenService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/RegistrationTokenService.java
@@ -44,6 +44,12 @@ public class RegistrationTokenService extends AbstractUserTokenService<Registrat
 	private String accountActivationPath;
 
 	/**
+	 * The registration token expiration time in minutes
+	 */
+	@Value("${login.registrationTokenExpirationTime}")
+	private int registrationTokenExpirationTime;
+
+	/**
 	 *
 	 */
 	@Autowired
@@ -74,7 +80,7 @@ public class RegistrationTokenService extends AbstractUserTokenService<Registrat
 			URISyntaxException, UnsupportedEncodingException {
 
 		// generate and save the unique registration token for the user
-		RegistrationToken registrationToken = getValidTokenForUser(user);
+		RegistrationToken registrationToken = getValidTokenForUser(user, registrationTokenExpirationTime);
 
 		// create the reset-password URI that will be send to the user
 		URI resetPasswordURI = createRegistrationActivationURI(request,
@@ -146,6 +152,21 @@ public class RegistrationTokenService extends AbstractUserTokenService<Registrat
 	 */
 	public void setAccountActivationPath(String accountActivationPath) {
 		this.accountActivationPath = accountActivationPath;
+	}
+
+	/**
+	 * @return the registrationTokenExpirationTime
+	 */
+	public int getRegistrationTokenExpirationTime() {
+		return registrationTokenExpirationTime;
+	}
+
+	/**
+	 * @param registrationTokenExpirationTime the registrationTokenExpirationTime to set
+	 */
+	public void setRegistrationTokenExpirationTime(
+			int registrationTokenExpirationTime) {
+		this.registrationTokenExpirationTime = registrationTokenExpirationTime;
 	}
 
 	/**

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/RegistrationTokenService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/RegistrationTokenService.java
@@ -35,7 +35,7 @@ public class RegistrationTokenService extends AbstractUserTokenService<Registrat
 	/**
 	 * The relative URL for the SHOGun2 registration activation interface.
 	 */
-	private static final String REGISTER_ACTIVATION_URL = "/register/activate.action";
+	private static final String REGISTER_ACTIVATION_URL = "/user/activate.action";
 
 	/**
 	 * The Logger

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/RegistrationTokenService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/RegistrationTokenService.java
@@ -1,0 +1,185 @@
+package de.terrestris.shogun2.service;
+
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.log4j.Logger;
+import org.hibernate.criterion.Criterion;
+import org.hibernate.criterion.Restrictions;
+import org.hibernate.criterion.SimpleExpression;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriUtils;
+
+import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.token.RegistrationToken;
+import de.terrestris.shogun2.util.application.Shogun2ContextUtil;
+import de.terrestris.shogun2.util.mail.MailPublisher;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author Nils Bühner
+ *
+ */
+@Service("registrationTokenService")
+public class RegistrationTokenService extends AbstractUserTokenService<RegistrationToken> {
+
+	/**
+	 * The relative URL for the SHOGun2 finalize registration interface.
+	 */
+	private static final String REGISTER_FINALIZE_URL = "/register/finalize.action";
+
+	/**
+	 * The Logger
+	 */
+	private static final Logger LOG =
+			Logger.getLogger(RegistrationTokenService.class);
+
+	/**
+	 *
+	 */
+	@Autowired
+	private MailPublisher mailPublisher;
+
+	/**
+	 *
+	 */
+	@Autowired
+	@Qualifier("registrationMailMessageTemplate")
+	private SimpleMailMessage registrationMailMessageTemplate;
+
+	/**
+	 *
+	 * @param user
+	 * @return
+	 */
+	public RegistrationToken findByUser(User user) {
+
+		SimpleExpression eqUser = Restrictions.eq("user", user);
+
+		RegistrationToken registrationToken =
+				dao.findByUniqueCriteria(eqUser);
+
+		return registrationToken;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public RegistrationToken findByTokenValue(String token) {
+
+		Criterion criteria = Restrictions.eq("token", token);
+
+		RegistrationToken registrationToken =
+				dao.findByUniqueCriteria(criteria);
+
+		return registrationToken;
+	}
+
+	/**
+	 * @throws InvocationTargetException
+	 * @throws IllegalArgumentException
+	 * @throws IllegalAccessException
+	 * @throws InstantiationException
+	 * @throws SecurityException
+	 * @throws NoSuchMethodException
+	 * @throws URISyntaxException
+	 * @throws UnsupportedEncodingException
+	 *
+	 */
+	public void sendRegistrationActivationMail(HttpServletRequest request,
+			User user) throws NoSuchMethodException, SecurityException,
+			InstantiationException, IllegalAccessException,
+			IllegalArgumentException, InvocationTargetException,
+			URISyntaxException, UnsupportedEncodingException {
+
+		// generate and save the unique registration token for the user
+		RegistrationToken registrationToken = getValidTokenForUser(user);
+
+		// create the reset-password URI that will be send to the user
+		URI resetPasswordURI = createFinalizeRegistrationURI(request,
+				registrationToken);
+
+		// create a thread safe "copy" of the template message
+		SimpleMailMessage registrationActivationMsg = new SimpleMailMessage(
+				registrationMailMessageTemplate);
+
+		// prepare a personalized mail with the given token
+		final String email = user.getEmail();
+		registrationActivationMsg.setTo(email);
+		registrationActivationMsg.setText(
+				String.format(
+						registrationActivationMsg.getText(),
+						UriUtils.decode(resetPasswordURI.toString(), "UTF-8")
+				)
+		);
+
+		// and send the mail
+		mailPublisher.sendMail(registrationActivationMsg);
+
+		LOG.debug("Sent activation mail to " + email);
+
+	}
+
+	/**
+	 *
+	 * @param request
+	 * @param registrationToken
+	 * @return
+	 * @throws URISyntaxException
+	 */
+	private URI createFinalizeRegistrationURI(HttpServletRequest request,
+			RegistrationToken registrationToken) throws URISyntaxException {
+
+		// get the webapp URI
+		URI appURI = Shogun2ContextUtil.getApplicationURIFromRequest(request);
+
+		// build the registration activation link URI
+		URI tokenURI = new URIBuilder(appURI)
+				.setPath(appURI.getPath() + REGISTER_FINALIZE_URL)
+				.setParameter("token", registrationToken.getToken())
+				.build();
+
+		return tokenURI;
+	}
+
+	/**
+	 * @return the mailPublisher
+	 */
+	public MailPublisher getMailPublisher() {
+		return mailPublisher;
+	}
+
+	/**
+	 * @param mailPublisher the mailPublisher to set
+	 */
+	public void setMailPublisher(MailPublisher mailPublisher) {
+		this.mailPublisher = mailPublisher;
+	}
+
+	/**
+	 * @return the registrationMailMessageTemplate
+	 */
+	public SimpleMailMessage getRegistrationMailMessageTemplate() {
+		return registrationMailMessageTemplate;
+	}
+
+	/**
+	 * @param registrationMailMessageTemplate the registrationMailMessageTemplate to set
+	 */
+	public void setRegistrationMailMessageTemplate(
+			SimpleMailMessage registrationMailMessageTemplate) {
+		this.registrationMailMessageTemplate = registrationMailMessageTemplate;
+	}
+
+
+}

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/RegistrationTokenService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/RegistrationTokenService.java
@@ -33,9 +33,9 @@ import de.terrestris.shogun2.util.mail.MailPublisher;
 public class RegistrationTokenService extends AbstractUserTokenService<RegistrationToken> {
 
 	/**
-	 * The relative URL for the SHOGun2 finalize registration interface.
+	 * The relative URL for the SHOGun2 registration activation interface.
 	 */
-	private static final String REGISTER_FINALIZE_URL = "/register/finalize.action";
+	private static final String REGISTER_ACTIVATION_URL = "/register/activate.action";
 
 	/**
 	 * The Logger
@@ -106,7 +106,7 @@ public class RegistrationTokenService extends AbstractUserTokenService<Registrat
 		RegistrationToken registrationToken = getValidTokenForUser(user);
 
 		// create the reset-password URI that will be send to the user
-		URI resetPasswordURI = createFinalizeRegistrationURI(request,
+		URI resetPasswordURI = createRegistrationActivationURI(request,
 				registrationToken);
 
 		// create a thread safe "copy" of the template message
@@ -137,7 +137,7 @@ public class RegistrationTokenService extends AbstractUserTokenService<Registrat
 	 * @return
 	 * @throws URISyntaxException
 	 */
-	private URI createFinalizeRegistrationURI(HttpServletRequest request,
+	private URI createRegistrationActivationURI(HttpServletRequest request,
 			RegistrationToken registrationToken) throws URISyntaxException {
 
 		// get the webapp URI
@@ -145,7 +145,7 @@ public class RegistrationTokenService extends AbstractUserTokenService<Registrat
 
 		// build the registration activation link URI
 		URI tokenURI = new URIBuilder(appURI)
-				.setPath(appURI.getPath() + REGISTER_FINALIZE_URL)
+				.setPath(appURI.getPath() + REGISTER_ACTIVATION_URL)
 				.setParameter("token", registrationToken.getToken())
 				.build();
 

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserService.java
@@ -143,6 +143,9 @@ public class UserService extends AbstractExtDirectCrudService<User> {
 		// update the user
 		dao.saveOrUpdate(user);
 
+		// delete the token
+		registrationTokenService.deleteTokenAfterActivation(token);
+
 		LOG.info("The user '" + user.getAccountName()
 				+ "' has successfully been activated.");
 	}

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserService.java
@@ -69,7 +69,8 @@ public class UserService extends AbstractExtDirectCrudService<User> {
 	}
 
 	/**
-	 * Registers a new user
+	 * Registers a new user. Initially, the user will be inactive. An email with
+	 * an activation link will be sent to the user.
 	 *
 	 * @param email
 	 * @param rawPassword

--- a/src/shogun2-core/shogun2-service/src/test/java/de/terrestris/shogun2/service/UserServiceTest.java
+++ b/src/shogun2-core/shogun2-service/src/test/java/de/terrestris/shogun2/service/UserServiceTest.java
@@ -1,18 +1,52 @@
 package de.terrestris.shogun2.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import javax.servlet.http.HttpServletRequest;
+
+import org.hibernate.HibernateException;
 import org.hibernate.criterion.SimpleExpression;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import de.terrestris.shogun2.model.User;
 
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = { "classpath*:META-INF/spring/test-encoder-bean.xml" })
 public class UserServiceTest extends AbstractExtDirectCrudServiceTest<User> {
+
+	@Mock
+	private RegistrationTokenService registrationTokenService;
+
+	/**
+	 * The autowired PasswordEncoder
+	 */
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+
+	@Before
+	public void setUp() {
+		super.setUp();
+
+		// set the pw encoder
+		((UserService) crudService).setPasswordEncoder(passwordEncoder);
+	}
 
 	/**
 	 *
@@ -64,6 +98,20 @@ public class UserServiceTest extends AbstractExtDirectCrudServiceTest<User> {
 		assertEquals(expectedUser, actualUser);
 	}
 
+	@Test(expected=HibernateException.class)
+	public void findByAccountName_shouldThrowHibernateException() {
+		String accountName = "erroraccount";
+
+		// mock the dao
+		doThrow(new HibernateException("errormsg"))
+			.when(dao).findByUniqueCriteria(any(SimpleExpression.class));
+
+		((UserService) crudService).findByAccountName(accountName);
+
+		verify(dao, times(1)).findByUniqueCriteria(any(SimpleExpression.class));
+		verifyNoMoreInteractions(dao);
+	}
+
 	@Test
 	public void findByEmail_shouldFindAsExpected() {
 		String eMail = "mail@example.com";
@@ -97,6 +145,84 @@ public class UserServiceTest extends AbstractExtDirectCrudServiceTest<User> {
 		verifyNoMoreInteractions(dao);
 
 		assertEquals(expectedUser, actualUser);
+	}
+
+	@Test(expected=HibernateException.class)
+	public void findByEmail_shouldThrowHibernateException() {
+		String email = "errormail@example.com";
+
+		// mock the dao
+		doThrow(new HibernateException("errormsg"))
+			.when(dao).findByUniqueCriteria(any(SimpleExpression.class));
+
+		((UserService) crudService).findByEmail(email);
+
+		verify(dao, times(1)).findByUniqueCriteria(any(SimpleExpression.class));
+		verifyNoMoreInteractions(dao);
+	}
+
+	@Test
+	public void registerUser_shouldRegisterNonExistingUserAsExpected() throws Exception {
+		String email = "test@example.com";
+		String rawPassword = "p@sSw0rd";
+		boolean isActive = false;
+
+		// mock the dao
+		// there is no existing user -> return null (in the findByEmail method)
+		when(dao.findByUniqueCriteria(any(SimpleExpression.class))).thenReturn(null);
+
+		// the saveOrUpdate will be called in the persistNewUser method
+		doNothing().when(dao).saveOrUpdate(any(User.class));
+
+		// mock the registrationTokenService (which sends the mail)
+		doNothing().when(registrationTokenService)
+				.sendRegistrationActivationMail(
+						any(HttpServletRequest.class),
+						any(User.class));
+
+		HttpServletRequest requestMock = mock(HttpServletRequest.class);
+
+		// finally call the method that is tested here
+		User registeredUser = ((UserService) crudService).registerUser(email, rawPassword, isActive, requestMock);
+
+		verify(dao, times(1)).findByUniqueCriteria(any(SimpleExpression.class));
+		verify(dao, times(1)).saveOrUpdate(any(User.class));
+		verifyNoMoreInteractions(dao);
+
+		verify(registrationTokenService, times(1))
+				.sendRegistrationActivationMail(
+						any(HttpServletRequest.class),
+						any(User.class));
+		verifyNoMoreInteractions(registrationTokenService);
+
+		assertTrue(passwordEncoder.matches(rawPassword, registeredUser.getPassword()));
+		assertEquals(email, registeredUser.getAccountName());
+		assertEquals(email, registeredUser.getEmail());
+		assertEquals(isActive, registeredUser.isActive());
+	}
+
+	@Test
+	public void registerUser_shouldThrowExceptionIfUserAlreadyExists() {
+		String email = "test@example.com";
+		String rawPassword = "p@sSw0rd";
+		boolean isActive = false;
+
+		User existingUser = new User();
+		existingUser.setEmail(email);
+
+		// there is an existing user -> return null (in the findByEmail method)
+		when(dao.findByUniqueCriteria(any(SimpleExpression.class))).thenReturn(existingUser);
+
+		HttpServletRequest requestMock = mock(HttpServletRequest.class);
+		// finally call the method that is tested here
+		try {
+			((UserService) crudService).registerUser(email, rawPassword, isActive, requestMock);
+			fail("Should have thrown Exception, but did not!");
+		} catch (Exception e) {
+			final String msg = e.getMessage();
+			assertEquals("User with eMail '" + email + "' already exists.", msg);
+		}
+
 	}
 
 }

--- a/src/shogun2-core/shogun2-service/src/test/resources/META-INF/spring/test-encoder-bean.xml
+++ b/src/shogun2-core/shogun2-service/src/test/resources/META-INF/spring/test-encoder-bean.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+                        http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <!-- bcrypt password encoder -->
+    <bean id="bcryptEncoder" class="org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder">
+        <!-- Configure the strength (log rounds). Default = 10 -->
+        <constructor-arg value="10"/>
+    </bean>
+
+</beans>

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/mail/MailPublisher.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/mail/MailPublisher.java
@@ -5,6 +5,7 @@ import java.io.File;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -148,20 +149,25 @@ public class MailPublisher {
 	 * @throws Exception 
 	 */
 	public void sendMail(SimpleMailMessage mailMessage) throws MailException {
-		LOG.debug("Requested to send a mail");
+		final String subject = mailMessage.getSubject();
+		final String to = StringUtils.join(mailMessage.getTo(), ", ");
+
+		LOG.debug("Sending a mail with subject '" + subject + "' to '" + to + "'");
 		mailSender.send(mailMessage);
-		LOG.debug("Successfully send mail.");
+		LOG.debug("Successfully sent mail to '" + to + "'");
 	}
 
 	/**
 	 *
 	 * @param mimeMessage
+	 * @throws MessagingException 
 	 * @throws Exception 
 	 */
-	public void sendMail(MimeMessage mimeMessage) throws MailException {
-		LOG.debug("Requested to send a mail");
+	public void sendMail(MimeMessage mimeMessage) throws MailException, MessagingException {
+		final String subject = mimeMessage.getSubject();
+		LOG.debug("Sending a mail (mime) with subject '" + subject + "'");
 		mailSender.send(mimeMessage);
-		LOG.debug("Successfully send mail.");
+		LOG.debug("Successfully sent mail (mime)");
 	}
 
 	/**

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/UserController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/UserController.java
@@ -12,7 +12,9 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.service.PasswordResetTokenService;
+import de.terrestris.shogun2.service.UserService;
 
 /**
  *
@@ -33,7 +35,35 @@ public class UserController extends AbstractWebController {
 	 *
 	 */
 	@Autowired
+	private UserService userService;
+
+	/**
+	 *
+	 */
+	@Autowired
 	private PasswordResetTokenService passwordResetTokenService;
+
+	/**
+	 *
+	 * @param email
+	 * @param password
+	 * @return
+	 */
+	@RequestMapping(value = "/register.action", method = RequestMethod.POST)
+	public @ResponseBody Map<String, Object> registerUser(HttpServletRequest request,
+			@RequestParam String email,
+			@RequestParam String password) {
+
+		try {
+			User user = userService.registerUser(email, password, false, request);
+			return this.getModelMapSuccess("You have been registered. "
+					+ "Please check your mails (" + user.getEmail()
+					+ ") for further instructions.");
+		} catch(Exception e) {
+			LOG.error("Could not register a new user: " + e.getMessage());
+			return this.getModelMapError("Could not register a new user.");
+		}
+	}
 
 	/**
 	 *
@@ -44,7 +74,7 @@ public class UserController extends AbstractWebController {
 	public @ResponseBody Map<String, Object> resetPassword(HttpServletRequest request,
 			@RequestParam(value = "email") String email) {
 
-		LOG.debug("Requested to reset a password for " + email);
+		LOG.debug("Requested to reset the password for '" + email + "'");
 
 		try {
 			passwordResetTokenService.sendResetPasswordMail(request, email);

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/UserController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/UserController.java
@@ -67,6 +67,23 @@ public class UserController extends AbstractWebController {
 
 	/**
 	 *
+	 * @param token
+	 * @return
+	 */
+	@RequestMapping(value = "/activate.action", method = RequestMethod.GET)
+	public @ResponseBody Map<String, Object> activateUser(@RequestParam String token) {
+
+		try {
+			userService.activateUser(token);
+			return this.getModelMapSuccess("Your account has successfully been activated.");
+		} catch(Exception e) {
+			LOG.error("Account could not be activated: " + e.getMessage());
+			return this.getModelMapError("Account could not be activated.");
+		}
+	}
+
+	/**
+	 *
 	 * @param email
 	 * @return
 	 */

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/UserController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/UserController.java
@@ -70,7 +70,7 @@ public class UserController extends AbstractWebController {
 		LOG.debug("Requested to change a password for token " + token);
 
 		try {
-			passwordResetTokenService.changePassword(password, token);
+			passwordResetTokenService.validateTokenAndUpdatePassword(password, token);
 			return this.getModelMapSuccess("Your password was changed successfully.");
 
 		} catch (Exception e) {

--- a/src/shogun2-web/src/test/java/de/terrestris/shogun2/web/UserControllerTest.java
+++ b/src/shogun2-web/src/test/java/de/terrestris/shogun2/web/UserControllerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -19,18 +20,27 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.service.PasswordResetTokenService;
+import de.terrestris.shogun2.service.UserService;
 
 /**
  * @author Nils Bühner
  *
  */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = { "classpath*:META-INF/spring/test-encoder-bean.xml" })
 public class UserControllerTest {
 
 	private MockMvc mockMvc;
@@ -38,8 +48,14 @@ public class UserControllerTest {
 	@Mock
 	private PasswordResetTokenService tokenService;
 
+	@Mock
+	private UserService userService;
+
 	@InjectMocks
 	private UserController UserController;
+
+	@Autowired
+	private PasswordEncoder passwordEncoder;
 
 	@Before
 	public void setUp() {
@@ -49,6 +65,70 @@ public class UserControllerTest {
 
 		// Setup Spring test in standalone mode
 		this.mockMvc = MockMvcBuilders.standaloneSetup(UserController).build();
+	}
+
+	@Test
+	public void registerUser_shouldWorkAsExpected() throws Exception {
+
+		String email = "test@example.com";
+		String rawPassword = "p@sSw0rd";
+		boolean isActive = false;
+
+		User user = new User();
+		user.setEmail(email);
+		user.setAccountName(email);
+		user.setPassword(passwordEncoder.encode(rawPassword));
+		user.setActive(isActive);
+
+		// mock service
+		when(userService.registerUser(
+				eq(email), eq(rawPassword), eq(isActive), any(HttpServletRequest.class)))
+			.thenReturn(user);
+
+
+		// Perform and test the POST-Request
+		mockMvc.perform(post("/user/register.action")
+				.param("email", email)
+				.param("password", rawPassword))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType("application/json;charset=UTF-8"))
+			.andExpect(jsonPath("$.*", hasSize(3)))
+			.andExpect(jsonPath("$.success", is(true)))
+			.andExpect(jsonPath("$.total", is(1)))
+			.andExpect(jsonPath("$.data", containsString("You have been registered.")))
+			.andExpect(jsonPath("$.data", containsString(email)));
+
+		verify(userService, times(1)).registerUser(
+				eq(email), eq(rawPassword), eq(isActive), any(HttpServletRequest.class));
+		verifyNoMoreInteractions(userService);
+	}
+
+	@Test
+	public void registerUser_shouldCatchExceptions() throws Exception {
+
+		String email = "test@example.com";
+		String rawPassword = "p@sSw0rd";
+		boolean isActive = false;
+
+		// mock service
+		doThrow(new Exception("errormsg"))
+			.when(userService).registerUser(
+				eq(email), eq(rawPassword), eq(isActive), any(HttpServletRequest.class));
+
+
+		// Perform and test the POST-Request
+		mockMvc.perform(post("/user/register.action")
+				.param("email", email)
+				.param("password", rawPassword))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType("application/json;charset=UTF-8"))
+			.andExpect(jsonPath("$.*", hasSize(2)))
+			.andExpect(jsonPath("$.success", is(false)))
+			.andExpect(jsonPath("$.message", is("Could not register a new user.")));
+
+		verify(userService, times(1)).registerUser(
+				eq(email), eq(rawPassword), eq(isActive), any(HttpServletRequest.class));
+		verifyNoMoreInteractions(userService);
 	}
 
 	@Test

--- a/src/shogun2-web/src/test/java/de/terrestris/shogun2/web/UserControllerTest.java
+++ b/src/shogun2-web/src/test/java/de/terrestris/shogun2/web/UserControllerTest.java
@@ -109,7 +109,7 @@ public class UserControllerTest {
 		String token = "token";
 
 		// mock service
-		doNothing().when(tokenService).changePassword(password, token);
+		doNothing().when(tokenService).validateTokenAndUpdatePassword(password, token);
 
 		// Perform and test the POST-Request
 		mockMvc.perform(post("/user/changePassword.action")
@@ -122,7 +122,7 @@ public class UserControllerTest {
 			.andExpect(jsonPath("$.total", is(1)))
 			.andExpect(jsonPath("$.data", is("Your password was changed successfully.")));
 
-		verify(tokenService, times(1)).changePassword(password, token);
+		verify(tokenService, times(1)).validateTokenAndUpdatePassword(password, token);
 		verifyNoMoreInteractions(tokenService);
 	}
 
@@ -133,7 +133,7 @@ public class UserControllerTest {
 		String token = "token";
 
 		// mock service
-		doThrow(new RuntimeException("errormsg")).when(tokenService).changePassword(password, token);
+		doThrow(new RuntimeException("errormsg")).when(tokenService).validateTokenAndUpdatePassword(password, token);
 
 		// Perform and test the POST-Request
 		mockMvc.perform(post("/user/changePassword.action")
@@ -145,7 +145,7 @@ public class UserControllerTest {
 			.andExpect(jsonPath("$.success", is(false)))
 			.andExpect(jsonPath("$.message", containsString("Could not change the password.")));
 
-		verify(tokenService, times(1)).changePassword(password, token);
+		verify(tokenService, times(1)).validateTokenAndUpdatePassword(password, token);
 		verifyNoMoreInteractions(tokenService);
 	}
 }

--- a/src/shogun2-web/src/test/resources/META-INF/spring/test-encoder-bean.xml
+++ b/src/shogun2-web/src/test/resources/META-INF/spring/test-encoder-bean.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+                        http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <!-- bcrypt password encoder -->
+    <bean id="bcryptEncoder" class="org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder">
+        <!-- Configure the strength (log rounds). Default = 10 -->
+        <constructor-arg value="10"/>
+    </bean>
+
+</beans>

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/__artifactId__.properties
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/__artifactId__.properties
@@ -7,7 +7,12 @@ ${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${sym
 
 ${symbol_pound} The relative URL to your change-password client component
 login.changePasswordPath=/login/${symbol_pound}passwordchange
+
+${symbol_pound} The relative URL for the user account activation link
 login.accountActivationPath=/user/activate.action
+
+${symbol_pound} Expiration time in minutes for a registration token. 10080 minutes = 1 week
+login.registrationTokenExpirationTime=10080
 
 ${symbol_pound} The Mail Server
 mail.server.host=mail.${artifactId}.de
@@ -51,7 +56,7 @@ Dear %s %s,${symbol_escape}n${symbol_escape}
 ${symbol_escape}n${symbol_escape}
 You have requested to have your password reset for your account at ${artifactId}.com.${symbol_escape}n${symbol_escape}
 ${symbol_escape}n${symbol_escape}
-Use the following link within the next 48 hours to reset your password:${symbol_escape}n${symbol_escape}
+Use the following link within the next 60 minutes to reset your password:${symbol_escape}n${symbol_escape}
 ${symbol_escape}n${symbol_escape}
 %s ${symbol_escape}n${symbol_escape}
 ${symbol_escape}n${symbol_escape}

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/__artifactId__.properties
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/__artifactId__.properties
@@ -23,7 +23,7 @@ mail.defaultSender=noreply@${artifactId}.de
 ${symbol_pound} The mail template being used as confirmation mail after registration
 mail.registrationMailTemplateSubject=[${artifactId}] Activate your account
 mail.registrationMailTemplateText=${symbol_escape}
-Dear %s,${symbol_escape}n${symbol_escape}
+Dear user,${symbol_escape}n${symbol_escape}
 ${symbol_escape}n${symbol_escape}
 Welcome to ${artifactId}!${symbol_escape}n${symbol_escape}
 ${symbol_escape}n${symbol_escape}

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/__artifactId__.properties
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/__artifactId__.properties
@@ -7,6 +7,7 @@ ${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${sym
 
 ${symbol_pound} The relative URL to your change-password client component
 login.changePasswordPath=/login/${symbol_pound}passwordchange
+login.accountActivationPath=/user/activate.action
 
 ${symbol_pound} The Mail Server
 mail.server.host=mail.${artifactId}.de

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-security.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-security.xml
@@ -28,6 +28,7 @@
         <!-- URL security -->
         <intercept-url pattern="/login/**" access="permitAll" />
         <intercept-url pattern="/user/register.action" access="permitAll" />
+        <intercept-url pattern="/user/activate.action" access="permitAll" />
         <intercept-url pattern="/user/resetPassword.action" access="permitAll" />
         <intercept-url pattern="/user/changePassword.action" access="permitAll" />
         <intercept-url pattern="/**" access="hasRole('ROLE_USER')" />

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-security.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-security.xml
@@ -27,6 +27,7 @@
 
         <!-- URL security -->
         <intercept-url pattern="/login/**" access="permitAll" />
+        <intercept-url pattern="/user/register.action" access="permitAll" />
         <intercept-url pattern="/user/resetPassword.action" access="permitAll" />
         <intercept-url pattern="/user/changePassword.action" access="permitAll" />
         <intercept-url pattern="/**" access="hasRole('ROLE_USER')" />


### PR DESCRIPTION
Enable user registration by introducing:

* a `RegistrationToken`
* a web interface `/user/register.action` that accepts an email address and a password
  * An email with an activation link will be send to the passed email address
* a web interface `/user/activate.action` that accepts a token value (the link will be send in the email from above)
  * The user will be activated and the default user role `ROLE_USER` is being assigned to the user. The user can login afterwards.

Also added some missing tests