### PR TITLE
Provide runtime entity class for controllers

### DIFF
--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
@@ -26,6 +26,14 @@ public abstract class AbstractRestController<E extends PersistentObject, D exten
 		extends AbstractWebController<E, D, S> {
 
 	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected AbstractRestController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
 	 * Find all entities.
 	 *
 	 * @return

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/ApplicationRestController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/ApplicationRestController.java
@@ -20,6 +20,22 @@ public class ApplicationRestController<E extends Application, D extends Applicat
 		extends AbstractRestController<E, D, S> {
 
 	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public ApplicationRestController() {
+		this((Class<E>) Application.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected ApplicationRestController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
 	 * We have to use {@link Qualifier} to define the correct service here.
 	 * Otherwise, spring can not decide which service has to be autowired here
 	 * as there are multiple candidates.

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/UserRestController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/UserRestController.java
@@ -20,6 +20,22 @@ public class UserRestController<E extends User, D extends UserDao<E>, S extends 
 		extends AbstractRestController<E, D, S> {
 
 	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public UserRestController() {
+		this((Class<E>) User.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected UserRestController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
 	 * We have to use {@link Qualifier} to define the correct service here.
 	 * Otherwise, spring can not decide which service has to be autowired here
 	 * as there are multiple candidates.

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/AbstractWebController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/AbstractWebController.java
@@ -24,6 +24,20 @@ public abstract class AbstractWebController<E extends PersistentObject, D extend
 	protected final Logger LOG = Logger.getLogger(getClass());
 
 	/**
+	 * Provides the concrete entity class of the controller.
+	 * Based on the pattern propsed here: http://stackoverflow.com/a/3403987
+	 */
+	private final Class<E> entityClass;
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected AbstractWebController(Class<E> entityClass) {
+		this.entityClass = entityClass;
+	}
+
+	/**
 	 * The {@link AbstractCrudService} for this controller.
 	 */
 	protected S service;
@@ -42,6 +56,13 @@ public abstract class AbstractWebController<E extends PersistentObject, D extend
 	 */
 	public S getService() {
 		return service;
+	}
+
+	/**
+	 * @return the entityClass
+	 */
+	public Class<E> getEntityClass() {
+		return entityClass;
 	}
 
 }

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/ApplicationController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/ApplicationController.java
@@ -23,6 +23,22 @@ public class ApplicationController<E extends Application, D extends ApplicationD
 		extends AbstractWebController<E, D, S> {
 
 	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public ApplicationController() {
+		this((Class<E>) Application.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected ApplicationController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
 	 * We have to use {@link Qualifier} to define the correct service here.
 	 * Otherwise, spring can not decide which service has to be autowired here
 	 * as there are multiple candidates.

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/ModuleController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/ModuleController.java
@@ -19,6 +19,22 @@ public class ModuleController<E extends Module, D extends ModuleDao<E>, S extend
 		extends AbstractWebController<E, D, S> {
 
 	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public ModuleController() {
+		this((Class<E>) Module.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected ModuleController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
 	 * We have to use {@link Qualifier} to define the correct service here.
 	 * Otherwise, spring can not decide which service has to be autowired here
 	 * as there are multiple candidates.

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/UserController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/UserController.java
@@ -37,6 +37,22 @@ public class UserController<E extends User, D extends UserDao<E>, S extends User
 	private PasswordResetTokenService<PasswordResetToken, PasswordResetTokenDao<PasswordResetToken>> passwordResetTokenService;
 
 	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public UserController() {
+		this((Class<E>) User.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected UserController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
 	 * We have to use {@link Qualifier} to define the correct service here.
 	 * Otherwise, spring can not decide which service has to be autowired here
 	 * as there are multiple candidates.
@@ -54,21 +70,20 @@ public class UserController<E extends User, D extends UserDao<E>, S extends User
 	 * @param password
 	 * @return
 	 */
-	@SuppressWarnings("unchecked")
 	@RequestMapping(value = "/register.action", method = RequestMethod.POST)
 	public @ResponseBody Map<String, Object> registerUser(HttpServletRequest request,
 			@RequestParam String email,
 			@RequestParam String password) {
 
-		// build the user object that will be passed to the service method
-		E user = (E) new User();
-
-		user.setEmail(email);
-		user.setAccountName(email);
-		user.setPassword(password);
-		user.setActive(false);
-
 		try {
+			// build the user object that will be passed to the service method
+			E user = getEntityClass().newInstance();
+
+			user.setEmail(email);
+			user.setAccountName(email);
+			user.setPassword(password);
+			user.setActive(false);
+
 			user = service.registerUser(user, request);
 
 			return ResultSet.success("You have been registered. "
@@ -157,6 +172,21 @@ public class UserController<E extends User, D extends UserDao<E>, S extends User
 			return ResultSet.error("Could not obtain the user by "
 					+ "session: " + e.getMessage());
 		}
+	}
+
+	/**
+	 * @return the passwordResetTokenService
+	 */
+	public PasswordResetTokenService<PasswordResetToken, PasswordResetTokenDao<PasswordResetToken>> getPasswordResetTokenService() {
+		return passwordResetTokenService;
+	}
+
+	/**
+	 * @param passwordResetTokenService the passwordResetTokenService to set
+	 */
+	public void setPasswordResetTokenService(
+			PasswordResetTokenService<PasswordResetToken, PasswordResetTokenDao<PasswordResetToken>> passwordResetTokenService) {
+		this.passwordResetTokenService = passwordResetTokenService;
 	}
 
 }

--- a/src/shogun2-web/src/test/java/de/terrestris/shogun2/rest/AbstractRestControllerTest.java
+++ b/src/shogun2-web/src/test/java/de/terrestris/shogun2/rest/AbstractRestControllerTest.java
@@ -80,6 +80,11 @@ public class AbstractRestControllerTest {
 	private class TestModelRestController<E extends TestModel, D extends GenericHibernateDao<E, Integer>, S extends AbstractCrudService<E, D>>
 			extends AbstractRestController<E, D, S> {
 
+		@SuppressWarnings("unchecked")
+		public TestModelRestController() {
+			super((Class<E>) TestModel.class);
+		}
+
 		@Override
 		public void setService(S service) {
 			this.service = service;

--- a/src/shogun2-web/src/test/java/de/terrestris/shogun2/web/ApplicationControllerTest.java
+++ b/src/shogun2-web/src/test/java/de/terrestris/shogun2/web/ApplicationControllerTest.java
@@ -1,15 +1,20 @@
 package de.terrestris.shogun2.web;
 
-import static org.hamcrest.Matchers.*;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.Arrays;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.test.web.servlet.MockMvc;
@@ -18,7 +23,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import de.terrestris.shogun2.dao.ApplicationDao;
 import de.terrestris.shogun2.model.Application;
 import de.terrestris.shogun2.service.ApplicationService;
-import de.terrestris.shogun2.web.ApplicationController;
 
 /**
  * @author Nils Bühner
@@ -31,7 +35,9 @@ public class ApplicationControllerTest {
 	@Mock
 	private ApplicationService<Application, ApplicationDao<Application>> applicationServiceMock;
 
-	@InjectMocks
+	/**
+	 * The controller to test
+	 */
 	private ApplicationController<Application, ApplicationDao<Application>, ApplicationService<Application, ApplicationDao<Application>>> applicationController;
 
 	@Before
@@ -39,6 +45,12 @@ public class ApplicationControllerTest {
 
 		// Process mock annotations
 		MockitoAnnotations.initMocks(this);
+
+		// init the controller to test. this is necessary as InjectMocks
+		// annotation will not work with the constructors of the controllers
+		// (entityClass). see https://goo.gl/jLbMZe
+		applicationController = new ApplicationController<Application, ApplicationDao<Application>, ApplicationService<Application, ApplicationDao<Application>>>();
+		applicationController.setService(applicationServiceMock);
 
 		// Setup Spring test in standalone mode
 		this.mockMvc = MockMvcBuilders.standaloneSetup(applicationController)

--- a/src/shogun2-web/src/test/java/de/terrestris/shogun2/web/UserControllerTest.java
+++ b/src/shogun2-web/src/test/java/de/terrestris/shogun2/web/UserControllerTest.java
@@ -21,7 +21,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,8 +53,10 @@ public class UserControllerTest {
 	@Mock(name="service")
 	private UserService<User, UserDao<User>> userService;
 
-	@InjectMocks
-	private UserController<User, UserDao<User>, UserService<User, UserDao<User>>> UserController;
+	/**
+	 * The controller to test
+	 */
+	private UserController<User, UserDao<User>, UserService<User, UserDao<User>>> userController;
 
 	@Autowired
 	private PasswordEncoder passwordEncoder;
@@ -66,8 +67,15 @@ public class UserControllerTest {
 		// Process mock annotations
 		MockitoAnnotations.initMocks(this);
 
+		// init the controller to test. this is necessary as InjectMocks
+		// annotation will not work with the constructors of the controllers
+		// (entityClass). see https://goo.gl/jLbMZe
+		userController = new UserController<User, UserDao<User>, UserService<User, UserDao<User>>>();
+		userController.setService(userService);
+		userController.setPasswordResetTokenService(tokenService);
+
 		// Setup Spring test in standalone mode
-		this.mockMvc = MockMvcBuilders.standaloneSetup(UserController).build();
+		this.mockMvc = MockMvcBuilders.standaloneSetup(userController).build();
 	}
 
 	@Test

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/web/ProjectApplicationController.java
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/web/ProjectApplicationController.java
@@ -16,7 +16,7 @@ import de.terrestris.shogun2.web.ApplicationController;
 /**
  * This is a demo controller that demonstrates how a SHOGun2 controllers can be
  * extended.
- * 
+ *
  * @author Nils Bühner
  *
  * @param <E>
@@ -27,6 +27,22 @@ import de.terrestris.shogun2.web.ApplicationController;
 @RequestMapping("/projectApplication")
 public class ProjectApplicationController<E extends ProjectApplication, D extends ProjectApplicationDao<E>, S extends ProjectApplicationService<E, D>>
 		extends ApplicationController<E, D, S> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public ProjectApplicationController() {
+		this((Class<E>) ProjectApplication.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected ProjectApplicationController(Class<E> entityClass) {
+		super(entityClass);
+	}
 
 	/**
 	 * We have to use {@link Qualifier} to define the correct service here.


### PR DESCRIPTION
This PR forces all web controller classes to provide their entity class by calling an appropriate constructor. This is very helpful when extending a web controller to create "generic" instances during runtime in a parent class (see change in UserController).

This pattern is already implemented in the DAO layer. See http://stackoverflow.com/a/3403987 for details.

I will also introduce this pattern for the service layer in a following PR