### PR TITLE
Add a BeanUtil to copy only non-null properties

### DIFF
--- a/src/shogun2-util/pom.xml
+++ b/src/shogun2-util/pom.xml
@@ -90,6 +90,12 @@
             <artifactId>httpclient</artifactId>
         </dependency>
 
+        <!-- BeanUtils -->
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/bean/NullAwareBeanUtilsBean.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/bean/NullAwareBeanUtilsBean.java
@@ -1,0 +1,23 @@
+package de.terrestris.shogun2.util.bean;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.apache.commons.beanutils.BeanUtilsBean;
+
+/**
+ * Credits go to http://stackoverflow.com/a/3521314
+ *
+ * @author Nils Bühner
+ *
+ */
+public class NullAwareBeanUtilsBean extends BeanUtilsBean {
+
+	@Override
+	public void copyProperty(Object dest, String name, Object value)
+			throws IllegalAccessException, InvocationTargetException {
+		if (value == null)
+			return;
+		super.copyProperty(dest, name, value);
+	}
+
+}


### PR DESCRIPTION
Based on http://stackoverflow.com/a/3521314, this new `NullAwareBeanUtilsBean` allows the use of `copyProperties()` to copy only those properties that are NOT null.