### PR TITLE
Added groups to the user model / service

### DIFF
--- a/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/UserGroupDao.java
+++ b/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/UserGroupDao.java
@@ -1,14 +1,7 @@
 package de.terrestris.shogun2.dao;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import org.hibernate.Criteria;
-import org.hibernate.HibernateException;
-import org.hibernate.criterion.Restrictions;
 import org.springframework.stereotype.Repository;
 
-import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.model.UserGroup;
 
 @Repository("userGroupDao")
@@ -30,19 +23,6 @@ public class UserGroupDao<E extends UserGroup> extends
 	 */
 	protected UserGroupDao(Class<E> clazz) {
 		super(clazz);
-	}
-
-	/**
-	 *
-	 */
-	@SuppressWarnings("unchecked")
-	public Set<E> findGroupsOfUser(User user) throws HibernateException {
-		Criteria criteria = createDistinctRootEntityCriteria();
-
-		criteria.createAlias("members", "m");
-		criteria.add(Restrictions.eq("m.id", user.getId()));
-
-		return new HashSet<E>(criteria.list());
 	}
 
 }

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/User.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/User.java
@@ -8,16 +8,20 @@ import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
+import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import ch.rasc.extclassgenerator.Model;
-
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
+
+import ch.rasc.extclassgenerator.Model;
 
 /**
  * @author Nils Bühner
@@ -50,6 +54,20 @@ public class User extends Person {
 		inverseJoinColumns = { @JoinColumn(name = "ROLE_ID") }
 	)
 	private Set<Role> roles = new HashSet<Role>();
+
+	@ManyToMany
+	@JoinTable(
+		name = "user_usergroup",
+		joinColumns = { @JoinColumn(name = "USER_ID") },
+		inverseJoinColumns = { @JoinColumn(name = "USERGROUP_ID") }
+	)
+	@OrderColumn(name = "IDX")
+	@JsonIdentityInfo(
+		generator = ObjectIdGenerators.PropertyGenerator.class,
+		property = "id"
+	)
+	@JsonIdentityReference(alwaysAsId = true)
+	private Set<UserGroup> userGroups = new HashSet<UserGroup>();
 
 	/**
 	 * Default constructor
@@ -113,6 +131,20 @@ public class User extends Person {
 	 */
 	public void setRoles(Set<Role> roles) {
 		this.roles = roles;
+	}
+
+	/**
+	 * @return the userGroups
+	 */
+	public Set<UserGroup> getUserGroups() {
+		return userGroups;
+	}
+
+	/**
+	 * @param userGroups the userGroups to set
+	 */
+	public void setUserGroups(Set<UserGroup> userGroups) {
+		this.userGroups = userGroups;
 	}
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/UserGroup.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/UserGroup.java
@@ -37,6 +37,7 @@ public class UserGroup extends PersistentObject {
 
 	@ManyToMany
 	@JoinTable(
+		name = "user_usergroup",
 		joinColumns = { @JoinColumn(name = "USERGROUP_ID") },
 		inverseJoinColumns = { @JoinColumn(name = "USER_ID") }
 	)

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserGroupService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserGroupService.java
@@ -1,13 +1,10 @@
 package de.terrestris.shogun2.service;
 
-import java.util.Set;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import de.terrestris.shogun2.dao.UserGroupDao;
-import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.model.UserGroup;
 
 /**
@@ -35,10 +32,6 @@ public class UserGroupService<E extends UserGroup, D extends UserGroupDao<E>>
 	 */
 	protected UserGroupService(Class<E> entityClass) {
 		super(entityClass);
-	}
-
-	public Set<E> findGroupsOfUser(User user) {
-		return dao.findGroupsOfUser(user);
 	}
 
 	/**

--- a/src/shogun2-security/src/main/java/de/terrestris/shogun2/security/Shogun2AuthenticationProvider.java
+++ b/src/shogun2-security/src/main/java/de/terrestris/shogun2/security/Shogun2AuthenticationProvider.java
@@ -89,8 +89,8 @@ public class Shogun2AuthenticationProvider implements AuthenticationProvider {
 			// check if rawPassword matches the hash from db
 			if(passwordEncoder.matches(rawPassword, encryptedPassword)) {
 
-				// collect all roles of the user
-				Set<UserGroup> userGroups = userGroupService.findGroupsOfUser(user);
+				// collect all roles and groups of the user
+				Set<UserGroup> userGroups = user.getUserGroups();
 
 				Set<Role> allUserRoles = getAllUserRoles(user, userGroups);
 


### PR DESCRIPTION
This PR adds usergroups to the usermodel. This way we can retrieve the assigned groups directly from the user instead of using the removed `findGroupsOfUser` function in the usergroup service