### PR TITLE
Refactor user registration

### DIFF
--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserService.java
@@ -99,24 +99,18 @@ public class UserService extends AbstractExtDirectCrudService<User> {
 	 * @return
 	 * @throws Exception
 	 */
-	public User registerUser(String email, String rawPassword, boolean isActive,
-			HttpServletRequest request) throws Exception {
+	public User registerUser(User user, HttpServletRequest request) throws Exception {
+
+		String email = user.getEmail();
 
 		// check if a user with the email already exists
-		User user = this.findByEmail(email);
+		User existingUser = this.findByEmail(email);
 
-		if(user != null) {
+		if(existingUser != null) {
 			final String errorMessage = "User with eMail '" + email + "' already exists.";
 			LOG.info(errorMessage);
 			throw new Exception(errorMessage);
 		}
-
-		user = new User();
-
-		user.setEmail(email);
-		user.setAccountName(email);
-		user.setPassword(rawPassword);
-		user.setActive(isActive);
 
 		user = this.persistNewUser(user, true);
 

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserService.java
@@ -92,9 +92,7 @@ public class UserService extends AbstractExtDirectCrudService<User> {
 	 * Registers a new user. Initially, the user will be inactive. An email with
 	 * an activation link will be sent to the user.
 	 *
-	 * @param email
-	 * @param rawPassword
-	 * @param isActive
+	 * @param user A user with an UNencrypted password (!)
 	 * @param request
 	 * @return
 	 * @throws Exception

--- a/src/shogun2-core/shogun2-service/src/test/java/de/terrestris/shogun2/service/UserServiceTest.java
+++ b/src/shogun2-core/shogun2-service/src/test/java/de/terrestris/shogun2/service/UserServiceTest.java
@@ -193,8 +193,15 @@ public class UserServiceTest extends AbstractExtDirectCrudServiceTest<User> {
 
 		HttpServletRequest requestMock = mock(HttpServletRequest.class);
 
+		// create user instance
+		User user = new User();
+		user.setEmail(email);
+		user.setAccountName(email);
+		user.setPassword(rawPassword);
+		user.setActive(isActive);
+
 		// finally call the method that is tested here
-		User registeredUser = ((UserService) crudService).registerUser(email, rawPassword, isActive, requestMock);
+		User registeredUser = ((UserService) crudService).registerUser(user, requestMock);
 
 		verify(dao, times(1)).findByUniqueCriteria(any(SimpleExpression.class));
 		verify(dao, times(1)).saveOrUpdate(any(User.class));
@@ -227,7 +234,14 @@ public class UserServiceTest extends AbstractExtDirectCrudServiceTest<User> {
 		HttpServletRequest requestMock = mock(HttpServletRequest.class);
 		// finally call the method that is tested here
 		try {
-			((UserService) crudService).registerUser(email, rawPassword, isActive, requestMock);
+			// create user instance
+			User user = new User();
+			user.setEmail(email);
+			user.setAccountName(email);
+			user.setPassword(rawPassword);
+			user.setActive(isActive);
+
+			((UserService) crudService).registerUser(user, requestMock);
 			fail("Should have thrown Exception, but did not!");
 		} catch (Exception e) {
 			final String msg = e.getMessage();

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/UserController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/UserController.java
@@ -54,8 +54,18 @@ public class UserController extends AbstractWebController {
 			@RequestParam String email,
 			@RequestParam String password) {
 
+		// build the user object that will be passed to the service method
+		User user = new User();
+
+		user.setEmail(email);
+		user.setAccountName(email);
+		user.setPassword(password);
+		user.setActive(false);
+
 		try {
-			User user = userService.registerUser(email, password, false, request);
+
+			user = userService.registerUser(user, request);
+
 			return this.getModelMapSuccess("You have been registered. "
 					+ "Please check your mails (" + user.getEmail()
 					+ ") for further instructions.");

--- a/src/shogun2-web/src/test/java/de/terrestris/shogun2/web/UserControllerTest.java
+++ b/src/shogun2-web/src/test/java/de/terrestris/shogun2/web/UserControllerTest.java
@@ -74,16 +74,16 @@ public class UserControllerTest {
 		String rawPassword = "p@sSw0rd";
 		boolean isActive = false;
 
-		User user = new User();
-		user.setEmail(email);
-		user.setAccountName(email);
-		user.setPassword(passwordEncoder.encode(rawPassword));
-		user.setActive(isActive);
+		// mock result
+		User registeredUser = new User();
+		registeredUser.setEmail(email);
+		registeredUser.setAccountName(email);
+		registeredUser.setPassword(passwordEncoder.encode(rawPassword));
+		registeredUser.setActive(isActive);
 
 		// mock service
-		when(userService.registerUser(
-				eq(email), eq(rawPassword), eq(isActive), any(HttpServletRequest.class)))
-			.thenReturn(user);
+		when(userService.registerUser(any(User.class), any(HttpServletRequest.class)))
+			.thenReturn(registeredUser);
 
 
 		// Perform and test the POST-Request
@@ -98,8 +98,7 @@ public class UserControllerTest {
 			.andExpect(jsonPath("$.data", containsString("You have been registered.")))
 			.andExpect(jsonPath("$.data", containsString(email)));
 
-		verify(userService, times(1)).registerUser(
-				eq(email), eq(rawPassword), eq(isActive), any(HttpServletRequest.class));
+		verify(userService, times(1)).registerUser(any(User.class), any(HttpServletRequest.class));
 		verifyNoMoreInteractions(userService);
 	}
 
@@ -108,12 +107,10 @@ public class UserControllerTest {
 
 		String email = "test@example.com";
 		String rawPassword = "p@sSw0rd";
-		boolean isActive = false;
 
 		// mock service
 		doThrow(new Exception("errormsg"))
-			.when(userService).registerUser(
-				eq(email), eq(rawPassword), eq(isActive), any(HttpServletRequest.class));
+			.when(userService).registerUser(any(User.class), any(HttpServletRequest.class));
 
 
 		// Perform and test the POST-Request
@@ -126,8 +123,7 @@ public class UserControllerTest {
 			.andExpect(jsonPath("$.success", is(false)))
 			.andExpect(jsonPath("$.message", is("Could not register a new user.")));
 
-		verify(userService, times(1)).registerUser(
-				eq(email), eq(rawPassword), eq(isActive), any(HttpServletRequest.class));
+		verify(userService, times(1)).registerUser(any(User.class), any(HttpServletRequest.class));
 		verifyNoMoreInteractions(userService);
 	}
 


### PR DESCRIPTION
Refactor the user registration interface to accept a `User` object, but not single properties (email and password). By doing, this we can easily use the SHOGun registration interface with user objects that extend the SHOGun2 `User` class