### PR TITLE
Various changes to the model classes

### DIFF
--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Application.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Application.java
@@ -186,8 +186,16 @@ public class Application extends PersistentObject {
 	@Override
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(29, 11).appendSuper(super.hashCode()).append(getName()).append(getLanguage())
-				.append(getOpen()).append(getActive()).append(getUrl()).toHashCode();
+		return new HashCodeBuilder(29, 11).
+				appendSuper(super.hashCode()).
+				append(getName()).
+				append(getDescription()).
+				append(getLanguage()).
+				append(getOpen()).
+				append(getActive()).
+				append(getUrl()).
+				append(getViewport()).
+				toHashCode();
 	}
 
 	/**
@@ -202,9 +210,16 @@ public class Application extends PersistentObject {
 			return false;
 		Application other = (Application) obj;
 
-		return new EqualsBuilder().appendSuper(super.equals(other)).append(getName(), other.getName())
-				.append(getLanguage(), other.getLanguage()).append(getOpen(), other.getOpen())
-				.append(getActive(), other.getActive()).isEquals();
+		return new EqualsBuilder().
+				appendSuper(super.equals(other)).
+				append(getName(), other.getName()).
+				append(getDescription(), other.getDescription()).
+				append(getLanguage(), other.getLanguage()).
+				append(getOpen(), other.getOpen()).
+				append(getActive(), other.getActive()).
+				append(getUrl(), other.getUrl()).
+				append(getViewport(), other.getViewport()).
+				isEquals();
 	}
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/PersistentObject.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/PersistentObject.java
@@ -118,8 +118,11 @@ public abstract class PersistentObject implements Serializable {
 	 */
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(17, 43).appendSuper(super.hashCode())
-				.append(getCreated()).append(getModified()).toHashCode();
+		return new HashCodeBuilder(17, 43).
+				appendSuper(super.hashCode()).
+				append(getCreated()).
+				append(getModified()).
+				toHashCode();
 	}
 
 	/**
@@ -135,8 +138,10 @@ public abstract class PersistentObject implements Serializable {
 			return false;
 		PersistentObject other = (PersistentObject) obj;
 
-		return new EqualsBuilder().append(getCreated(), other.getCreated())
-				.append(getModified(), other.getModified()).isEquals();
+		return new EqualsBuilder().
+				append(getCreated(), other.getCreated()).
+				append(getModified(), other.getModified()).
+				isEquals();
 	}
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Person.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Person.java
@@ -114,10 +114,14 @@ public class Person extends PersistentObject {
 	@Override
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(19, 53).appendSuper(super.hashCode())
-				.append(getFirstName()).append(getLastName())
-				.append(getEmail()).append(getBirthday()).append(getLanguage())
-				.toHashCode();
+		return new HashCodeBuilder(19, 53).
+				appendSuper(super.hashCode()).
+				append(getFirstName()).
+				append(getLastName()).
+				append(getEmail()).
+				append(getBirthday()).
+				append(getLanguage()).
+				toHashCode();
 	}
 
 	/**
@@ -134,10 +138,14 @@ public class Person extends PersistentObject {
 			return false;
 		Person other = (Person) obj;
 
-		return new EqualsBuilder().appendSuper(super.equals(other))
-				.append(getFirstName(), other.getFirstName())
-				.append(getLastName(), other.getLastName())
-				.append(getEmail(), other.getEmail()).isEquals();
+		return new EqualsBuilder().
+				appendSuper(super.equals(other)).
+				append(getFirstName(), other.getFirstName()).
+				append(getLastName(), other.getLastName()).
+				append(getEmail(), other.getEmail()).
+				append(getBirthday(), other.getBirthday()).
+				append(getLanguage(), other.getLanguage()).
+				isEquals();
 	}
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Role.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Role.java
@@ -77,10 +77,11 @@ public class Role extends PersistentObject {
 	@Override
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(13, 53).appendSuper(super.hashCode())
-				.append(getName())
-				.append(getDescription())
-				.toHashCode();
+		return new HashCodeBuilder(13, 53).
+				appendSuper(super.hashCode()).
+				append(getName()).
+				append(getDescription()).
+				toHashCode();
 	}
 
 	/**
@@ -97,9 +98,11 @@ public class Role extends PersistentObject {
 			return false;
 		Role other = (Role) obj;
 
-		return new EqualsBuilder().appendSuper(super.equals(other))
-				.append(getName(), other.getName())
-				.append(getDescription(), other.getDescription()).isEquals();
+		return new EqualsBuilder().
+				appendSuper(super.equals(other)).
+				append(getName(), other.getName()).
+				append(getDescription(), other.getDescription()).
+				isEquals();
 	}
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/User.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/User.java
@@ -127,9 +127,12 @@ public class User extends Person {
 	@Override
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(23, 13).appendSuper(super.hashCode())
-				.append(getAccountName()).append(getPassword())
-				.append(isActive()).toHashCode();
+		return new HashCodeBuilder(23, 13).
+				appendSuper(super.hashCode()).
+				append(getAccountName()).
+				append(getPassword()).
+				append(isActive()).
+				toHashCode();
 	}
 
 	/**
@@ -146,10 +149,12 @@ public class User extends Person {
 			return false;
 		User other = (User) obj;
 
-		return new EqualsBuilder().appendSuper(super.equals(other))
-				.append(getAccountName(), other.getAccountName())
-				.append(getPassword(), other.getPassword())
-				.append(isActive(), other.isActive()).isEquals();
+		return new EqualsBuilder().
+				appendSuper(super.equals(other)).
+				append(getAccountName(), other.getAccountName()).
+				append(getPassword(), other.getPassword()).
+				append(isActive(), other.isActive()).
+				isEquals();
 	}
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/UserGroup.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/UserGroup.java
@@ -124,12 +124,13 @@ public class UserGroup extends PersistentObject {
 	@Override
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(53, 19).appendSuper(super.hashCode())
-				.append(getName())
-				.append(getOwner())
-				.append(getMembers())
-				.append(getRoles())
-				.toHashCode();
+		return new HashCodeBuilder(53, 19).
+				appendSuper(super.hashCode()).
+				append(getName()).
+				append(getOwner()).
+				append(getMembers()).
+				append(getRoles()).
+				toHashCode();
 	}
 
 	/**
@@ -146,12 +147,13 @@ public class UserGroup extends PersistentObject {
 			return false;
 		UserGroup other = (UserGroup) obj;
 
-		return new EqualsBuilder().appendSuper(super.equals(other))
-				.append(getName(), other.getName())
-				.append(getOwner(), other.getOwner())
-				.append(getMembers(), other.getMembers())
-				.append(getRoles(), other.getRoles())
-				.isEquals();
+		return new EqualsBuilder().
+				appendSuper(super.equals(other)).
+				append(getName(), other.getName()).
+				append(getOwner(), other.getOwner()).
+				append(getMembers(), other.getMembers()).
+				append(getRoles(), other.getRoles()).
+				isEquals();
 	}
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/Layer.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/Layer.java
@@ -138,8 +138,8 @@ public class Layer extends PersistentObject {
 				appendSuper(super.hashCode()).
 				append(getName()).
 				append(getType()).
-				append(getSource().hashCode()).
-				append(getAppearance().hashCode()).
+				append(getSource()).
+				append(getAppearance()).
 				toHashCode();
 	}
 

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/source/WmtsLayerDataSource.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/source/WmtsLayerDataSource.java
@@ -42,7 +42,9 @@ public class WmtsLayerDataSource extends LayerDataSource {
 	 */
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(11, 19).appendSuper(super.hashCode()).toHashCode();
+		return new HashCodeBuilder(11, 19).
+				appendSuper(super.hashCode()).
+				toHashCode();
 	}
 
 	/**
@@ -58,7 +60,9 @@ public class WmtsLayerDataSource extends LayerDataSource {
 			return false;
 		WmtsLayerDataSource other = (WmtsLayerDataSource) obj;
 
-		return new EqualsBuilder().appendSuper(super.equals(other)).isEquals();
+		return new EqualsBuilder().
+				appendSuper(super.equals(other)).
+				isEquals();
 	}
 
 	/* (non-Javadoc)

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/Extent.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/Extent.java
@@ -79,6 +79,19 @@ public class Extent extends PersistentObject {
 	}
 
 	/**
+	 * @param lowerLeftX
+	 * @param lowerLeftY
+	 * @param upperRightX
+	 * @param upperRightY
+	 */
+	public Extent(double lowerLeftX, double lowerLeftY,
+			double upperRightX, double upperRightY) {
+		super();
+		this.lowerLeft = new Double(lowerLeftX, lowerLeftY);
+		this.upperRight = new Double(upperRightX, upperRightY);;
+	}
+
+	/**
 	 * @return the lowerLeft
 	 */
 	public Point2D.Double getLowerLeft() {

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/Extent.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/Extent.java
@@ -21,14 +21,17 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import de.terrestris.shogun2.model.PersistentObject;
 
 /**
- *
  * Util class representing the extent of a layer or a map.
- * The extent is modellesd by the lower left and the upper
+ * The extent is modelled by the lower left and the upper
  * right point of the bounding rectangle
  *
- * |--------o
- * |        |
- * o--------|
+ * <pre>
+ *                UR
+ *     +--------o
+ *     |        |
+ *     o--------+
+ *  LL
+ * </pre>
  *
  * @author Andre Henn
  * @author terrestris GmbH & Co. KG

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/WmsTileGrid.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/WmsTileGrid.java
@@ -203,9 +203,9 @@ public class WmsTileGrid extends PersistentObject {
 		return new HashCodeBuilder(43, 13).
 				appendSuper(super.hashCode()).
 				append(getType()).
-				append(getTileSize()).
 				append(getTileGridOrigin()).
 				append(getTileGridExtent()).
+				append(getTileSize()).
 				append(getTileGridResolutions()).
 				toHashCode();
 	}
@@ -227,8 +227,8 @@ public class WmsTileGrid extends PersistentObject {
 		return new EqualsBuilder().
 				appendSuper(super.equals(other)).
 				append(getType(), other.getType()).
-				append(getTileGridExtent(), other.getTileGridExtent()).
 				append(getTileGridOrigin(), other.getTileGridOrigin()).
+				append(getTileGridExtent(), other.getTileGridExtent()).
 				append(getTileSize(), other.getTileSize()).
 				append(getTileGridResolutions(), other.getTileGridResolutions()).
 				isEquals();

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/AbsoluteLayout.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/AbsoluteLayout.java
@@ -84,7 +84,10 @@ public class AbsoluteLayout extends Layout {
 	 */
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(11, 13).appendSuper(super.hashCode()).append(getCoords()).toHashCode();
+		return new HashCodeBuilder(11, 13).
+				appendSuper(super.hashCode()).
+				append(getCoords()).
+				toHashCode();
 	}
 
 	/**
@@ -100,7 +103,10 @@ public class AbsoluteLayout extends Layout {
 			return false;
 		AbsoluteLayout other = (AbsoluteLayout) obj;
 
-		return new EqualsBuilder().appendSuper(super.equals(other)).append(getCoords(), other.getCoords()).isEquals();
+		return new EqualsBuilder().
+				appendSuper(super.equals(other)).
+				append(getCoords(), other.getCoords()).
+				isEquals();
 	}
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/BorderLayout.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/BorderLayout.java
@@ -83,7 +83,10 @@ public class BorderLayout extends Layout {
 	 */
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(53, 23).appendSuper(super.hashCode()).append(getRegions()).toHashCode();
+		return new HashCodeBuilder(53, 23).
+				appendSuper(super.hashCode()).
+				append(getRegions()).
+				toHashCode();
 	}
 
 	/**
@@ -99,7 +102,10 @@ public class BorderLayout extends Layout {
 			return false;
 		BorderLayout other = (BorderLayout) obj;
 
-		return new EqualsBuilder().appendSuper(super.equals(other)).append(getRegions(), other.getRegions()).isEquals();
+		return new EqualsBuilder().
+				appendSuper(super.equals(other)).
+				append(getRegions(), other.getRegions()).
+				isEquals();
 	}
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/Layout.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layout/Layout.java
@@ -132,12 +132,12 @@ public class Layout extends PersistentObject {
 	 */
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(13, 7)
-				.appendSuper(super.hashCode())
-				.append(getType())
-				.append(getPropertyHints())
-				.append(getPropertyMusts())
-				.toHashCode();
+		return new HashCodeBuilder(13, 7).
+				appendSuper(super.hashCode()).
+				append(getType()).
+				append(getPropertyHints()).
+				append(getPropertyMusts()).
+				toHashCode();
 	}
 
 	/**
@@ -153,12 +153,12 @@ public class Layout extends PersistentObject {
 			return false;
 		Layout other = (Layout) obj;
 
-		return new EqualsBuilder()
-				.appendSuper(super.equals(other))
-				.append(getType(), other.getType())
-				.append(getPropertyHints(), other.getPropertyHints())
-				.append(getPropertyMusts(), other.getPropertyMusts())
-				.isEquals();
+		return new EqualsBuilder().
+				appendSuper(super.equals(other)).
+				append(getType(), other.getType()).
+				append(getPropertyHints(), other.getPropertyHints()).
+				append(getPropertyMusts(), other.getPropertyMusts()).
+				isEquals();
 	}
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/map/MapControl.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/map/MapControl.java
@@ -113,11 +113,11 @@ public class MapControl extends PersistentObject {
 	@Override
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(7, 13)
-				.appendSuper(super.hashCode())
-				.append(getMapControlName())
-				.append(getMapControlProperties())
-				.toHashCode();
+		return new HashCodeBuilder(7, 13).
+				appendSuper(super.hashCode()).
+				append(getMapControlName()).
+				append(getMapControlProperties()).
+				toHashCode();
 	}
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/map/MapControl.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/map/MapControl.java
@@ -39,10 +39,13 @@ public class MapControl extends PersistentObject {
 	private static final long serialVersionUID = 1L;
 	/**
 	 * String which represents the OL3 class name of the interaction, e.g.
-	 * ol.control.Zoom
-	 * ol.control.Rotate
-	 * ol.control.Attribution
-	 * ...
+	 *
+	 * <ul>
+	 *   <li>ol.control.Zoom</li>
+	 *   <li>ol.control.Rotate</li>
+	 *   <li>ol.control.Attribution</li>
+	 *   <li>...</li>
+	 * </ul>
 	 */
 	private String mapControlName;
 

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/AccordionPanel.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/AccordionPanel.java
@@ -27,7 +27,7 @@ public class AccordionPanel extends CompositeModule {
 	private static final long serialVersionUID = 1L;
 
 	/**
-	 * Defines which of the contained Modules is initally expanded.
+	 * Defines which of the contained Modules is initially expanded.
 	 */
 	private Module expandedItem;
 

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Map.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Map.java
@@ -151,10 +151,9 @@ public class Map extends Module {
 		// two randomly chosen prime numbers
 		return new HashCodeBuilder(47, 11).
 				appendSuper(super.hashCode()).
-				append(getName()).
-				append(getMapLayers()).
-				append(getMapControls()).
 				append(getMapConfig()).
+				append(getMapControls()).
+				append(getMapLayers()).
 				toHashCode();
 	}
 
@@ -173,7 +172,6 @@ public class Map extends Module {
 		Map other = (Map) obj;
 
 		return new EqualsBuilder().
-				append(getName(), other.getName()).
 				append(getMapConfig(), other.getMapConfig()).
 				append(getMapControls(), other.getMapControls()).
 				append(getMapLayers(), other.getMapLayers()).

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Module.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Module.java
@@ -131,11 +131,11 @@ public class Module extends PersistentObject {
 	@Override
 	public int hashCode() {
 		// two randomly chosen prime numbers
-		return new HashCodeBuilder(5, 7)
-				.appendSuper(super.hashCode())
-				.append(getName())
-				.append(getProperties())
-				.toHashCode();
+		return new HashCodeBuilder(5, 7).
+				appendSuper(super.hashCode()).
+				append(getName()).
+				append(getProperties()).
+				toHashCode();
 	}
 
 	/**
@@ -152,11 +152,11 @@ public class Module extends PersistentObject {
 			return false;
 		Module other = (Module) obj;
 
-		return new EqualsBuilder().appendSuper(super.equals(other))
-				.append(getName(), other.getName())
-				.append(getXtype(), other.getXtype())
-				.append(getProperties(), other.getProperties())
-				.isEquals();
+		return new EqualsBuilder().appendSuper(super.equals(other)).
+				append(getName(), other.getName()).
+				append(getXtype(), other.getXtype()).
+				append(getProperties(), other.getProperties()).
+				isEquals();
 	}
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/NominatimSearch.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/NominatimSearch.java
@@ -267,8 +267,8 @@ public class NominatimSearch extends Module {
 				isEquals();
 	}
 
-	/**
-	 *
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
 	 */
 	public String toString() {
 		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/OverpassSearch.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/OverpassSearch.java
@@ -116,20 +116,6 @@ public class OverpassSearch extends Module {
 	private List<Integer> viewboxlbrt = new ArrayList<Integer>();
 
 	/**
-	 * Explicitly adding the default constructor as this is important, e.g. for
-	 * Hibernate: http://goo.gl/3Cr1pw
-	 */
-	public OverpassSearch() {
-	}
-
-	/**
-	 * @param groupHeaderTpl the groupHeaderTpl to set
-	 */
-	public void setGroupHeaderTpl(String groupHeaderTpl) {
-		this.groupHeaderTpl = groupHeaderTpl;
-	}
-
-	/**
 	 * Characters needed to send a request.
 	 */
 	private Integer minSearchTextChars;
@@ -144,6 +130,13 @@ public class OverpassSearch extends Module {
 	 * See: http://docs.sencha.com/extjs/6.0/6.0.0-classic/#!/api/Ext.grid.feature.Grouping-cfg-groupHeaderTpl
 	 */
 	private String groupHeaderTpl;
+
+	/**
+	 * Explicitly adding the default constructor as this is important, e.g. for
+	 * Hibernate: http://goo.gl/3Cr1pw
+	 */
+	public OverpassSearch() {
+	}
 
 	/**
 	 * @return the format
@@ -223,6 +216,13 @@ public class OverpassSearch extends Module {
 	}
 
 	/**
+	 * @param groupHeaderTpl the groupHeaderTpl to set
+	 */
+	public void setGroupHeaderTpl(String groupHeaderTpl) {
+		this.groupHeaderTpl = groupHeaderTpl;
+	}
+
+	/**
 	 * @see java.lang.Object#hashCode()
 	 *
 	 *      According to
@@ -267,8 +267,8 @@ public class OverpassSearch extends Module {
 				isEquals();
 	}
 
-	/**
-	 *
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
 	 */
 	public String toString() {
 		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/OverviewMap.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/OverviewMap.java
@@ -144,8 +144,8 @@ public class OverviewMap extends Module {
 		// two randomly chosen prime numbers
 		return new HashCodeBuilder(47, 13).
 				appendSuper(super.hashCode()).
-				append(getMagnification()).
 				append(getOverviewMapLayers()).
+				append(getMagnification()).
 				toHashCode();
 	}
 
@@ -165,8 +165,8 @@ public class OverviewMap extends Module {
 
 		return new EqualsBuilder().
 				append(getMagnification(), other.getMagnification()).
-				append(getParentMapModule(), other.getParentMapModule()).
 				append(getOverviewMapLayers(), other.getOverviewMapLayers()).
+				append(getParentMapModule(), other.getParentMapModule()).
 				isEquals();
 	}
 

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/WfsSearch.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/WfsSearch.java
@@ -198,8 +198,9 @@ public class WfsSearch extends Module {
 				append(getWfsServerUrl()).
 				append(getMinSearchTextChars()).
 				append(getTypeDelay()).
-				append(getAllowedFeatureTypeDataTypes()).
 				append(getGroupHeaderTpl()).
+				append(getLayers()).
+				append(getAllowedFeatureTypeDataTypes()).
 				toHashCode();
 	}
 
@@ -221,8 +222,9 @@ public class WfsSearch extends Module {
 				append(getWfsServerUrl(), other.getWfsServerUrl()).
 				append(getMinSearchTextChars(), other.getMinSearchTextChars()).
 				append(getTypeDelay(), other.getTypeDelay()).
-				append(getAllowedFeatureTypeDataTypes(), other.getAllowedFeatureTypeDataTypes()).
 				append(getGroupHeaderTpl(), other.getGroupHeaderTpl()).
+				append(getLayers(), other.getLayers()).
+				append(getAllowedFeatureTypeDataTypes(), other.getAllowedFeatureTypeDataTypes()).
 				isEquals();
 	}
 


### PR DESCRIPTION
This PR suggest some changes to the minor classes and fixes some issues with them:

* 3360c81f4ef86b78b661b593cc89175555dd2c9f corrects `hashCode()` and `equals()` overwrites, which were sometimes missing fields or adding too many of them. The builder calls have been harmonized to enhance readability 
* 66a338e enhances readability of `hashCode()` and `equals()`, but doesn't change logic
* 73cf351 gives the `Extent` class a nice new constructor accepting four doubles

The other commit messages speak for themself.

Please review.
