### PR TITLE
Towards an automated (Central Repository) deploy process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ tmp
 .settings
 .project
 .wtpmodules
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ jdk:
   - oraclejdk8
   - openjdk7
 
+env:
+  global:
+  - secure: gmi5f87L/GsqhsrJj2WUtu261Ywry6fQM9eKY6KIv/z4TpHZDQf7TVgEnw1dKWnC2ogHXkPXGMHoR2BR44DCKrVrtGGAu7zPbSrtagquhpRwwAA3od5nV+lgx1EXvp8dJmUDPzxPBLoAYp+9eqXjH+TGziJy7bkxXO1OKX3H6mI=
+  - secure: OfjAssoJByPB8TzXB0tik5fDbar9CYWDpt964Itk3XODM8f5bzeft5hXmba4cCWvNa4etde5SzJQh68qZrWkvjzNClAtL6BpGMimX69tvRrqHvoE6h/PKD7DR2Uynpa1EBD3RD+7lyVHAX04/D3EIAyPI6olsHxwcLPokXV6njI=
+
 before_script:
   - cd src/
   - mvn --batch-mode --threads 2.0C -DskipTests=true install
@@ -35,6 +40,7 @@ script:
 
 after_success:
   - mvn clean test jacoco:report coveralls:report
+  - ../scripts/snapshot-release.sh > /dev/null 2>&1
 
 after_script:
   - cd ..
@@ -43,3 +49,4 @@ notifications:
   email:
     on_success: never
     on_failure: never
+

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# stop at first command failure
+set -e
+
+read -p "Do you really want to deploy to maven central repository (yes/no)? "
+
+# check if prompted to continue
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    exit 1
+fi
+
+# check if the input parameter RELEASE_VERSION is valid
+RELEASE_VERSION="$1"
+if [[ ! $RELEASE_VERSION =~ ^([0-9]+\.[0-9]+\.[0-9])(\-SNAPSHOT){0,1}$ ]]; then
+    echo "Error: RELEASE_VERSION must be in X.Y.Z(-SNAPSHOT) format, but was $RELEASE_VERSION"
+    exit 1
+fi
+
+mvn release:clean
+mvn release:prepare --batch-mode -DreleaseVersion=$RELEASE_VERSION
+mvn release:perform --batch-mode

--- a/scripts/settings.xml
+++ b/scripts/settings.xml
@@ -1,0 +1,22 @@
+<settings
+  xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository/>
+  <interactiveMode/>
+  <usePluginRegistry/>
+  <offline/>
+  <pluginGroups/>
+  <servers>
+    <server>
+      <id>ossrh</id>
+      <username>${env.SONATYPE_USERNAME}</username>
+      <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+  </servers>
+  <mirrors/>
+  <proxies/>
+  <profiles/>
+  <activeProfiles/>
+</settings>

--- a/scripts/snapshot-release.sh
+++ b/scripts/snapshot-release.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# stop at first command failure
+set -e
+
+if [ "$TRAVIS" != "true" ]; then
+    echo "This script is supposed to be run inside the travis environment."
+    exit 1
+fi
+
+if [ $TRAVIS_PULL_REQUEST != "false" ]; then
+    # only proceed if we were called by a merge (and not by a PR request)
+    exit 1
+fi
+
+if [ $TRAVIS_BRANCH != "master" ]; then
+    # only proceed if the target branch is master
+    exit 1
+fi
+
+if [ "$TRAVIS_JDK_VERSION" != "openjdk7" ]; then
+    # only proceed if the target JDK is openjdk7
+    exit 1
+fi
+
+SCRIPTDIR=`dirname "$0"`
+
+SETTINGSFILE=$SCRIPTDIR/settings.xml
+
+mvn clean deploy --settings $SETTINGSFILE

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -10,22 +10,46 @@
     <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>SHOGun2</name>
+    <description>SHOGun2 is a Java based WebGIS framework</description>
+    <url>https://github.com/terrestris/shogun2</url>
 
     <organization>
-        <name>terrestris GmbH &#038; Co. KG</name>
+        <name>terrestris GmbH &amp; Co. KG</name>
         <url>http://www.terrestris.de/</url>
     </organization>
 
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
     <scm>
+        <url>https://github.com/terrestris/shogun2</url>
         <connection>scm:git:git://github.com/terrestris/shogun2.git</connection>
-        <developerConnection>scm:git:[fetch=]git://github.com/terrestris/shogun2.git[push=]git@github.com:terrestris/shogun2.git</developerConnection>
-        <url>https://github.com/terrestris/shogun2.git</url>
+        <developerConnection>scm:git:git@github.com:terrestris/shogun2.git</developerConnection>
+        <tag>HEAD</tag>
     </scm>
 
     <ciManagement>
         <system>travis</system>
         <url>https://travis-ci.org/terrestris/shogun2</url>
     </ciManagement>
+
+    <distributionManagement>
+        <repository>
+            <id>ossrh</id>
+            <name>Nexus Release Repository</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <name>Nexus Snapshot Repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
 
     <repositories>
         <repository>
@@ -47,7 +71,7 @@
             <id>buehner</id>
             <name>Nils Bühner</name>
             <email>buehner@terrestris.de</email>
-            <organization>terrestris GmbH &#038; Co. KG</organization>
+            <organization>terrestris GmbH &amp; Co. KG</organization>
             <organizationUrl>http://www.terrestris.de/</organizationUrl>
             <roles>
                 <role>architect</role>
