### PR TITLE
Added JSONProperty Annotation for better password handling

### DIFF
--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/User.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/User.java
@@ -18,6 +18,8 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import ch.rasc.extclassgenerator.Model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
 
 /**
  * @author Nils Bühner
@@ -38,7 +40,7 @@ public class User extends Person {
 	private String accountName;
 
 	@Column
-	@JsonIgnore
+	@JsonProperty(access = Access.WRITE_ONLY)
 	private String password;
 
 	@Column


### PR DESCRIPTION
The JSONProperty Annotation is now used for the users password in order to avoid sending the password from backend to frontend but allow the sending from frontend to backend (e.g. in registration process / login)