### PR TITLE
Use persisted role

### DIFF
--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/RoleService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/RoleService.java
@@ -1,0 +1,36 @@
+package de.terrestris.shogun2.service;
+
+import org.hibernate.criterion.Restrictions;
+import org.hibernate.criterion.SimpleExpression;
+import org.springframework.stereotype.Service;
+
+import de.terrestris.shogun2.model.Role;
+
+/**
+ * Service class for the {@link Role} model.
+ *
+ * @author Nils Bühner
+ * @see AbstractExtDirectCrudService
+ *
+ */
+@Service("roleService")
+public class RoleService extends AbstractExtDirectCrudService<Role> {
+
+	/**
+	 * Returns the role for the given (unique) role name.
+	 * If no role was found, null will be returned.
+	 *
+	 * @param roleName A unique role name.
+	 * @return The unique role for the role name or null.
+	 */
+	public Role findByRoleName(String roleName) {
+
+		SimpleExpression eqRoleName =
+			Restrictions.eq("name", roleName);
+
+		Role role = dao.findByUniqueCriteria(eqRoleName);
+
+		return role;
+	}
+
+}

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserService.java
@@ -37,6 +37,12 @@ public class UserService extends AbstractExtDirectCrudService<User> {
 	private RegistrationTokenService registrationTokenService;
 
 	/**
+	 * Role service
+	 */
+	@Autowired
+	private RoleService roleService;
+
+	/**
 	 * The autowired PasswordEncoder
 	 */
 	@Autowired
@@ -44,7 +50,9 @@ public class UserService extends AbstractExtDirectCrudService<User> {
 
 	/**
 	 * The default user role that is assigned to a user if he activates his
-	 * account.
+	 * account. ATTENTION: This autowired bean will NOT have an ID if the
+	 * system did not boot with hibernate/CREATE mode and SHOGun2-content
+	 * initialization!
 	 */
 	@Autowired
 	@Qualifier("userRole")
@@ -137,8 +145,13 @@ public class UserService extends AbstractExtDirectCrudService<User> {
 		User user = token.getUser();
 		user.setActive(true);
 
+		// get the persisted default user role
+		final String defaultRoleName = defaultUserRole.getName();
+		Role persistedDefaultUserRole = roleService
+				.findByRoleName(defaultRoleName);
+
 		// assign the default user role
-		user.getRoles().add(defaultUserRole);
+		user.getRoles().add(persistedDefaultUserRole);
 
 		// update the user
 		dao.saveOrUpdate(user);

--- a/src/shogun2-core/shogun2-service/src/test/java/de/terrestris/shogun2/service/RoleServiceTest.java
+++ b/src/shogun2-core/shogun2-service/src/test/java/de/terrestris/shogun2/service/RoleServiceTest.java
@@ -1,0 +1,83 @@
+package de.terrestris.shogun2.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.hibernate.HibernateException;
+import org.hibernate.criterion.SimpleExpression;
+import org.junit.Test;
+
+import de.terrestris.shogun2.model.Role;
+
+public class RoleServiceTest extends AbstractExtDirectCrudServiceTest<Role> {
+
+	/**
+	 *
+	 * @throws Exception
+	 */
+	public void setUpImplToTest() throws Exception {
+		implToTest = new Role();
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	protected AbstractExtDirectCrudService<Role> getCrudService() {
+		return new RoleService();
+	}
+
+	@Test
+	public void findByRoleName_shouldFindAsExpected() {
+		String roleName = "ROLE_TEST";
+
+		Role expectedRole = new Role(roleName);
+
+		// mock the dao
+		when(dao.findByUniqueCriteria(any(SimpleExpression.class))).thenReturn(expectedRole);
+
+		Role actualRole = ((RoleService) crudService).findByRoleName(roleName);
+
+		verify(dao, times(1)).findByUniqueCriteria(any(SimpleExpression.class));
+		verifyNoMoreInteractions(dao);
+
+		assertEquals(expectedRole, actualRole);
+	}
+
+	@Test
+	public void findByRoleName_shouldFindNothing() {
+		String roleName = "ROLE_THAT_NOT_EXISTS";
+
+		Role expectedRole = null;
+
+		// mock the dao
+		when(dao.findByUniqueCriteria(any(SimpleExpression.class))).thenReturn(expectedRole);
+
+		Role actualRole = ((RoleService) crudService).findByRoleName(roleName);
+
+		verify(dao, times(1)).findByUniqueCriteria(any(SimpleExpression.class));
+		verifyNoMoreInteractions(dao);
+
+		assertEquals(expectedRole, actualRole);
+	}
+
+	@Test(expected=HibernateException.class)
+	public void findByRoleName_shouldThrowHibernateException() {
+		String roleName = "ROLE_THAT_THROWS_EXCEPTION";
+
+		// mock the dao
+		doThrow(new HibernateException("errormsg"))
+			.when(dao).findByUniqueCriteria(any(SimpleExpression.class));
+
+		((RoleService) crudService).findByRoleName(roleName);
+
+		verify(dao, times(1)).findByUniqueCriteria(any(SimpleExpression.class));
+		verifyNoMoreInteractions(dao);
+	}
+
+}

--- a/src/shogun2-core/shogun2-service/src/test/java/de/terrestris/shogun2/service/UserServiceTest.java
+++ b/src/shogun2-core/shogun2-service/src/test/java/de/terrestris/shogun2/service/UserServiceTest.java
@@ -26,6 +26,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import de.terrestris.shogun2.model.Role;
 import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.model.token.RegistrationToken;
 import de.terrestris.shogun2.util.test.TestUtil;
@@ -36,6 +37,12 @@ public class UserServiceTest extends AbstractExtDirectCrudServiceTest<User> {
 
 	@Mock
 	private RegistrationTokenService registrationTokenService;
+
+	@Mock
+	private RoleService roleService;
+
+	@Mock
+	private Role defaultUserRole;
 
 	/**
 	 * The autowired PasswordEncoder
@@ -248,6 +255,11 @@ public class UserServiceTest extends AbstractExtDirectCrudServiceTest<User> {
 		doNothing().when(registrationTokenService).validateToken(token);
 		doNothing().when(registrationTokenService).deleteTokenAfterActivation(token);
 
+		//mock the role service
+		final String defaultUserRoleName = "ROLE_USER";
+		when(defaultUserRole.getName()).thenReturn(defaultUserRoleName);
+		when(roleService.findByRoleName(defaultUserRoleName)).thenReturn(defaultUserRole);
+
 		// mock the dao
 		doNothing().when(dao).saveOrUpdate(any(User.class));
 
@@ -268,6 +280,12 @@ public class UserServiceTest extends AbstractExtDirectCrudServiceTest<User> {
 		verify(registrationTokenService, times(1)).validateToken(token);
 		verify(registrationTokenService, times(1)).deleteTokenAfterActivation(token);
 		verifyNoMoreInteractions(registrationTokenService);
+
+		verify(defaultUserRole, times(1)).getName();
+		verifyNoMoreInteractions(defaultUserRole);
+
+		verify(roleService, times(1)).findByRoleName(defaultUserRoleName);
+		verifyNoMoreInteractions(roleService);
 
 		verify(dao, times(1)).saveOrUpdate(any(User.class));
 		verifyNoMoreInteractions(dao);


### PR DESCRIPTION
* Add a role service to access a persisted role by name (tests included)
* Adapt user service to use persisted role when activating an account: The previous code was only working if the system booted with hibernate/CREATE mode and SHOGun2 init content flag set to true. In other cases, the autowired defaultUserRole had no ID