### PR TITLE
Rename update User By Session Interface

### DIFF
--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserService.java
@@ -111,12 +111,17 @@ public class UserService extends AbstractExtDirectCrudService<User> {
 	 * @param request
 	 * @throws Exception
 	 */
-	public User getUserInfoBySession() {
+	public User getUserBySession() {
 
 		User loggedInUser = (User) SecurityContextHolder.getContext()
 				.getAuthentication().getPrincipal();
 
-		return loggedInUser;
+		// The SecurityContextHolder holds a static copy of the user from
+		// the moment he logged in. So we need to get the current instance from
+		// dao.
+		Integer id = loggedInUser.getId();
+
+		return dao.findById(id);
 	}
 
 	/**

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/UserController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/UserController.java
@@ -91,13 +91,13 @@ public class UserController extends AbstractWebController {
 	 *
 	 * @return
 	 */
-	@RequestMapping(value = "/getUserInfoBySession.action", method = RequestMethod.GET)
-	public @ResponseBody Map<String, Object> getUserInfoBySession() {
+	@RequestMapping(value = "/getUserBySession.action", method = RequestMethod.GET)
+	public @ResponseBody Map<String, Object> getUserBySession() {
 
-		LOG.debug("Requested to return information about a logged in user");
+		LOG.debug("Requested to return the logged in user");
 
 		try {
-			return this.getModelMapSuccess(userService.getUserInfoBySession());
+			return this.getModelMapSuccess(userService.getUserBySession());
 		} catch (Exception e) {
 			return this.getModelMapError("Could not obtain the user by "
 					+ "session: " + e.getMessage());


### PR DESCRIPTION
The SecurityContextHolder holds a static copy of the user from the moment he logged in. So we need to get the current instance from dao.