@@ -60,7 +84,7 @@
             <id>marcjansen</id>
             <name>Marc Jansen</name>
             <email>jansen@terrestris.de</email>
-            <organization>terrestris GmbH &#038; Co. KG</organization>
+            <organization>terrestris GmbH &amp; Co. KG</organization>
             <organizationUrl>http://www.terrestris.de/</organizationUrl>
             <roles>
                 <role>architect</role>
@@ -73,7 +97,7 @@
             <id>dnlkoch</id>
             <name>Daniel Koch</name>
             <email>koch@terrestris.de</email>
-            <organization>terrestris GmbH &#038; Co. KG</organization>
+            <organization>terrestris GmbH &amp; Co. KG</organization>
             <organizationUrl>http://www.terrestris.de/</organizationUrl>
             <roles>
                 <role>architect</role>
@@ -141,6 +165,8 @@
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
 
         <!-- Other -->
         <ext-direct-spring.version>1.6.1</ext-direct-spring.version>
@@ -217,6 +243,31 @@
                 </plugins>
             </build>
         </profile>
+
+        <!-- A profile that is used for release a version of SHOGun2 to the
+             Central Repository -->
+        <profile>
+            <id>release-artifact</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
     </profiles>
 
     <build>
@@ -310,6 +361,22 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>${maven-deploy-plugin.version}</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${maven-release-plugin.version}</version>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
+                    <!-- Disable the release profile that is part of the
+                         Maven Super POM since we are using our own profile -->
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <releaseProfiles>release-artifact</releaseProfiles>
+                    <goals>deploy</goals>
+                    <allowTimestampedSnapshots>true</allowTimestampedSnapshots>
+                </configuration>
             </plugin>
 
         </plugins>


### PR DESCRIPTION
This PR suggests an automated workflow for deploying the current (SNAPSHOT and release) state of the `shogun2` repository to the *Central Repository* using the `maven-release-plugin`. The presented steps are mainly inspired by the official guide as described [here](http://central.sonatype.org/pages/ossrh-guide.html).

The deployment process has to be differentiated between a *full* and *SNAPSHOT* release:

  1. A *full* release will happen only after a manual execution of the provided script `release.sh` (including the wished version as only parameter, e.g. `release.sh 0.0.1`). Running this script will do the following steps for you (with the help of the `maven-release-plugin`):

  > * Check that there are no uncommitted changes in the sources
  > * Check that there are no SNAPSHOT dependencies
  > * Change the version in the POMs from x-SNAPSHOT to a new version (you will be prompted for   the versions to use)
  > * Transform the SCM information in the POM to include the final destination of the tag
  > * Run the project tests against the modified POMs to confirm everything is in working order
  > * Commit the modified POMs
  > * Tag the code in the SCM with a version name (this will be prompted for)
  > * Bump the version in the POMs to a new value y-SNAPSHOT (these values will also be prompted for)
  > * Commit the modified POMs
  
  ([Source](http://maven.apache.org/maven-release/maven-release-plugin/examples/prepare-release.html))

  > * Checkout from an SCM URL with optional tag
  > * Run the predefined Maven goals to release the project
  
  ([Source](http://maven.apache.org/maven-release/maven-release-plugin/examples/perform-release.html))

  In short: 
   * All shogun2 version-strings (in `pom.xml`) will be updated to the given version (e.g. `0.0.1`).
   * All modified files will be committed (and be included in a newly created tag, see below).
   * A new tag with the format `v{{NEW_VERSION}}` (e.g. `v0.0.1`) will be created (and will contain the actual state of the repo).
   * All shogun2 version-strings (in `pom.xml`) will be updated to the next development version (e.g.  `0.0.2`).
   * All modified files will be committed (and be included in the current master branch).
   * The newly created tag (or release) will be deployed to the staging area of the *Central Repository* repository.

  To do a release the following prerequisites are needed:
   * (maybe obsolute as we have a `shogun2` account) Create a Sonatype [JIRA account](https://issues.sonatype.org/secure/Signup!default.jspa)
   * Create a PGP signature and distribute your public key as described [here](http://central.sonatype.org/pages/working-with-pgp-signatures.html)
   * Set up SSH access to GitHub as described [here](https://help.github.com/articles/generating-ssh-keys/)
   * Adjust and add the following block to your local maven `settings.xml`
  (typically in `~/.m2/settings.xml`):

     ```xml
<settings>
  <servers>
    <server>
      <id>ossrh</id>
      <username>{{SONATYPE_USERNAME}}</username>
      <password>{{SONATYPE_PASSWORD}}</password>
    </server>
  </servers>
  <profiles>
    <profile>
      <id>ossrh</id>
      <activation>
        <activeByDefault>true</activeByDefault>
      </activation>
      <properties>
        <gpg.executable>gpg</gpg.executable>
        <gpg.keyname>{{GPG_KEYNAME}}</gpg.keyname>
        <gpg.passphrase>{{GPG_PASSPHRASE}}</gpg.passphrase>
      </properties>
    </profile>
  </profiles>
</settings>
     ```
  2. A *SNAPSHOT* release will happen automatically after each merged pull request. In this case the given state of the `terrestris/shogun2` master branch will be deployed to the *Central Repository* snapshots repository. 
