### PR TITLE
Embed the AWT 2D Points to x and y columns

### DIFF
--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/source/XyzLayerDataSource.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/source/XyzLayerDataSource.java
@@ -5,6 +5,10 @@ import java.awt.geom.Point2D.Double;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.JoinTable;
 import javax.persistence.OneToMany;
@@ -37,6 +41,11 @@ public class XyzLayerDataSource extends LayerDataSource {
 	 */
 	private static final long serialVersionUID = 1L;
 
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "x", column = @Column(name = "CENTER_X")),
+		@AttributeOverride(name = "y", column = @Column(name = "CENTER_Y"))
+	})
 	private Point2D.Double center;
 
 	@OneToOne

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/Extent.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/Extent.java
@@ -6,6 +6,10 @@ package de.terrestris.shogun2.model.layer.util;
 import java.awt.geom.Point2D;
 import java.awt.geom.Point2D.Double;
 
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 
@@ -39,7 +43,19 @@ public class Extent extends PersistentObject {
 	 *
 	 */
 	private static final long serialVersionUID = 1L;
+
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "x", column = @Column(name = "LOWERLEFT_X")),
+		@AttributeOverride(name = "y", column = @Column(name = "LOWERLEFT_Y"))
+	})
 	private Point2D.Double lowerLeft;
+
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "x", column = @Column(name = "UPPERRIGHT_X")),
+		@AttributeOverride(name = "y", column = @Column(name = "UPPERRIGHT_Y"))
+	})
 	private Point2D.Double upperRight;
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/WmsTileGrid.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/WmsTileGrid.java
@@ -7,6 +7,10 @@ import java.awt.geom.Point2D;
 import java.awt.geom.Point2D.Double;
 import java.util.List;
 
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
@@ -55,6 +59,11 @@ public class WmsTileGrid extends PersistentObject {
 	 * Tile coordinates increase left to right and upwards.
 	 * If not specified, extent or origins must be provided.
 	 */
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "x", column = @Column(name = "TILEGRIDORIGIN_X")),
+		@AttributeOverride(name = "y", column = @Column(name = "TILEGRIDORIGIN_Y"))
+	})
 	private Point2D.Double tileGridOrigin;
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/map/MapConfig.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/map/MapConfig.java
@@ -3,6 +3,10 @@ package de.terrestris.shogun2.model.map;
 import java.awt.geom.Point2D;
 import java.util.List;
 
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
@@ -52,6 +56,11 @@ public class MapConfig extends PersistentObject{
 	/**
 	 *
 	 */
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "x", column = @Column(name = "CENTER_X")),
+		@AttributeOverride(name = "y", column = @Column(name = "CENTER_Y"))
+	})
 	private Point2D.Double center;
 
 	/**


### PR DESCRIPTION
This will avoid that hibernate uses BLOB columns for the Java AWT 2D point data. By using the `@Embedded` annotation in combination with `@AttributeOverrides`, the `x` and `y` values will now be stored in different columns with a numeric type, which makes it easier to debug/develop or change data in the database.

Closes #94.