### PR TITLE
Get rid of cascading operations

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -140,9 +140,6 @@
         <jsonpath.version>1.2.0</jsonpath.version>
         <greenmail.version>1.4.2-SNAPSHOT</greenmail.version>
 
-        <!-- AOP -->
-        <aspectj.version>1.8.7</aspectj.version>
-
         <!-- Code Coverage -->
         <coveralls-maven-plugin.version>3.0.1</coveralls-maven-plugin.version>
         <jacoco-maven-plugin.version>0.7.5.201505241946</jacoco-maven-plugin.version>
@@ -501,18 +498,6 @@
 
             <dependency>
                 <groupId>org.springframework</groupId>
-                <artifactId>spring-aspects</artifactId>
-                <version>${spring.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-aop</artifactId>
-                <version>${spring.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.springframework</groupId>
                 <artifactId>spring-expression</artifactId>
                 <version>${spring.version}</version>
             </dependency>
@@ -566,19 +551,6 @@
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-acl</artifactId>
                 <version>${spring-security.version}</version>
-            </dependency>
-
-            <!-- AspectJ -->
-            <dependency>
-                <groupId>org.aspectj</groupId>
-                <artifactId>aspectjrt</artifactId>
-                <version>${aspectj.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.aspectj</groupId>
-                <artifactId>aspectjweaver</artifactId>
-                <version>${aspectj.version}</version>
             </dependency>
 
             <!-- Hamcrest -->

--- a/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/GenericHibernateDao.java
+++ b/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/GenericHibernateDao.java
@@ -14,6 +14,7 @@ import org.hibernate.criterion.Projections;
 import org.hibernate.transform.DistinctRootEntityResultTransformer;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
 
 import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.paging.PagingResult;
@@ -25,7 +26,8 @@ import de.terrestris.shogun2.paging.PagingResult;
  * @author Nils Bühner
  *
  */
-public abstract class GenericHibernateDao<E extends PersistentObject, ID extends Serializable> {
+@Repository("genericDao")
+public class GenericHibernateDao<E extends PersistentObject, ID extends Serializable> {
 
 	/**
 	 * The LOGGER instance (that will be available in all subclasses)
@@ -36,6 +38,14 @@ public abstract class GenericHibernateDao<E extends PersistentObject, ID extends
 	 * Represents the class of the entity
 	 */
 	private final Class<E> clazz;
+
+	/**
+	 * Default constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public GenericHibernateDao() {
+		this((Class<E>) PersistentObject.class);
+	}
 
 	/**
 	 * Constructor

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Application.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Application.java
@@ -17,8 +17,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
 import org.joda.time.ReadableDateTime;
 
 import ch.rasc.extclassgenerator.Model;
@@ -99,7 +97,6 @@ public class Application extends SecuredPersistentObject {
 	 *
 	 */
 	@ManyToOne
-	@Cascade(CascadeType.SAVE_UPDATE)
 	private CompositeModule viewport;
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/SecuredPersistentObject.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/SecuredPersistentObject.java
@@ -9,8 +9,6 @@ import javax.persistence.OneToMany;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -29,12 +27,10 @@ public abstract class SecuredPersistentObject extends PersistentObject {
 	private static final long serialVersionUID = 1L;
 
 	@OneToMany
-	@Cascade(CascadeType.ALL)
 	@JsonIgnore
 	private Map<User, PermissionCollection> userPermissions = new HashMap<User, PermissionCollection>();
 
 	@OneToMany
-	@Cascade(CascadeType.ALL)
 	@JsonIgnore
 	private Map<UserGroup, PermissionCollection> groupPermissions = new HashMap<UserGroup, PermissionCollection>();
 

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/Layer.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/Layer.java
@@ -8,8 +8,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
 
 import de.terrestris.shogun2.model.layer.appearance.LayerAppearance;
 import de.terrestris.shogun2.model.layer.source.LayerDataSource;
@@ -33,11 +31,9 @@ public class Layer extends AbstractLayer {
 	private static final long serialVersionUID = 1L;
 
 	@ManyToOne
-	@Cascade(CascadeType.SAVE_UPDATE)
 	private LayerDataSource source;
 
 	@ManyToOne
-	@Cascade(CascadeType.SAVE_UPDATE)
 	private LayerAppearance appearance;
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/LayerGroup.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/LayerGroup.java
@@ -14,8 +14,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
 
 /**
  *
@@ -47,7 +45,6 @@ public class LayerGroup extends AbstractLayer {
 	 *
 	 */
 	@ManyToMany
-	@Cascade(CascadeType.SAVE_UPDATE)
 	@JoinTable(
 		name = "LAYERGROUP_LAYERS",
 		joinColumns = { @JoinColumn(name = "LAYERGROUP_ID") },

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/appearance/LayerAppearance.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/appearance/LayerAppearance.java
@@ -8,8 +8,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
@@ -50,7 +48,6 @@ public class LayerAppearance extends PersistentObject{
 	 *
 	 */
 	@ManyToOne
-	@Cascade(CascadeType.SAVE_UPDATE)
 	// The maxResolution will be serialized (JSON)
 	// as the simple resolution value
 	@JsonIdentityInfo(
@@ -64,7 +61,6 @@ public class LayerAppearance extends PersistentObject{
 	 *
 	 */
 	@ManyToOne
-	@Cascade(CascadeType.SAVE_UPDATE)
 	// The maxResolution will be serialized (JSON)
 	// as the simple resolution value
 	@JsonIdentityInfo(

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/source/ImageWmsLayerDataSource.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/source/ImageWmsLayerDataSource.java
@@ -13,8 +13,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
@@ -49,7 +47,6 @@ public class ImageWmsLayerDataSource extends LayerDataSource {
 		inverseJoinColumns = { @JoinColumn(name = "LAYERNAME_ID") }
 	)
 	@OrderColumn(name = "IDX")
-	@Cascade(CascadeType.SAVE_UPDATE)
 	// The List of layerNames will be serialized (JSON) as an array of
 	// simple layerName string values
 	@JsonIdentityInfo(
@@ -66,7 +63,6 @@ public class ImageWmsLayerDataSource extends LayerDataSource {
 		inverseJoinColumns = { @JoinColumn(name = "STYLE_ID") }
 	)
 	@OrderColumn(name = "IDX")
-	@Cascade(CascadeType.SAVE_UPDATE)
 	// The List of layerStyles will be serialized (JSON) as an array of
 	// simple layerStyle string values
 	@JsonIdentityInfo(

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/source/TileWmsLayerDataSource.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/source/TileWmsLayerDataSource.java
@@ -14,8 +14,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
@@ -51,7 +49,6 @@ public class TileWmsLayerDataSource extends LayerDataSource {
 		inverseJoinColumns = { @JoinColumn(name = "LAYERNAME_ID") }
 	)
 	@OrderColumn(name = "IDX")
-	@Cascade(CascadeType.SAVE_UPDATE)
 	// The List of layerNames will be serialized (JSON) as an array of
 	// simple layerName string values
 	@JsonIdentityInfo(
@@ -68,7 +65,6 @@ public class TileWmsLayerDataSource extends LayerDataSource {
 		inverseJoinColumns = { @JoinColumn(name = "STYLE_ID") }
 	)
 	@OrderColumn(name = "IDX")
-	@Cascade(CascadeType.SAVE_UPDATE)
 	// The List of layerStyles will be serialized (JSON) as an array of
 	// simple layerStyle string values
 	@JsonIdentityInfo(
@@ -79,7 +75,6 @@ public class TileWmsLayerDataSource extends LayerDataSource {
 	private List<GeoWebServiceLayerStyle> layerStyles;
 
 	@ManyToOne
-	@Cascade(CascadeType.SAVE_UPDATE)
 	private WmsTileGrid tileGrid;
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/WmsTileGrid.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/WmsTileGrid.java
@@ -23,8 +23,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
@@ -72,7 +70,6 @@ public class WmsTileGrid extends PersistentObject {
 	 * the origin will be set to the top-left corner of the extent.
 	 */
 	@ManyToOne
-	@Cascade(CascadeType.SAVE_UPDATE)
 	private Extent tileGridExtent;
 
 	/**
@@ -84,7 +81,6 @@ public class WmsTileGrid extends PersistentObject {
 	 * The tileGrid resolutions.
 	 */
 	@ManyToMany
-	@Cascade(CascadeType.SAVE_UPDATE)
 	@JoinTable(
 		joinColumns = { @JoinColumn(name = "WMSTILEGRID_ID") },
 		inverseJoinColumns = { @JoinColumn(name = "RESOLUTION_ID") }

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/map/MapConfig.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/map/MapConfig.java
@@ -19,8 +19,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
@@ -67,14 +65,12 @@ public class MapConfig extends PersistentObject{
 	 *
 	 */
 	@ManyToOne
-	@Cascade(CascadeType.SAVE_UPDATE)
 	private Extent extent;
 
 	/**
 	 *
 	 */
 	@ManyToMany
-	@Cascade(CascadeType.SAVE_UPDATE)
 	@JoinTable(
 		joinColumns = { @JoinColumn(name = "MAPCONFIG_ID") },
 		inverseJoinColumns = { @JoinColumn(name = "RESOLUTION_ID") }
@@ -98,7 +94,6 @@ public class MapConfig extends PersistentObject{
 	 *
 	 */
 	@ManyToOne
-	@Cascade(CascadeType.SAVE_UPDATE)
 	// The maxResolution will be serialized (JSON)
 	// as the simple resolution value
 	@JsonIdentityInfo(
@@ -112,7 +107,6 @@ public class MapConfig extends PersistentObject{
 	 *
 	 */
 	@ManyToOne
-	@Cascade(CascadeType.SAVE_UPDATE)
 	// The minResolution will be serialized (JSON)
 	// as the simple resolution value
 	@JsonIdentityInfo(

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/CompositeModule.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/CompositeModule.java
@@ -18,8 +18,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
 
 import de.terrestris.shogun2.model.layout.Layout;
 
@@ -45,14 +43,12 @@ public class CompositeModule extends Module {
 	 * {@link CompositeModule}.
 	 */
 	@ManyToOne
-	@Cascade(CascadeType.SAVE_UPDATE)
 	private Layout layout;
 
 	/**
 	 *
 	 */
 	@ManyToMany
-	@Cascade(CascadeType.SAVE_UPDATE)
 	@JoinTable(
 		name = "MODULES_SUBMODULES",
 		joinColumns = { @JoinColumn(name = "MODULE_ID") },

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Map.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/Map.java
@@ -20,8 +20,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
 
 import de.terrestris.shogun2.model.layer.AbstractLayer;
 import de.terrestris.shogun2.model.map.MapConfig;
@@ -51,7 +49,6 @@ public class Map extends Module {
 	 * or overview maps.
 	 */
 	@ManyToOne
-	@Cascade(CascadeType.SAVE_UPDATE)
 	private MapConfig mapConfig;
 
 	/**
@@ -62,7 +59,6 @@ public class Map extends Module {
 		joinColumns = { @JoinColumn(name = "MAP_ID") },
 		inverseJoinColumns = { @JoinColumn(name = "CONTROL_ID") }
 	)
-	@Cascade(CascadeType.SAVE_UPDATE)
 	private Set<MapControl> mapControls = new HashSet<MapControl>();
 
 	/**
@@ -74,7 +70,6 @@ public class Map extends Module {
 		inverseJoinColumns = { @JoinColumn(name = "LAYER_ID") }
 	)
 	@OrderColumn(name = "IDX")
-	@Cascade(CascadeType.SAVE_UPDATE)
 	private List<AbstractLayer> mapLayers = new ArrayList<AbstractLayer>();
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/OverviewMap.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/OverviewMap.java
@@ -18,8 +18,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
@@ -66,7 +64,6 @@ public class OverviewMap extends Module {
 	 *
 	 */
 	@ManyToOne
-	@Cascade(CascadeType.SAVE_UPDATE)
 	@JsonIdentityInfo(
 		generator = ObjectIdGenerators.PropertyGenerator.class,
 		property = "name"

--- a/src/shogun2-init/src/main/java/de/terrestris/shogun2/init/ContentInitializer.java
+++ b/src/shogun2-init/src/main/java/de/terrestris/shogun2/init/ContentInitializer.java
@@ -1,18 +1,16 @@
 package de.terrestris.shogun2.init;
 
-import java.util.Set;
+import java.util.List;
+
+import javax.annotation.Resource;
 
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.authentication.AuthenticationProvider;
 
-import de.terrestris.shogun2.model.Application;
-import de.terrestris.shogun2.model.Role;
+import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.model.User;
-import de.terrestris.shogun2.model.UserGroup;
-import de.terrestris.shogun2.model.layout.Layout;
-import de.terrestris.shogun2.model.module.Module;
 import de.terrestris.shogun2.service.InitializationService;
 
 /**
@@ -36,54 +34,6 @@ public class ContentInitializer {
 	private Boolean shogunInitEnabled;
 
 	/**
-	 * Flag symbolizing if a set of default {@link Role}s should be created
-	 * up on startup. This will only happen if {@link #shogunInitEnabled} is true.
-	 */
-	@Autowired
-	@Qualifier("createDefaultRoles")
-	private Boolean createDefaultRoles;
-
-	/**
-	 * Flag symbolizing if a set of default {@link User}s should be created
-	 * up on startup. This will only happen if {@link #shogunInitEnabled} is true.
-	 */
-	@Autowired
-	@Qualifier("createDefaultUsers")
-	private Boolean createDefaultUsers;
-
-	/**
-	 * Flag symbolizing if a set of default {@link UserGroup}s should be created
-	 * up on startup. This will only happen if {@link #shogunInitEnabled} is true.
-	 */
-	@Autowired
-	@Qualifier("createDefaultUserGroups")
-	private Boolean createDefaultUserGroups;
-
-	/**
-	 * Flag symbolizing if a set of default {@link Layout}s should be created
-	 * up on startup. This will only happen if {@link #shogunInitEnabled} is true.
-	 */
-	@Autowired
-	@Qualifier("createDefaultLayouts")
-	private Boolean createDefaultLayouts;
-
-	/**
-	 * Flag symbolizing if a set of default {@link Module}s should be created
-	 * up on startup. This will only happen if {@link #shogunInitEnabled} is true.
-	 */
-	@Autowired
-	@Qualifier("createDefaultModules")
-	private Boolean createDefaultModules;
-
-	/**
-	 * Flag symbolizing if a set of default {@link Application}s should be created
-	 * up on startup. This will only happen if {@link #shogunInitEnabled} is true.
-	 */
-	@Autowired
-	@Qualifier("createDefaultApplications")
-	private Boolean createDefaultApplications;
-
-	/**
 	 * Initialization Service to init shogun content like users or default
 	 * applications.
 	 */
@@ -99,52 +49,16 @@ public class ContentInitializer {
 	protected AuthenticationProvider authenticationProvider;
 
 	/**
-	 * A set of default roles that will be created
-	 * if {@link #createDefaultRoles} is true.
+	 * The list of objects that shall be persisted.
 	 *
+	 * The order of the objects is important here (as one object may require
+	 * that another object has been created before to avoid errors like 'object
+	 * references an unsaved transient instance save the transient instance
+	 * before flushing').
 	 */
-	@Autowired(required = false)
-	private Set<Role> defaultRoles;
-
-	/**
-	 * A set of default users that will be created
-	 * if {@link #createDefaultUsers} is true.
-	 *
-	 */
-	@Autowired(required = false)
-	private Set<User> defaultUsers;
-
-	/**
-	 * A set of default userGroups that will be created
-	 * if {@link #createDefaultUserGroups} is true.
-	 *
-	 */
-	@Autowired(required = false)
-	private Set<UserGroup> defaultUserGroups;
-
-	/**
-	 * A set of default layouts that will be created
-	 * if {@link #createDefaultLayouts} is true.
-	 *
-	 */
-	@Autowired(required = false)
-	private Set<Layout> defaultLayouts;
-
-	/**
-	 * A set of default modules that will be created
-	 * if {@link #createDefaultModules} is true.
-	 *
-	 */
-	@Autowired(required = false)
-	private Set<Module> defaultModules;
-
-	/**
-	 * A set of default applications that will be created
-	 * if {@link #createDefaultApplications} is true.
-	 *
-	 */
-	@Autowired(required = false)
-	private Set<Application> defaultApplications;
+	@Resource
+	@Qualifier("objectsToCreate")
+	private List<PersistentObject> objectsToCreate;
 
 	/**
 	 * The method called on initialization
@@ -156,111 +70,18 @@ public class ContentInitializer {
 
 			LOG.info("Initializing SHOGun2 content");
 
-			if(createDefaultRoles) {
-				createDefaultRoles();
-			}
-
-			if(createDefaultUsers) {
-				createDefaultUsers();
-			}
-
-			if(createDefaultUserGroups) {
-				createDefaultUserGroups();
-			}
-
-			if(createDefaultLayouts) {
-				createDefaultLayouts();
-			}
-
-			if(createDefaultModules) {
-				createDefaultModules();
-			}
-
-			if(createDefaultApplications) {
-				createDefaultApplications();
+			for (PersistentObject object : objectsToCreate) {
+				if(object instanceof User) {
+					// special handling of users to encrypt the password!
+					initService.saveUser((User) object);
+				} else {
+					initService.savePersistentObject(object);
+				}
 			}
 
 		} else {
 			LOG.info("Not initializing anything for SHOGun2.");
 		}
-	}
-
-	/**
-	 * Creates the {@link User}s defined in {@link #defaultUsers}
-	 */
-	private void createDefaultRoles() {
-		LOG.info("Creating a set of default roles.");
-
-		for (Role role : defaultRoles) {
-			initService.createRole(role);
-		}
-
-		LOG.info("Created a total of " + defaultRoles.size() + " default roles.");
-	}
-
-	/**
-	 * Creates the {@link User}s defined in {@link #defaultUsers}
-	 */
-	private void createDefaultUsers() {
-		LOG.info("Creating a set of default users.");
-
-		for (User user : defaultUsers) {
-			initService.createUser(user);
-		}
-
-		LOG.info("Created a total of " + defaultUsers.size() + " default users.");
-	}
-
-	/**
-	 * Creates the {@link UserGroup}s defined in {@link #defaultUserGroups}
-	 */
-	private void createDefaultUserGroups() {
-		LOG.info("Creating a set of default user groups.");
-
-		for (UserGroup userGroup : defaultUserGroups) {
-			initService.createUserGroup(userGroup);
-		}
-
-		LOG.info("Created a total of " + defaultUserGroups.size() + " default user groups.");
-	}
-
-	/**
-	 * Creates the {@link Layout}s defined in {@link #defaultLayouts}
-	 */
-	private void createDefaultLayouts() {
-		LOG.info("Creating a set of default layouts.");
-
-		for (Layout layout : defaultLayouts) {
-			initService.createLayout(layout);
-		}
-
-		LOG.info("Created a total of " + defaultLayouts.size() + " default layouts.");
-	}
-
-	/**
-	 * Creates the {@link Module}s defined in {@link #defaultApplications}
-	 */
-	private void createDefaultModules() {
-		LOG.info("Creating a set of default modules.");
-
-		for (Module module : defaultModules) {
-			initService.createModule(module);
-		}
-
-		LOG.info("Created a total of " + defaultModules.size() + " default modules.");
-	}
-
-	/**
-	 * Creates the {@link Application}s defined in {@link #defaultApplications}
-	 */
-	private void createDefaultApplications() {
-		LOG.info("Creating a set of default applications.");
-
-		for (Application app : defaultApplications) {
-			initService.createApplication(app);
-		}
-
-		LOG.info("Created a total of " + defaultApplications.size() + " default applications.");
 	}
 
 }

--- a/src/shogun2-security/pom.xml
+++ b/src/shogun2-security/pom.xml
@@ -31,11 +31,6 @@
 
         <dependency>
             <groupId>org.springframework</groupId>
-            <artifactId>spring-aop</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
         </dependency>
 
@@ -58,17 +53,6 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-acl</artifactId>
-        </dependency>
-
-        <!-- AspectJ -->
-        <dependency>
-            <groupId>org.aspectj</groupId>
-            <artifactId>aspectjrt</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.aspectj</groupId>
-            <artifactId>aspectjweaver</artifactId>
         </dependency>
 
         <!-- ehcache -->

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/__artifactId__-init.properties
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/__artifactId__-init.properties
@@ -10,27 +10,3 @@ init.shogunInitEnabled=true
 
 ${symbol_pound} Whether the ProjectContentInitializer (of the this project) should init content or not
 init.projectInitEnabled=true
-
-${symbol_pound} Whether the set of default roles should be created or not.
-${symbol_pound} This will only have effect if shogunInitEnabled is true.
-init.createDefaultRoles=true
-
-${symbol_pound} Whether the set of default users should be created or not.
-${symbol_pound} This will only have effect if shogunInitEnabled is true.
-init.createDefaultUsers=true
-
-${symbol_pound} Whether the set of default userGroups should be created or not.
-${symbol_pound} This will only have effect if shogunInitEnabled is true.
-init.createDefaultUserGroups=true
-
-${symbol_pound} Whether the set of default layouts should be created or not.
-${symbol_pound} This will only have effect if shogunInitEnabled is true.
-init.createDefaultLayouts=true
-
-${symbol_pound} Whether the set of default modules should be created or not.
-${symbol_pound} This will only have effect if shogunInitEnabled is true.
-init.createDefaultModules=true
-
-${symbol_pound} Whether the set of default applications should be created or not.
-${symbol_pound} This will only have effect if shogunInitEnabled is true.
-init.createDefaultApplications=true

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-init.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-init.xml
@@ -24,34 +24,4 @@
     <bean id="contentInitializer" class="${package}.init.ProjectContentInitializer"
         init-method="initializeDatabaseContent" />
 
-    <!-- Flag enabling/disabling the creation of default roles on startup -->
-    <bean id="createDefaultRoles" class="java.lang.Boolean">
-        <constructor-arg value="${init.createDefaultRoles}"></constructor-arg>
-    </bean>
-
-    <!-- Flag enabling/disabling the creation of default users on startup -->
-    <bean id="createDefaultUsers" class="java.lang.Boolean">
-        <constructor-arg value="${symbol_dollar}{init.createDefaultUsers}"></constructor-arg>
-    </bean>
-
-    <!-- Flag enabling/disabling the creation of default userGroups on startup -->
-    <bean id="createDefaultUserGroups" class="java.lang.Boolean">
-        <constructor-arg value="${init.createDefaultUserGroups}"></constructor-arg>
-    </bean>
-
-    <!-- Flag enabling/disabling the creation of default layouts on startup -->
-    <bean id="createDefaultLayouts" class="java.lang.Boolean">
-        <constructor-arg value="${symbol_dollar}{init.createDefaultLayouts}"></constructor-arg>
-    </bean>
-
-    <!-- Flag enabling/disabling the creation of default modules on startup -->
-    <bean id="createDefaultModules" class="java.lang.Boolean">
-        <constructor-arg value="${symbol_dollar}{init.createDefaultModules}"></constructor-arg>
-    </bean>
-
-    <!-- Flag enabling/disabling the creation of default modules on startup -->
-    <bean id="createDefaultApplications" class="java.lang.Boolean">
-        <constructor-arg value="${symbol_dollar}{init.createDefaultApplications}"></constructor-arg>
-    </bean>
-
 </beans>

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-initialize-beans.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-initialize-beans.xml
@@ -10,6 +10,96 @@
                            http://www.springframework.org/schema/util
                            http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!--
+      The list of objects that shall be persisted.
+
+      The order of the objects is important here (as one object may require
+      that another object has been created before to avoid errors like 'object
+      references an unsaved transient instance save the transient instance
+      before flushing').
+    -->
+    <util:list id="objectsToCreate">
+
+        <!-- Roles -->
+        <ref bean="adminRole"/>
+        <ref bean="userRole"/>
+
+        <!-- Users -->
+        <ref bean="adminUser"/>
+        <ref bean="defaultUser"/>
+
+        <!-- UserGroups -->
+        <ref bean="adminUserGroup"/>
+        <ref bean="defaultUserGroup"/>
+
+        <!-- Layouts -->
+        <ref bean="borderLayout"/>
+        <ref bean="absoluteLayout"/>
+        <ref bean="hboxLayout"/>
+
+        <!-- Resolutions -->
+        <ref bean="res01" />
+        <ref bean="res02" />
+        <ref bean="res03" />
+        <ref bean="res04" />
+        <ref bean="res05" />
+        <ref bean="res06" />
+        <ref bean="res07" />
+        <ref bean="res08" />
+        <ref bean="res09" />
+        <ref bean="res10" />
+        <ref bean="res11" />
+        <ref bean="res12" />
+        <ref bean="res13" />
+        <ref bean="res14" />
+        <ref bean="res15" />
+        <ref bean="res16" />
+        <ref bean="res17" />
+        <ref bean="res18" />
+        <ref bean="res19" />
+
+        <!-- Layer sources/appearance -->
+        <ref bean="osmWmsLayerTileGridExtent" />
+
+        <ref bean="osmWmsLayerTileGrid" />
+
+        <ref bean="osmWmsLayerName" />
+        <ref bean="osmWmsLayerStyle" />
+
+        <ref bean="osmWmsLayerDataSource" />
+        <ref bean="osmWmsLayerGrayDataSource" />
+        <ref bean="osmWmsLayerAppearance" />
+
+        <!-- Layers -->
+        <ref bean="osmWmsLayer" />
+        <ref bean="osmWmsLayerGray" />
+
+        <!-- Controls -->
+        <ref bean="controlAttribution" />
+        <ref bean="controlZoom" />
+        <ref bean="controlRotate" />
+        <ref bean="controlZoomSlider" />
+        <ref bean="controlScaleLine" />
+
+        <!-- Map config -->
+        <ref bean="mapConfigExtent" />
+        <ref bean="mapConfig" />
+
+        <!-- Modules -->
+        <ref bean="headerLogoModule" />
+        <ref bean="headerTitleModule" />
+        <ref bean="headerModule" />
+        <ref bean="layerTreeModule" />
+        <ref bean="mapModule" />
+        <ref bean="viewportModule" />
+
+        <!-- Permissions -->
+        <ref bean="defaultUserPermissionCollection" />
+
+        <!-- Applications -->
+        <ref bean="defaultApplication"/>
+    </util:list>
+
     <!-- Define roles -->
     <bean id="adminRole" class="de.terrestris.shogun2.model.Role">
         <property name="name" value="${symbol_dollar}{role.superAdminRoleName}"/>
@@ -186,8 +276,24 @@
         <property name="resolution" value="0.5971642833948135" />
     </bean>
 
+    <!-- Default extent -->
+    <bean id="mapConfigExtent" class="de.terrestris.shogun2.model.layer.util.Extent">
+        <property name="lowerLeft">
+            <bean class="java.awt.geom.Point2D$Double">
+                <constructor-arg index="0" value="-20026376.39" />
+                <constructor-arg index="1" value="-20048966.10" />
+            </bean>
+        </property>
+        <property name="upperRight">
+            <bean class="java.awt.geom.Point2D$Double">
+                <constructor-arg index="0" value="20026376.39" />
+                <constructor-arg index="1" value="20048966.10" />
+            </bean>
+        </property>
+    </bean>
+
     <!-- Define the MapConfig -->
-    <bean id="mapConfigModule" class="de.terrestris.shogun2.model.map.MapConfig">
+    <bean id="mapConfig" class="de.terrestris.shogun2.model.map.MapConfig">
         <property name="name" value="default" />
         <property name="center">
             <bean class="java.awt.geom.Point2D$Double">
@@ -221,20 +327,7 @@
             </util:list>
         </property>
         <property name="extent">
-            <bean class="de.terrestris.shogun2.model.layer.util.Extent">
-                <property name="lowerLeft">
-                    <bean class="java.awt.geom.Point2D$Double">
-                        <constructor-arg index="0" value="-20026376.39" />
-                        <constructor-arg index="1" value="-20048966.10" />
-                    </bean>
-                </property>
-                <property name="upperRight">
-                    <bean class="java.awt.geom.Point2D$Double">
-                        <constructor-arg index="0" value="20026376.39" />
-                        <constructor-arg index="1" value="20048966.10" />
-                    </bean>
-                </property>
-            </bean>
+            <ref bean="mapConfigExtent" />
         </property>
         <property name="projection" value="3857" />
         <property name="rotation" value="0" />
@@ -283,14 +376,14 @@
         </property>
     </bean>
 
-    <bean id="osmWmsLayerTileGridOrigin" class="java.awt.geom.Point2D$Double">
-        <constructor-arg index="0" value="0" />
-        <constructor-arg index="1" value="0" />
-    </bean>
-
     <bean id="osmWmsLayerTileGrid" class="de.terrestris.shogun2.model.layer.util.WmsTileGrid">
         <property name="type" value="TileGrid" />
-        <property name="tileGridOrigin" ref="osmWmsLayerTileGridOrigin" />
+        <property name="tileGridOrigin">
+            <bean class="java.awt.geom.Point2D$Double">
+                <constructor-arg index="0" value="0" />
+                <constructor-arg index="1" value="0" />
+            </bean>
+        </property>
         <property name="tileGridExtent" ref="osmWmsLayerTileGridExtent" />
         <property name="tileSize" value="256" />
         <property name="tileGridResolutions">
@@ -388,7 +481,7 @@
     <bean id="mapModule" class="de.terrestris.shogun2.model.module.Map">
         <property name="name" value="Main Map" />
         <property name="xtype" value="shogun-component-map" />
-        <property name="mapConfig" ref="mapConfigModule" />
+        <property name="mapConfig" ref="mapConfig" />
         <property name="mapLayers">
             <util:list>
                 <ref bean="osmWmsLayer" />

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context.xml
@@ -14,12 +14,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
                            http://www.springframework.org/schema/beans/spring-beans.xsd
                            http://www.springframework.org/schema/context
-                           http://www.springframework.org/schema/context/spring-context.xsd
-                           http://www.springframework.org/schema/aop
-                           http://www.springframework.org/schema/aop/spring-aop.xsd">
-
-    <!-- Enable AspectJ auto proxy -->
-    <aop:aspectj-autoproxy />
+                           http://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:property-placeholder location="classpath*:META-INF/*.properties" />
 


### PR DESCRIPTION
Until now, we had a vast quantity of `@Cascade(CascadeType.SAVE_UPDATE)` annotations in our models. This may not only lead to performance problems, but also resulted in serious problems when we tried to implement the removal of object references (where a deleted entity would have been recreated immediately due to an `@Cascade` annotation).

This PR removes ALL the `@Cascade` annotations and additionally simplifies the `ContentInitializer` a lot, which allows us to implement the above mentioned functionality.

The main difference of the "new" approach is that the `ContentInitializer` is now based on the following "generic" list of arbitrary `PersistentObject`s:

```Java
@Resource
@Qualifier("objectsToCreate")
private List<PersistentObject> objectsToCreate;
```

In this list (which is configured as a list of beans in the init-beans-XML from the archetype), the order of the elements is important as some objects may require the existence of related objects to avoid errors like `'object references an unsaved transient instance save the transient instance before flushing'`

Nobody wants to "forbid" the use of `@Cascade` annotations, but they should only be used where it really makes sense.