### PR TITLE
Introduces setLayersForMap in MapService

### DIFF
--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/AbstractLayerService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/AbstractLayerService.java
@@ -75,14 +75,14 @@ public class AbstractLayerService<E extends AbstractLayer, D extends AbstractLay
 	 * @throws Exception
 	 */
 	@SuppressWarnings("unchecked")
-	public List<AbstractLayer> setLayersForLayerGroup (Integer layerGroupId, List<String> abstractLayerIds) throws Exception{
+	public List<AbstractLayer> setLayersForLayerGroup (Integer layerGroupId, List<Integer> abstractLayerIds) throws Exception{
 		E abstractlayer = this.findById(layerGroupId);
 		List<AbstractLayer> layers = new ArrayList<AbstractLayer>();
 
 		if(abstractlayer instanceof LayerGroup) {
 			LayerGroup layerGroup = (LayerGroup) abstractlayer;
-			for (String id : abstractLayerIds) {
-				AbstractLayer layer = this.findById(Integer.parseInt(id));
+			for (Integer id : abstractLayerIds) {
+				AbstractLayer layer = this.findById(id);
 				if(layer != null){
 					layers.add(layer);
 				}

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/MapService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/MapService.java
@@ -75,14 +75,14 @@ public class MapService<E extends Map, D extends MapDao<E>> extends
 	 * @throws Exception
 	 */
 	@SuppressWarnings("unchecked")
-	public List<AbstractLayer> setLayersForMap (Integer mapModuleId, List<String> abstractLayerIds) throws Exception{
+	public List<AbstractLayer> setLayersForMap (Integer mapModuleId, List<Integer> abstractLayerIds) throws Exception{
 		E module = this.findById(mapModuleId);
 		List<AbstractLayer> layers = new ArrayList<AbstractLayer>();
 
 		if(module instanceof Map) {
 			Map mapModule = (Map) module;
-			for (String id : abstractLayerIds) {
-				PersistentObject entity = this.abstractLayerService.findById(Integer.parseInt(id));
+			for (Integer id : abstractLayerIds) {
+				PersistentObject entity = this.abstractLayerService.findById(id);
 				if(entity instanceof AbstractLayer){
 					AbstractLayer layer = (AbstractLayer) entity;
 					if(layer != null){

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/MapService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/MapService.java
@@ -94,7 +94,7 @@ public class MapService<E extends Map, D extends MapDao<E>> extends
 			this.saveOrUpdate((E) mapModule);
 			return layers;
 		} else {
-			throw new Exception("Layer of with given Id is not a LayerGroup.");
+			throw new Exception("Can't find mapModule with id " + mapModuleId.toString());
 		}
 
 	}

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/MapService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/MapService.java
@@ -1,12 +1,16 @@
 package de.terrestris.shogun2.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
+import de.terrestris.shogun2.dao.AbstractLayerDao;
 import de.terrestris.shogun2.dao.MapDao;
+import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.model.layer.AbstractLayer;
 import de.terrestris.shogun2.model.module.Map;
 import de.terrestris.shogun2.model.module.Module;
@@ -21,6 +25,10 @@ import de.terrestris.shogun2.model.module.Module;
 @Service("mapService")
 public class MapService<E extends Map, D extends MapDao<E>> extends
 		ModuleService<E, D> {
+
+	@Autowired
+	@Qualifier("abstractLayerService")
+	private AbstractLayerService<AbstractLayer, AbstractLayerDao<AbstractLayer>> abstractLayerService;
 
 	/**
 	 * Default constructor, which calls the type-constructor
@@ -57,5 +65,37 @@ public class MapService<E extends Map, D extends MapDao<E>> extends
 	 */
 	public Set<E> findMapsWithLayer(AbstractLayer layer) {
 		return dao.findMapsWithLayer(layer);
+	}
+
+	/**
+	 *
+	 * @param MapModuleId
+	 * @param abstractLayerIds
+	 * @return
+	 * @throws Exception
+	 */
+	@SuppressWarnings("unchecked")
+	public List<AbstractLayer> setLayersForMap (Integer mapModuleId, List<String> abstractLayerIds) throws Exception{
+		E module = this.findById(mapModuleId);
+		List<AbstractLayer> layers = new ArrayList<AbstractLayer>();
+
+		if(module instanceof Map) {
+			Map mapModule = (Map) module;
+			for (String id : abstractLayerIds) {
+				PersistentObject entity = this.abstractLayerService.findById(Integer.parseInt(id));
+				if(entity instanceof AbstractLayer){
+					AbstractLayer layer = (AbstractLayer) entity;
+					if(layer != null){
+						layers.add(layer);
+					}
+				}
+			}
+			mapModule.setMapLayers(layers);
+			this.saveOrUpdate((E) mapModule);
+			return layers;
+		} else {
+			throw new Exception("Layer of with given Id is not a LayerGroup.");
+		}
+
 	}
 }

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/AbstractLayerController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/AbstractLayerController.java
@@ -83,7 +83,7 @@ public class AbstractLayerController<E extends AbstractLayer, D extends Abstract
 	 */
 	@RequestMapping(value = "/setLayersForLayerGroup.action", method = RequestMethod.POST)
 	public @ResponseBody Map<String, Object> setLayersForLayerGroup(
-			Integer layerGroupId, @RequestParam("abstractLayerIds") List<String> abstractLayerIds) {
+			Integer layerGroupId, @RequestParam("abstractLayerIds") List<Integer> abstractLayerIds) {
 
 		try {
 			List<AbstractLayer> layers = this.service.setLayersForLayerGroup(layerGroupId, abstractLayerIds);

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/AbstractLayerController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/AbstractLayerController.java
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import de.terrestris.shogun2.dao.AbstractLayerDao;
@@ -83,7 +82,7 @@ public class AbstractLayerController<E extends AbstractLayer, D extends Abstract
 	 */
 	@RequestMapping(value = "/setLayersForLayerGroup.action", method = RequestMethod.POST)
 	public @ResponseBody Map<String, Object> setLayersForLayerGroup(
-			Integer layerGroupId, @RequestParam("abstractLayerIds") List<Integer> abstractLayerIds) {
+			Integer layerGroupId, List<Integer> abstractLayerIds) {
 
 		try {
 			List<AbstractLayer> layers = this.service.setLayersForLayerGroup(layerGroupId, abstractLayerIds);

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/MapController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/MapController.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import de.terrestris.shogun2.dao.MapDao;
@@ -65,13 +64,13 @@ public class MapController<E extends Map, D extends MapDao<E>, S extends MapServ
 	 */
 	@RequestMapping(value = "/setLayersForMap.action", method = RequestMethod.POST)
 	public @ResponseBody java.util.Map<String, Object> setLayersForMap(
-			Integer mapModuleId, @RequestParam("abstractLayerIds") List<Integer> abstractLayerIds) {
+			Integer mapModuleId, List<Integer> abstractLayerIds) {
 
 		try {
 			List<AbstractLayer> layers = this.service.setLayersForMap(mapModuleId, abstractLayerIds);
 			return ResultSet.success(layers);
 		} catch (Exception e) {
-			return ResultSet.error("Could not set Layers for LayerGroup");
+			return ResultSet.error("Could not set Layers for Map");
 		}
 	}
 	

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/MapController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/MapController.java
@@ -1,0 +1,78 @@
+/**
+ *
+ */
+package de.terrestris.shogun2.web;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import de.terrestris.shogun2.dao.MapDao;
+import de.terrestris.shogun2.model.layer.AbstractLayer;
+import de.terrestris.shogun2.model.module.Map;
+import de.terrestris.shogun2.service.MapService;
+import de.terrestris.shogun2.util.data.ResultSet;
+
+/**
+ * @author Johannes Weskamm
+ * @author Kai Volland
+ *
+ */
+@Controller
+@RequestMapping("/maps")
+public class MapController<E extends Map, D extends MapDao<E>, S extends MapService<E, D>>{
+
+	protected S service;
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct service here.
+	 * Otherwise, spring can not decide which service has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Autowired
+	@Qualifier("mapService")
+	public void setService(S service) {
+		this.service = service;
+	}
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public MapController() {
+		this((Class<E>) Map.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete type for this controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected MapController(Class<E> type) {
+		super();
+	}
+
+	/**
+	 * 
+	 * @param moduleId
+	 * @param toolIds
+	 * @return
+	 */
+	@RequestMapping(value = "/setLayersForMap.action", method = RequestMethod.POST)
+	public @ResponseBody java.util.Map<String, Object> setLayersForMap(
+			Integer mapModuleId, @RequestParam("abstractLayerIds") List<String> abstractLayerIds) {
+
+		try {
+			List<AbstractLayer> layers = this.service.setLayersForMap(mapModuleId, abstractLayerIds);
+			return ResultSet.success(layers);
+		} catch (Exception e) {
+			return ResultSet.error("Could not set Layers for LayerGroup");
+		}
+	}
+	
+}

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/MapController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/MapController.java
@@ -65,7 +65,7 @@ public class MapController<E extends Map, D extends MapDao<E>, S extends MapServ
 	 */
 	@RequestMapping(value = "/setLayersForMap.action", method = RequestMethod.POST)
 	public @ResponseBody java.util.Map<String, Object> setLayersForMap(
-			Integer mapModuleId, @RequestParam("abstractLayerIds") List<String> abstractLayerIds) {
+			Integer mapModuleId, @RequestParam("abstractLayerIds") List<Integer> abstractLayerIds) {
 
 		try {
 			List<AbstractLayer> layers = this.service.setLayersForMap(mapModuleId, abstractLayerIds);


### PR DESCRIPTION
This PR contains the needed code to update the list of layers contained by a mapmodule.

Posting to the MapController with a `mapModuleId` and a list of `abstractLayerIds` updates the contained layers. If the list is empty all layers will be removed.