### PR TITLE
Assure compatablity with Java 1.7

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -362,8 +362,8 @@
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Title says it all.

Until now, the `maven-compiler-plugin` was using the current Java version of the system. By setting the target version to 1.7, we can be sure that all artifacts are always compatible with version 1.7 - disregarding which version was used to compile (e.g. version 1.8)