### PR TITLE
GeoServer interceptor

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -183,6 +183,9 @@
         <!-- Apache HTTP Client -->
         <apache-httpclient.version>4.5.2</apache-httpclient.version>
 
+        <!-- Java XML Parser -->
+        <jaxp-api.version>1.4.5</jaxp-api.version>
+
         <downloadSources>true</downloadSources>
         <downloadJavadocs>true</downloadJavadocs>
     </properties>
@@ -727,6 +730,12 @@
                 <groupId>com.icegreen</groupId>
                 <artifactId>greenmail</artifactId>
                 <version>${greenmail.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.xml</groupId>
+                <artifactId>jaxp-api</artifactId>
+                <version>${jaxp-api.version}</version>
             </dependency>
 
         </dependencies>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -186,6 +186,9 @@
         <!-- Java XML Parser -->
         <jaxp-api.version>1.4.5</jaxp-api.version>
 
+        <!-- Powermock -->
+        <powermock.version>1.6.4</powermock.version>
+
         <downloadSources>true</downloadSources>
         <downloadJavadocs>true</downloadJavadocs>
     </properties>
@@ -580,6 +583,19 @@
                 <scope>test</scope>
             </dependency>
 
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-junit4</artifactId>
+                <version>${powermock.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito</artifactId>
+                <version>${powermock.version}</version>
+                  <scope>test</scope>
+            </dependency>
 
             <!-- JsonPath -->
             <dependency>

--- a/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/InterceptorRuleDao.java
+++ b/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/InterceptorRuleDao.java
@@ -51,8 +51,9 @@ public class InterceptorRuleDao<E extends InterceptorRule>
 		Criteria criteria = createDistinctRootEntityCriteria();
 
 		for (Entry<String, String> filter : filterMap.entrySet()) {
-			if (StringUtils.isNoneEmpty(filter.getValue())) {
-				criteria.add(Restrictions.like(filter.getKey(), filter.getValue()));
+			if (StringUtils.isNotEmpty(filter.getValue())) {
+				criteria.add(Restrictions.eq(filter.getKey(),
+						filter.getValue()).ignoreCase());
 			} else {
 				criteria.add(Restrictions.isNull(filter.getKey()));
 			}

--- a/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/InterceptorRuleDao.java
+++ b/src/shogun2-core/shogun2-dao/src/main/java/de/terrestris/shogun2/dao/InterceptorRuleDao.java
@@ -1,0 +1,66 @@
+package de.terrestris.shogun2.dao;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hibernate.Criteria;
+import org.hibernate.criterion.Restrictions;
+import org.springframework.stereotype.Repository;
+
+import de.terrestris.shogun2.model.interceptor.InterceptorRule;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author Kai Volland
+ * @author terrestris GmbH & Co. KG
+ *
+ * @param <E>
+ */
+@Repository("interceptorRuleDao")
+public class InterceptorRuleDao<E extends InterceptorRule>
+		extends GenericHibernateDao<E, Integer> {
+
+	/**
+	 * Public default constructor for this DAO.
+	 */
+	@SuppressWarnings("unchecked")
+	public InterceptorRuleDao() {
+		super((Class<E>) InterceptorRule.class);
+	}
+
+	/**
+	 * Constructor that has to be called by subclasses.
+	 *
+	 * @param clazz
+	 */
+	protected InterceptorRuleDao(Class<E> clazz) {
+		super(clazz);
+	}
+
+	/**
+	 *
+	 * @param filterMap
+	 * @return
+	 */
+	@SuppressWarnings("unchecked")
+	public List<E> findSpecificRule(Map<String, String> filterMap) {
+
+		Criteria criteria = createDistinctRootEntityCriteria();
+
+		for (Entry<String, String> filter : filterMap.entrySet()) {
+			if (StringUtils.isNoneEmpty(filter.getValue())) {
+				criteria.add(Restrictions.like(filter.getKey(), filter.getValue()));
+			} else {
+				criteria.add(Restrictions.isNull(filter.getKey()));
+			}
+		}
+
+		List<E> result = criteria.list();
+
+		return result;
+	}
+
+}

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/interceptor/InterceptorRule.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/interceptor/InterceptorRule.java
@@ -1,0 +1,219 @@
+package de.terrestris.shogun2.model.interceptor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import de.terrestris.shogun2.model.PersistentObject;
+
+/**
+ * The model representing the rules for the GeoServer Interceptor class.
+ *
+ * A rule is following the schema:
+ *
+ * <event>.<service>.<operation>.<endPoint>=<rule>
+ *
+ * The rules will be evaluated for every request where we determine the most
+ * specific rule to apply.
+ *
+ * Allowed values for the rule are ALLOW, DENY, MODIFY.
+ * Allowed values for the event are REQUEST and RESPONSE.
+ *
+ * @author Daniel Koch
+ * @author Kai Volland
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+@Entity
+@Table
+public class InterceptorRule extends PersistentObject {
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * The event for this rule, possible values are:
+	 *   * REQUEST
+	 *   * RESPONSE
+	 */
+	@Column(nullable = false)
+	private String event;
+
+	/**
+	 * The rule type for this rule, possible rules are:
+	 *   * ALLOW
+	 *   * DENY
+	 *   * MODIFY
+	 */
+	@Column(nullable = false)
+	private String rule;
+
+	/**
+	 * The OGC service type, e.g. WMS, WFS or WCS.
+	 */
+	@Column(nullable = false)
+	private String service;
+
+	/**
+	 * The OGC operation type, e.g. GetMap.
+	 */
+	private String operation;
+
+	/**
+	 * The OGC/GeoServer endPoint (a generalization for layer, featureType,
+	 * coverage or namespace), e.g. SHOGUN:SHINJI.
+	 */
+	private String endPoint;
+
+	/**
+	 *
+	 */
+	public InterceptorRule() {
+	}
+
+	/**
+	 *
+	 * @param rule
+	 * @param service
+	 * @param operation
+	 * @param endPoint
+	 */
+	public InterceptorRule(String event, String rule, String service,
+			String operation, String endPoint) {
+		this.event = event;
+		this.rule = rule;
+		this.service = service;
+		this.operation = operation;
+		this.endPoint = endPoint;
+	}
+
+	/**
+	 * @return the event
+	 */
+	public String getEvent() {
+		return event;
+	}
+
+	/**
+	 * @param event the event to set
+	 */
+	public void setEvent(String event) {
+		this.event = event;
+	}
+
+	/**
+	 * @return the rule
+	 */
+	public String getRule() {
+		return rule;
+	}
+
+	/**
+	 * @param rule the rule to set
+	 */
+	public void setRule(String rule) {
+		this.rule = rule;
+	}
+
+	/**
+	 * @return the service
+	 */
+	public String getService() {
+		return service;
+	}
+
+	/**
+	 * @param service the service to set
+	 */
+	public void setService(String service) {
+		this.service = service;
+	}
+
+	/**
+	 * @return the operation
+	 */
+	public String getOperation() {
+		return operation;
+	}
+
+	/**
+	 * @param operation the operation to set
+	 */
+	public void setOperation(String operation) {
+		this.operation = operation;
+	}
+
+	/**
+	 * @return the endPoint
+	 */
+	public String getEndPoint() {
+		return endPoint;
+	}
+
+	/**
+	 * @param endPoint the endPoint to set
+	 */
+	public void setEndPoint(String endPoint) {
+		this.endPoint = endPoint;
+	}
+
+	/**
+	 * @see java.lang.Object#hashCode()
+	 *
+	 *      According to
+	 *      http://stackoverflow.com/questions/27581/overriding-equals
+	 *      -and-hashcode-in-java it is recommended only to use getter-methods
+	 *      when using ORM like Hibernate
+	 */
+	@Override
+	public int hashCode() {
+		// two randomly chosen prime numbers
+		return new HashCodeBuilder(19, 89).
+				appendSuper(super.hashCode()).
+				append(getEvent()).
+				append(getRule()).
+				append(getService()).
+				append(getOperation()).
+				append(getEndPoint()).
+				toHashCode();
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 *
+	 *      According to
+	 *      http://stackoverflow.com/questions/27581/overriding-equals
+	 *      -and-hashcode-in-java it is recommended only to use getter-methods
+	 *      when using ORM like Hibernate
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof InterceptorRule))
+			return false;
+		InterceptorRule other = (InterceptorRule) obj;
+
+		return new EqualsBuilder().
+				appendSuper(super.equals(other)).
+				append(getEvent(), other.getEvent()).
+				append(getRule(), other.getRule()).
+				append(getService(), other.getService()).
+				append(getOperation(), other.getOperation()).
+				append(getEndPoint(), other.getEndPoint()).
+				isEquals();
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
+	}
+}

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/interceptor/InterceptorRule.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/interceptor/InterceptorRule.java
@@ -7,7 +7,6 @@ import javax.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.shogun2.model.PersistentObject;
 
@@ -209,11 +208,18 @@ public class InterceptorRule extends PersistentObject {
 				isEquals();
 	}
 
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
+	/**
+	 *
 	 */
 	@Override
 	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
+		return new ToStringBuilder(this)
+				.appendSuper(super.toString())
+				.append("event", getEvent())
+				.append("rule", getRule())
+				.append("service", getService())
+				.append("operation", getOperation())
+				.append("endPoint", getEndPoint())
+				.toString();
 	}
 }

--- a/src/shogun2-core/shogun2-service/pom.xml
+++ b/src/shogun2-core/shogun2-service/pom.xml
@@ -58,6 +58,17 @@
             <artifactId>mockito-core</artifactId>
         </dependency>
 
+        <!-- Powermock -->
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+        </dependency>
+
         <!-- ExtDirectSpring -->
         <dependency>
             <groupId>ch.ralscha</groupId>

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
@@ -17,6 +17,7 @@ import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpException;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ContentType;
@@ -95,9 +96,11 @@ public class GeoServerInterceptorService {
 	 * @throws InterceptorException
 	 * @throws URISyntaxException
 	 * @throws UnsupportedEncodingException
+	 * @throws HttpException
 	 */
 	public Response interceptGeoServerRequest(HttpServletRequest request)
-			throws InterceptorException, URISyntaxException, UnsupportedEncodingException {
+			throws InterceptorException, URISyntaxException,
+			UnsupportedEncodingException, HttpException {
 
 		// wrap the request, we want to manipulate it
 		MutableHttpServletRequest mutableRequest =
@@ -451,9 +454,10 @@ public class GeoServerInterceptorService {
 	 * @param request
 	 * @return
 	 * @throws InterceptorException
+	 * @throws HttpException
 	 */
 	private static Response sendRequest(MutableHttpServletRequest request)
-			throws InterceptorException {
+			throws InterceptorException, HttpException {
 
 		Response httpResponse = new Response();
 
@@ -524,6 +528,11 @@ public class GeoServerInterceptorService {
 			throws UnsupportedEncodingException {
 
 		HttpHeaders responseHeaders = new HttpHeaders();
+
+		if (headers == null) {
+			LOG.debug("No headers found to forward!");
+			return responseHeaders;
+		}
 
 		LOG.debug("Requested to filter the Headers to respond with:");
 

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
@@ -1,0 +1,602 @@
+package de.terrestris.shogun2.service;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.w3c.dom.Document;
+
+import de.terrestris.shogun2.model.interceptor.InterceptorRule;
+import de.terrestris.shogun2.util.http.HttpUtil;
+import de.terrestris.shogun2.util.interceptor.InterceptorException;
+import de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest;
+import de.terrestris.shogun2.util.interceptor.OgcMessage;
+import de.terrestris.shogun2.util.interceptor.OgcMessageDistributor;
+import de.terrestris.shogun2.util.interceptor.OgcNaming;
+import de.terrestris.shogun2.util.interceptor.OgcXmlUtil;
+import de.terrestris.shogun2.util.model.Response;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author Kai Volland
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+@Service
+public class GeoServerInterceptorService {
+
+	/**
+	 * The Logger.
+	 */
+	private static final Logger LOG = Logger.getLogger(
+			GeoServerInterceptorService.class);
+
+	/**
+	 * The autowired properties file containing the (application driven)
+	 * GeoServer namespace - GeoServer BaseURI mapping, e.g.:
+	 *
+	 *   topp=http://localhost:8080/geoserver/topp/ows
+	 *
+	 */
+	private Properties geoServerNameSpaces;
+
+	/**
+	 * An array of whitelisted Headers to forward within the Interceptor.
+	 */
+	private static final String[] FORWARD_HEADER_KEYS = new String[] {
+		"Content-Type",
+		"Content-Disposition",
+		"geowebcache-cache-result",
+		"geowebcache-crs",
+		"geowebcache-gridset",
+		"geowebcache-tile-bounds",
+		"geowebcache-tile-index"
+	};
+
+	/**
+	 *
+	 */
+	@Autowired
+	OgcMessageDistributor ogcMessageDistributor;
+
+	/**
+	 *
+	 */
+	@Autowired
+	InterceptorRuleService<InterceptorRule, ?> interceptorRuleService;
+
+	/**
+	 *
+	 * @param request
+	 * @return
+	 * @throws InterceptorException
+	 * @throws URISyntaxException
+	 * @throws UnsupportedEncodingException
+	 */
+	public Response interceptGeoServerRequest(HttpServletRequest request)
+			throws InterceptorException, URISyntaxException, UnsupportedEncodingException {
+
+		// wrap the request, we want to manipulate it
+		MutableHttpServletRequest mutableRequest =
+				new MutableHttpServletRequest(request);
+
+		// get the OGC request information (service, request, endPoint)
+		OgcMessage message = getOgcRequest(mutableRequest);
+
+		// get the GeoServer base URI by the provided request
+		URI geoServerBaseUri = getGeoServerBaseURI(message);
+
+		// set the GeoServer base URI to the (wrapped) request
+		mutableRequest.setRequestURI(geoServerBaseUri);
+
+		// intercept the request (if needed)
+		mutableRequest = ogcMessageDistributor
+				.distributeToRequestInterceptor(mutableRequest, message);
+
+		// send the request
+		// TODO: Move to global proxy class
+		Response response = sendRequest(mutableRequest);
+
+		// intercept the response (if needed)
+		Response interceptedResponse = ogcMessageDistributor
+				.distributeToResponeInterceptor(response, message);
+
+		// finally filter the white-listed response headers
+		// TODO: Move to global proxy class
+		interceptedResponse.setHeaders(
+				getHeadersToForward(interceptedResponse.getHeaders()));
+
+		return interceptedResponse;
+	}
+
+	/**
+	 *
+	 * @param mutableRequest
+	 * @return
+	 * @throws InterceptorException
+	 */
+	private OgcMessage getOgcRequest(MutableHttpServletRequest mutableRequest)
+			throws InterceptorException {
+
+		OgcMessage ogcRequest = new OgcMessage();
+
+		String requestService = getRequestParameterValue(
+				mutableRequest, OgcNaming.PARAMETER_SERVICE);
+		String requestOperation = getRequestParameterValue(
+				mutableRequest, OgcNaming.PARAMETER_OPERATION);
+		String requestLayer = getRequestParameterValue(
+				mutableRequest, OgcNaming.PARAMETER_ENDPOINT);
+		InterceptorRule mostSpecificRequestRule = getMostSpecificRule(requestService,
+				requestOperation, requestLayer, "REQUEST");
+		InterceptorRule mostSpecificResponseRule = getMostSpecificRule(requestService,
+				requestOperation, requestLayer, "RESPONSE");
+
+		if (StringUtils.isNoneEmpty(requestService)) {
+			ogcRequest.setService(requestService);
+		} else {
+			LOG.debug("No service found.");
+		}
+
+		if (StringUtils.isNoneEmpty(requestOperation)) {
+			ogcRequest.setOperation(requestOperation);
+		} else {
+			LOG.debug("No operation found.");
+		}
+
+		if (StringUtils.isNoneEmpty(requestLayer)) {
+			ogcRequest.setEndPoint(requestLayer);
+		} else {
+			LOG.debug("No endPoint found.");
+		}
+
+		if (mostSpecificRequestRule != null) {
+			ogcRequest.setRequestRule(mostSpecificRequestRule.getRule());
+		} else {
+			LOG.debug("No interceptor rule found for the request.");
+		}
+
+		if (mostSpecificResponseRule != null) {
+			ogcRequest.setResponseRule(mostSpecificResponseRule.getRule());
+		} else {
+			LOG.debug("No interceptor rule found for the response.");
+		}
+
+		if (StringUtils.isEmpty(requestService) &&
+				StringUtils.isEmpty(requestOperation) &&
+				StringUtils.isEmpty(requestLayer)) {
+			throw new InterceptorException("Couldn't find all required OGC " +
+					"parameters (SERVICE, REQUEST, LAYER). Please check the" +
+					"validity of the request.");
+		}
+
+		return ogcRequest;
+	}
+
+	/**
+	 *
+	 * @param requestService
+	 * @param requestOperation
+	 * @param requestLayer
+	 * @return
+	 */
+	private InterceptorRule getMostSpecificRule(String requestService,
+			String requestOperation, String requestEndPoint, String ruleEvent) {
+
+		List<InterceptorRule> result;
+
+		Map<String, String> filterMap = new HashMap<String, String>();
+
+		filterMap.put("event", ruleEvent);
+
+		filterMap.put("service", requestService);
+		filterMap.put("operation", requestOperation);
+		filterMap.put("endPoint", requestEndPoint);
+
+		result = this.interceptorRuleService.findSpecificRule(filterMap);
+
+		if (!result.isEmpty()) {
+			LOG.debug(ruleEvent + ": Found Service, Operation and EndPoint " +
+					"set in interceptor rule");
+			return result.get(0);
+		}
+
+		filterMap.put("operation", null);
+
+		result = this.interceptorRuleService.findSpecificRule(filterMap);
+
+		if (!result.isEmpty()) {
+			LOG.debug(ruleEvent + ": Found Service and EndPoint set in " +
+					"interceptor rule");
+			return result.get(0);
+		}
+
+		filterMap.put("operation", requestOperation);
+		filterMap.put("endPoint", null);
+
+		result = this.interceptorRuleService.findSpecificRule(filterMap);
+
+		if (!result.isEmpty()) {
+			LOG.debug(ruleEvent + ": Found Service and Operation set in " +
+					"interceptor rule");
+			return result.get(0);
+		}
+
+		filterMap.put("operation", null);
+		filterMap.put("endPoint", null);
+
+		result = this.interceptorRuleService.findSpecificRule(filterMap);
+
+		if (!result.isEmpty()) {
+			LOG.debug(ruleEvent + ": Found Service set in interceptor rule");
+			return result.get(0);
+		}
+
+		return null;
+
+	}
+
+	/**
+	 *
+	 * @param mutableRequest
+	 * @param key
+	 * @return
+	 * @throws InterceptorException
+	 */
+	private static String getRequestParameterValue(MutableHttpServletRequest mutableRequest,
+			String[] keys) throws InterceptorException {
+
+		String value = StringUtils.EMPTY;
+
+		for (String key : keys) {
+			value = getRequestParameterValue(mutableRequest, key);
+
+			if (StringUtils.isNoneEmpty(value)) {
+				break;
+			}
+		}
+
+		return value;
+	}
+
+	/**
+	 *
+	 * @param mutableRequest
+	 * @param key
+	 * @return
+	 * @throws InterceptorException
+	 */
+	private static String getRequestParameterValue(MutableHttpServletRequest mutableRequest,
+			String key) throws InterceptorException {
+
+		if (StringUtils.isEmpty(key)) {
+			throw new InterceptorException("Missing parameter key");
+		}
+
+		String value = StringUtils.EMPTY;
+
+		Map<String, String[]> queryParams = mutableRequest.getParameterMap();
+
+		if (!queryParams.isEmpty()) {
+
+			TreeMap<String, String[]> params = new TreeMap<String, String[]>(
+					String.CASE_INSENSITIVE_ORDER);
+
+			params.putAll(queryParams);
+
+			if (params.containsKey(key)) {
+				value = StringUtils.join(params.get(key), ";");
+			}
+
+		} else {
+
+			String xml = OgcXmlUtil.getRequestBody(mutableRequest);
+
+			if (!StringUtils.isEmpty(xml)) {
+
+				Document document = OgcXmlUtil.getDocumentFromString(xml);
+
+				if (key.equalsIgnoreCase(OgcNaming.PARAMETER_SERVICE)) {
+					value = OgcXmlUtil.getPathInDocument(
+							document, "/*/@service");
+				} else if (key.equalsIgnoreCase(OgcNaming.PARAMETER_OPERATION)) {
+					value = OgcXmlUtil.getPathInDocument(
+							document, "name(/*)");
+
+					if (value.contains(":")) {
+						value = value.split(":")[1];
+					}
+
+				} else if (Arrays.asList(OgcNaming.PARAMETER_ENDPOINT).contains(key)) {
+					value = OgcXmlUtil.getPathInDocument(
+							document, "//TypeName/text()");
+					if (StringUtils.isEmpty(value)) {
+						value = OgcXmlUtil.getPathInDocument(document,
+								"//@typeName");
+					}
+				}
+
+			} else {
+				LOG.error("No body found");
+			}
+		}
+
+		return value;
+
+	}
+
+	/**
+	 *
+	 * @param params
+	 * @return
+	 */
+	private static List<NameValuePair> createQueryParams(Map<String, String[]> params) {
+
+		List<NameValuePair> queryParams = new ArrayList<NameValuePair>();
+
+		for (Entry<String, String[]> param : params.entrySet()) {
+			queryParams.add(new BasicNameValuePair(param.getKey(),
+					StringUtils.join(param.getValue())));
+		}
+
+		return queryParams;
+	}
+
+	/**
+	 *
+	 * @param baseUri
+	 * @param queryParams
+	 * @return
+	 * @throws URISyntaxException
+	 */
+	private static URI getFullRequestURI(URI baseUri, List<NameValuePair> queryParams)
+			throws URISyntaxException {
+
+		URI requestUri = null;
+
+		URIBuilder builder = new URIBuilder(baseUri);
+		builder.addParameters(queryParams);
+		requestUri = builder.build();
+
+		return requestUri;
+	}
+
+	/**
+	 *
+	 * @param params
+	 * @return
+	 * @throws URISyntaxException
+	 * @throws InterceptorException
+	 */
+	private URI getGeoServerBaseURIFromNameSpace(String geoServerNamespace)
+			throws URISyntaxException, InterceptorException {
+
+		URI uri = null;
+
+		String geoServerUrl = this.geoServerNameSpaces.getProperty(
+				geoServerNamespace);
+
+		if (StringUtils.isEmpty(geoServerUrl)) {
+			throw new InterceptorException("Couldn't detect GeoServer URI " +
+					"from the given namespace");
+		}
+
+		URIBuilder builder = new URIBuilder(geoServerUrl);
+
+		uri = builder.build();
+
+		return uri;
+	}
+
+	/**
+	 *
+	 * @param message
+	 * @throws URISyntaxException
+	 * @throws InterceptorException
+	 */
+	private URI getGeoServerBaseURI(OgcMessage message) throws URISyntaxException,
+			InterceptorException {
+
+		// get the namespace from the qualified endpoint name
+		String geoServerNamespace = getGeoServerNameSpace(message.getEndPoint());
+
+		// set the GeoServer base URL
+		URI geoServerBaseUri = getGeoServerBaseURIFromNameSpace(geoServerNamespace);
+
+		return geoServerBaseUri;
+	}
+
+	/**
+	 *
+	 * @param qualifiedLayerName
+	 * @return
+	 */
+	private static String getGeoServerNameSpace(String endPoint) {
+
+		// return the endPoint as nameSpace per default
+		String geoServerNamespace = endPoint;
+
+		if (endPoint.contains(":")) {
+			String[] split = endPoint.split(":");
+			geoServerNamespace = split[0];
+		}
+
+		return geoServerNamespace;
+	}
+
+	/**
+	 *
+	 * @param request
+	 * @return
+	 * @throws InterceptorException
+	 */
+	private static Response sendRequest(MutableHttpServletRequest request)
+			throws InterceptorException {
+
+		Response httpResponse = new Response();
+
+		boolean getRequest = request.getMethod().equalsIgnoreCase("GET");
+		boolean postRequest = request.getMethod().equalsIgnoreCase("POST");
+
+		try {
+
+			// get the request URI
+			URI requestUri = new URI(request.getRequestURI());
+
+			// get the query parameters provided by the GET/POST request and
+			// convert to a list of NameValuePairs
+			List<NameValuePair> queryParams = createQueryParams(
+					request.getParameterMap());
+
+			// append the given request parameters to the base URI
+			URI fullRequestUri = getFullRequestURI(requestUri,
+					queryParams);
+
+			if (getRequest) {
+				// if we're called via GET method
+
+				// perform the request with the given parameters
+				httpResponse = HttpUtil.get(fullRequestUri);
+
+			} else if (postRequest) {
+				// if we're called via POST method
+
+				// get the request body if any
+				String body = OgcXmlUtil.getRequestBody(request);
+
+				if (!StringUtils.isEmpty(body)) {
+					// we do have a POST with string data present
+
+					// parse the content type of the request
+					ContentType contentType = ContentType.parse(
+							request.getContentType());
+
+					// perform the request with the given parameters
+					httpResponse = HttpUtil.post(fullRequestUri, body,
+							contentType);
+				} else {
+					// perform the request with the given parameters
+					httpResponse = HttpUtil.post(fullRequestUri, queryParams);
+				}
+
+			} else {
+				// otherwise throw an exception
+				throw new InterceptorException("Only GET or POST method "
+						+ "is allowed");
+			}
+
+		} catch (URISyntaxException | UnsupportedEncodingException e) {
+			LOG.error("Error while sending request: " + e.getMessage());
+		}
+
+		return httpResponse;
+
+	}
+
+	/**
+	 * @return
+	 * @throws UnsupportedEncodingException
+	 *
+	 */
+	private static HttpHeaders getHeadersToForward(HttpHeaders headers)
+			throws UnsupportedEncodingException {
+
+		HttpHeaders responseHeaders = new HttpHeaders();
+
+		LOG.debug("Requested to filter the Headers to respond with:");
+
+		for (Entry<String, List<String>> header : headers.entrySet()) {
+			String headerKey = header.getKey();
+			String headerVal = StringUtils.join(header.getValue(), ",");
+
+			LOG.debug("  * Header: " + headerKey);
+
+			if (Arrays.asList(FORWARD_HEADER_KEYS).contains(headerKey)) {
+
+				// the GeoServer response may contain a subtype in the
+				// "Content-Type" header without double quotes surrounding the
+				// subtype's value. If this is set we need to surround it
+				// with double quotes as this is required by the Spring
+				// ResponseEntity (and the RFC 2616 standard).
+				Pattern pattern = Pattern.compile("subtype=(.*)");
+				Matcher matcher = pattern.matcher(headerVal);
+
+				if (matcher.find()) {
+					String replaceCandidate = matcher.group(1);
+					String replacer;
+
+					replacer = StringUtils.prependIfMissing(
+							replaceCandidate, "\"");
+					replacer = StringUtils.appendIfMissing(
+							replacer, "\"");
+
+					headerVal = StringUtils.replace(headerVal,
+							replaceCandidate, replacer);
+				}
+
+				responseHeaders.set(headerKey, headerVal);
+				LOG.debug("    > Forwarded");
+			} else {
+				LOG.debug("    > Skipped");
+			}
+		}
+
+		return responseHeaders;
+	}
+
+	/**
+	 * @param ogcMessageDistributor the ogcMessageDistributor to set
+	 */
+	public void setOgcMessageDistributor(OgcMessageDistributor ogcMessageDistributor) {
+		this.ogcMessageDistributor = ogcMessageDistributor;
+	}
+
+
+
+	/**
+	 * @param interceptorRuleService the interceptorRuleService to set
+	 */
+	public void setInterceptorRuleService(
+			InterceptorRuleService<InterceptorRule, ?> interceptorRuleService) {
+		this.interceptorRuleService = interceptorRuleService;
+	}
+
+	/**
+	 * @return the geoServerNameSpaces
+	 */
+	public Properties getGeoServerNameSpaces() {
+		return geoServerNameSpaces;
+	}
+
+	/**
+	 * @param geoServerNameSpaces the geoServerNameSpaces to set
+	 */
+	@Autowired
+	@Qualifier("geoServerNameSpaces")
+	public void setGeoServerNameSpaces(Properties geoServerNameSpaces) {
+		this.geoServerNameSpaces = geoServerNameSpaces;
+	}
+
+}

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
@@ -71,6 +71,7 @@ public class GeoServerInterceptorService {
 	private static final String[] FORWARD_HEADER_KEYS = new String[] {
 		"Content-Type",
 		"Content-Disposition",
+		"Content-Language",
 		"geowebcache-cache-result",
 		"geowebcache-crs",
 		"geowebcache-gridset",

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
@@ -1,5 +1,6 @@
 package de.terrestris.shogun2.service;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -95,12 +96,12 @@ public class GeoServerInterceptorService {
 	 * @return
 	 * @throws InterceptorException
 	 * @throws URISyntaxException
-	 * @throws UnsupportedEncodingException
 	 * @throws HttpException
+	 * @throws IOException
 	 */
 	public Response interceptGeoServerRequest(HttpServletRequest request)
 			throws InterceptorException, URISyntaxException,
-			UnsupportedEncodingException, HttpException {
+			HttpException, IOException {
 
 		// wrap the request, we want to manipulate it
 		MutableHttpServletRequest mutableRequest =
@@ -140,9 +141,10 @@ public class GeoServerInterceptorService {
 	 * @param mutableRequest
 	 * @return
 	 * @throws InterceptorException
+	 * @throws IOException
 	 */
 	private OgcMessage getOgcRequest(MutableHttpServletRequest mutableRequest)
-			throws InterceptorException {
+			throws InterceptorException, IOException {
 
 		OgcMessage ogcRequest = new OgcMessage();
 
@@ -267,16 +269,17 @@ public class GeoServerInterceptorService {
 	 * @param key
 	 * @return
 	 * @throws InterceptorException
+	 * @throws IOException
 	 */
 	private static String getRequestParameterValue(MutableHttpServletRequest mutableRequest,
-			String[] keys) throws InterceptorException {
+			String[] keys) throws InterceptorException, IOException {
 
 		String value = StringUtils.EMPTY;
 
 		for (String key : keys) {
 			value = getRequestParameterValue(mutableRequest, key);
 
-			if (StringUtils.isNoneEmpty(value)) {
+			if (StringUtils.isNotEmpty(value)) {
 				break;
 			}
 		}
@@ -290,9 +293,10 @@ public class GeoServerInterceptorService {
 	 * @param key
 	 * @return
 	 * @throws InterceptorException
+	 * @throws IOException
 	 */
 	private static String getRequestParameterValue(MutableHttpServletRequest mutableRequest,
-			String key) throws InterceptorException {
+			String key) throws InterceptorException, IOException {
 
 		if (StringUtils.isEmpty(key)) {
 			throw new InterceptorException("Missing parameter key");

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
@@ -150,27 +150,27 @@ public class GeoServerInterceptorService {
 				mutableRequest, OgcNaming.PARAMETER_SERVICE);
 		String requestOperation = getRequestParameterValue(
 				mutableRequest, OgcNaming.PARAMETER_OPERATION);
-		String requestLayer = getRequestParameterValue(
+		String requestEndPoint = getRequestParameterValue(
 				mutableRequest, OgcNaming.PARAMETER_ENDPOINT);
 		InterceptorRule mostSpecificRequestRule = getMostSpecificRule(requestService,
-				requestOperation, requestLayer, "REQUEST");
+				requestOperation, requestEndPoint, "REQUEST");
 		InterceptorRule mostSpecificResponseRule = getMostSpecificRule(requestService,
-				requestOperation, requestLayer, "RESPONSE");
+				requestOperation, requestEndPoint, "RESPONSE");
 
-		if (StringUtils.isNoneEmpty(requestService)) {
+		if (StringUtils.isNotEmpty(requestService)) {
 			ogcRequest.setService(requestService);
 		} else {
 			LOG.debug("No service found.");
 		}
 
-		if (StringUtils.isNoneEmpty(requestOperation)) {
+		if (StringUtils.isNotEmpty(requestOperation)) {
 			ogcRequest.setOperation(requestOperation);
 		} else {
 			LOG.debug("No operation found.");
 		}
 
-		if (StringUtils.isNoneEmpty(requestLayer)) {
-			ogcRequest.setEndPoint(requestLayer);
+		if (StringUtils.isNotEmpty(requestEndPoint)) {
+			ogcRequest.setEndPoint(requestEndPoint);
 		} else {
 			LOG.debug("No endPoint found.");
 		}
@@ -189,9 +189,9 @@ public class GeoServerInterceptorService {
 
 		if (StringUtils.isEmpty(requestService) &&
 				StringUtils.isEmpty(requestOperation) &&
-				StringUtils.isEmpty(requestLayer)) {
+				StringUtils.isEmpty(requestEndPoint)) {
 			throw new InterceptorException("Couldn't find all required OGC " +
-					"parameters (SERVICE, REQUEST, LAYER). Please check the " +
+					"parameters (SERVICE, REQUEST, ENDPOINT). Please check the " +
 					"validity of the request.");
 		}
 

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
@@ -188,7 +188,7 @@ public class GeoServerInterceptorService {
 				StringUtils.isEmpty(requestOperation) &&
 				StringUtils.isEmpty(requestLayer)) {
 			throw new InterceptorException("Couldn't find all required OGC " +
-					"parameters (SERVICE, REQUEST, LAYER). Please check the" +
+					"parameters (SERVICE, REQUEST, LAYER). Please check the " +
 					"validity of the request.");
 		}
 

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
@@ -304,13 +304,13 @@ public class GeoServerInterceptorService {
 
 		if (!queryParams.isEmpty()) {
 
-			TreeMap<String, String[]> params = new TreeMap<String, String[]>(
+			Map<String, String[]> params = new TreeMap<String, String[]>(
 					String.CASE_INSENSITIVE_ORDER);
 
 			params.putAll(queryParams);
 
 			if (params.containsKey(key)) {
-				value = StringUtils.join(params.get(key), ";");
+				value = StringUtils.join(params.get(key), ",");
 			}
 
 		} else {

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
@@ -125,7 +125,7 @@ public class GeoServerInterceptorService {
 
 		// intercept the response (if needed)
 		Response interceptedResponse = ogcMessageDistributor
-				.distributeToResponeInterceptor(response, message);
+				.distributeToResponseInterceptor(response, message);
 
 		// finally filter the white-listed response headers
 		// TODO: Move to global proxy class

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/InterceptorRuleService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/InterceptorRuleService.java
@@ -1,0 +1,63 @@
+package de.terrestris.shogun2.service;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import de.terrestris.shogun2.dao.InterceptorRuleDao;
+import de.terrestris.shogun2.model.interceptor.InterceptorRule;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author Kai Volland
+ * @author terrestris GmbH & Co. KG
+ *
+ * @param <E>
+ * @param <D>
+ */
+@Service("interceptorRuleService")
+public class InterceptorRuleService<E extends InterceptorRule, D extends InterceptorRuleDao<E>>
+		extends AbstractExtDirectCrudService<E, D> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public InterceptorRuleService() {
+		this((Class<E>) InterceptorRule.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the service.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected InterceptorRuleService(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * 
+	 * @param filterMap
+	 * @return
+	 */
+	public List<E> findSpecificRule(Map<String, String> filterMap) {
+		return this.dao.findSpecificRule(filterMap);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct dao here.
+	 * Otherwise, spring can not decide which dao has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("interceptorRuleDao")
+	public void setDao(D dao) {
+		this.dao = dao;
+	}
+
+}

--- a/src/shogun2-core/shogun2-service/src/test/java/de/terrestris/shogun2/service/GeoServerInterceptorServiceTest.java
+++ b/src/shogun2-core/shogun2-service/src/test/java/de/terrestris/shogun2/service/GeoServerInterceptorServiceTest.java
@@ -1,0 +1,163 @@
+package de.terrestris.shogun2.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.http.HttpException;
+import org.apache.http.entity.ContentType;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import de.terrestris.shogun2.dao.InterceptorRuleDao;
+import de.terrestris.shogun2.model.interceptor.InterceptorRule;
+import de.terrestris.shogun2.util.http.HttpUtil;
+import de.terrestris.shogun2.util.interceptor.InterceptorException;
+import de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest;
+import de.terrestris.shogun2.util.interceptor.OgcMessage;
+import de.terrestris.shogun2.util.interceptor.OgcMessageDistributor;
+import de.terrestris.shogun2.util.model.Response;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(HttpUtil.class)
+public class GeoServerInterceptorServiceTest {
+
+	@InjectMocks
+	GeoServerInterceptorService gsInterceptorService;
+
+	@Mock(name="interceptorRuleService")
+	InterceptorRuleService<InterceptorRule, InterceptorRuleDao<InterceptorRule>> ruleService;
+
+	@Mock
+	OgcMessageDistributor ogcMessageDistributor;
+
+	@Before
+	public void setUp() throws IOException {
+		MockitoAnnotations.initMocks(this);
+
+		Properties geoServerNameSpaces = new Properties();
+		geoServerNameSpaces.setProperty("topp", "http://localhost:1234/geoserver/topp/ows");
+		gsInterceptorService.setGeoServerNameSpaces(geoServerNameSpaces);
+	}
+
+	@Test(expected=InterceptorException.class)
+	public void test_throws_on_non_ogc_request() throws InterceptorException,
+	URISyntaxException, HttpException, IOException {
+		MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+		gsInterceptorService.interceptGeoServerRequest(httpRequest);
+	}
+
+	@Test
+	public void send_get() throws InterceptorException,
+			URISyntaxException, HttpException, IOException {
+
+		Response resp = new Response();
+
+		MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+		httpRequest.setRequestURI("http://example.com/geoserver.action");
+		httpRequest.setParameter("SERVICE", "WMS");
+		httpRequest.setParameter("REQUEST", "GetMap");
+		httpRequest.setParameter("LAYERS", "topp:maul");
+		httpRequest.setMethod("GET");
+
+		PowerMockito.mockStatic(HttpUtil.class);
+		when(HttpUtil.get(any(String.class))).thenReturn(resp);
+
+		MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(httpRequest);
+
+		when(ogcMessageDistributor.distributeToRequestInterceptor(
+				any(MutableHttpServletRequest.class), any(OgcMessage.class))).thenReturn(mutableRequest);
+
+		when(ogcMessageDistributor.distributeToResponseInterceptor(
+				any(Response.class), any(OgcMessage.class))).thenReturn(resp);
+
+		Response got = gsInterceptorService.interceptGeoServerRequest(httpRequest);
+
+		assertEquals(resp, got);
+
+	}
+
+	@Test
+	public void send_post_kvp() throws URISyntaxException, HttpException,
+			InterceptorException, IOException {
+
+		Response resp = new Response();
+
+		MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+		httpRequest.setRequestURI("http://example.com/geoserver.action");
+		httpRequest.setParameter("SERVICE", "WMS");
+		httpRequest.setParameter("REQUEST", "GetMap");
+		httpRequest.setParameter("LAYERS", "topp:maul");
+		httpRequest.setMethod("POST");
+
+		PowerMockito.mockStatic(HttpUtil.class);
+		when(HttpUtil.post(any(String.class), any(List.class))).thenReturn(resp);
+
+		MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(httpRequest);
+
+		when(ogcMessageDistributor.distributeToRequestInterceptor(
+				any(MutableHttpServletRequest.class), any(OgcMessage.class))).thenReturn(mutableRequest);
+
+		when(ogcMessageDistributor.distributeToResponseInterceptor(
+				any(Response.class), any(OgcMessage.class))).thenReturn(resp);
+
+		Response got = gsInterceptorService.interceptGeoServerRequest(httpRequest);
+
+		assertEquals(resp, got);
+
+	}
+
+	@Test
+	public void send_post_body() throws URISyntaxException, HttpException,
+			InterceptorException, IOException {
+
+		Response resp = new Response();
+
+		String describeFeature =
+				"<DescribeFeatureType " +
+				"  version=\"1.1.0\" " +
+				"  service=\"WFS\" " +
+				"  xmlns=\"http://www.opengis.net/wfs\" " +
+				"  xmlns:topp=\"http://www.openplans.org/topp\" " +
+				"  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+				"  xsi:schemaLocation=\"http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd\"> " +
+				"    <TypeName>topp:maul</TypeName> " +
+				"</DescribeFeatureType>";
+
+		MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+		httpRequest.setRequestURI("http://example.com/geoserver.action");
+		httpRequest.setContent(describeFeature.getBytes());
+		httpRequest.setContentType(ContentType.APPLICATION_XML.toString());
+		httpRequest.setMethod("POST");
+
+		PowerMockito.mockStatic(HttpUtil.class);
+		when(HttpUtil.post(any(String.class), any(String.class), any(ContentType.class))).thenReturn(resp);
+
+		MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(httpRequest);
+
+		when(ogcMessageDistributor.distributeToRequestInterceptor(
+				any(MutableHttpServletRequest.class), any(OgcMessage.class))).thenReturn(mutableRequest);
+
+		when(ogcMessageDistributor.distributeToResponseInterceptor(
+				any(Response.class), any(OgcMessage.class))).thenReturn(resp);
+
+		Response got = gsInterceptorService.interceptGeoServerRequest(httpRequest);
+
+		assertEquals(resp, got);
+
+	}
+
+}

--- a/src/shogun2-init/src/main/java/de/terrestris/shogun2/service/InitializationService.java
+++ b/src/shogun2-init/src/main/java/de/terrestris/shogun2/service/InitializationService.java
@@ -37,9 +37,6 @@ public class InitializationService {
 	@Qualifier("genericDao")
 	private GenericHibernateDao<PersistentObject, Integer> dao;
 
-	/**
-	 * The password encoder that is used to encode the password of a user.
-	 */
 	@Autowired
 	private PasswordEncoder passwordEncoder;
 

--- a/src/shogun2-init/src/main/java/de/terrestris/shogun2/service/InitializationService.java
+++ b/src/shogun2-init/src/main/java/de/terrestris/shogun2/service/InitializationService.java
@@ -37,6 +37,9 @@ public class InitializationService {
 	@Qualifier("genericDao")
 	private GenericHibernateDao<PersistentObject, Integer> dao;
 
+	/**
+	 * The password encoder that is used to encode the password of a user.
+	 */
 	@Autowired
 	private PasswordEncoder passwordEncoder;
 

--- a/src/shogun2-util/pom.xml
+++ b/src/shogun2-util/pom.xml
@@ -91,6 +91,11 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
+        
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
@@ -135,7 +135,6 @@ public class HttpUtil {
 	 * @throws URISyntaxException
 	 * @throws UnsupportedEncodingException
 	 * @throws HttpException
-<<<<<<< HEAD
 	 */
 	public static Response post(String url)
 			throws URISyntaxException, UnsupportedEncodingException, HttpException {
@@ -211,8 +210,6 @@ public class HttpUtil {
 	 * @throws URISyntaxException
 	 * @throws UnsupportedEncodingException
 	 * @throws HttpException
-=======
->>>>>>> Throw exception if server doesn't respond with 200 OK
 	 */
 	public static Response post(String url, List<NameValuePair> queryParams)
 			throws URISyntaxException, UnsupportedEncodingException, HttpException {

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
@@ -135,6 +135,7 @@ public class HttpUtil {
 	 * @throws URISyntaxException
 	 * @throws UnsupportedEncodingException
 	 * @throws HttpException
+<<<<<<< HEAD
 	 */
 	public static Response post(String url)
 			throws URISyntaxException, UnsupportedEncodingException, HttpException {
@@ -210,6 +211,8 @@ public class HttpUtil {
 	 * @throws URISyntaxException
 	 * @throws UnsupportedEncodingException
 	 * @throws HttpException
+=======
+>>>>>>> Throw exception if server doesn't respond with 200 OK
 	 */
 	public static Response post(String url, List<NameValuePair> queryParams)
 			throws URISyntaxException, UnsupportedEncodingException, HttpException {

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/CachedServletInputStream.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/CachedServletInputStream.java
@@ -12,6 +12,8 @@ import javax.servlet.ServletInputStream;
  * An inputstream which reads the cached request body and has mutable
  * request URI and params.
  *
+ * @see http://stackoverflow.com/questions/10210645/http-servlet-request-lose-params-from-post-body-after-read-it-once
+ *
  * @author Daniel Koch
  * @author terrestris GmbH & Co. KG
  *

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/CachedServletInputStream.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/CachedServletInputStream.java
@@ -1,0 +1,63 @@
+package de.terrestris.shogun2.util.interceptor;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+
+/**
+ *
+ * An inputstream which reads the cached request body and has mutable
+ * request URI and params.
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class CachedServletInputStream extends ServletInputStream {
+
+	/**
+	 *
+	 */
+	private ByteArrayInputStream input;
+
+	/**
+	 * Create a new input stream from the cached request body
+	 */
+	public CachedServletInputStream(ByteArrayOutputStream cachedBytes) {
+		input = new ByteArrayInputStream(cachedBytes.toByteArray());
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public int read() throws IOException {
+		return input.read();
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public boolean isFinished() {
+		return false;
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public boolean isReady() {
+		return false;
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public void setReadListener(ReadListener readListener) {
+	}
+}

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/InterceptorException.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/InterceptorException.java
@@ -1,0 +1,43 @@
+package de.terrestris.shogun2.util.interceptor;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class InterceptorException extends Exception {
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = -125687480423577256L;
+
+	/**
+	 *
+	 */
+	public InterceptorException() {}
+
+	/**
+	 * @param message
+	 */
+	public InterceptorException(String message) {
+		super(message);
+	}
+
+	/**
+	 * @param cause
+	 */
+	public InterceptorException(Throwable cause) {
+		super(cause);
+	}
+
+	/**
+	 * @param message
+	 * @param cause
+	 */
+	public InterceptorException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/InterceptorException.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/InterceptorException.java
@@ -9,9 +9,9 @@ package de.terrestris.shogun2.util.interceptor;
 public class InterceptorException extends Exception {
 
 	/**
-	 *
+	 * 
 	 */
-	private static final long serialVersionUID = -125687480423577256L;
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 *

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequest.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequest.java
@@ -18,9 +18,10 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * An implementation of HttpServletRequestWrapper.
  *
+ * @see http://stackoverflow.com/questions/10210645/http-servlet-request-lose-params-from-post-body-after-read-it-once
+ *
  * @author Daniel Koch
  *
- * See: http://stackoverflow.com/questions/10210645/http-servlet-request-lose-params-from-post-body-after-read-it-once
  */
 public class MutableHttpServletRequest extends HttpServletRequestWrapper {
 

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequest.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequest.java
@@ -1,0 +1,184 @@
+package de.terrestris.shogun2.util.interceptor;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * An implementation of HttpServletRequestWrapper.
+ *
+ * @author Daniel Koch
+ *
+ * See: http://stackoverflow.com/questions/10210645/http-servlet-request-lose-params-from-post-body-after-read-it-once
+ */
+public class MutableHttpServletRequest extends HttpServletRequestWrapper {
+
+	/**
+	 * Holds custom parameter mapping
+	 */
+	private Map<String, String[]> customParameters;
+
+	/**
+	 *
+	 */
+	private String customRequestURI;
+
+	/**
+	 *
+	 */
+	private ByteArrayOutputStream cachedInputStream;
+
+	/**
+	 *
+	 * @param request
+	 */
+	public MutableHttpServletRequest(HttpServletRequest request) {
+		super(request);
+		this.customRequestURI = request.getRequestURI();
+		this.customParameters = new HashMap<String, String[]>(
+				request.getParameterMap());
+	}
+
+	/**
+	 *
+	 * @param url
+	 */
+	public void setRequestURI(String url) {
+		this.customRequestURI = url;
+	}
+
+	/**
+	 *
+	 * @param url
+	 */
+	public void setRequestURI(URI uri) {
+		this.customRequestURI = uri.toString();
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public String getRequestURI() {
+		if (this.customRequestURI != null) {
+			return this.customRequestURI;
+		} else {
+			HttpServletRequest request = (HttpServletRequest) super.getRequest();
+			return request.getRequestURI();
+		}
+	}
+
+	/**
+	 *
+	 * @param key
+	 * @param value
+	 */
+	public void setParameter(String key, String[] value) {
+		if (!StringUtils.isEmpty(this.getParameter(key))) {
+			this.removeParameter(key);
+		}
+		this.addParameter(key, value);
+	}
+
+	/**
+	 *
+	 * @param key
+	 * @param value
+	 */
+	public void setParameter(String key, String value) {
+		if (!StringUtils.isEmpty(this.getParameter(key))) {
+			this.removeParameter(key);
+		}
+		this.addParameter(key, value);
+	}
+
+	/**
+	 *
+	 * @param key
+	 * @param value
+	 */
+	public void addParameter(String key, String[] value) {
+		customParameters.put(key, value);
+	}
+
+	/**
+	 *
+	 * @param key
+	 * @param value
+	 */
+	public void addParameter(String key, String value) {
+		String[] values = value.split(",", -1);
+		customParameters.put(key, values);
+	}
+
+	/**
+	 *
+	 * @param key
+	 */
+	public void removeParameter(String key) {
+		if (customParameters.get(key) != null) {
+			customParameters.remove(key);
+		}
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public String getParameter(String key) {
+		if (customParameters.get(key) != null) {
+			return StringUtils.join(customParameters.get(key), ",");
+		} else {
+			HttpServletRequest request = (HttpServletRequest) super.getRequest();
+			return request.getParameter(key);
+		}
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public Map<String, String[]> getParameterMap() {
+		return customParameters;
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public ServletInputStream getInputStream() throws IOException {
+		if (cachedInputStream == null) {
+			cacheInputStream();
+		}
+		return new CachedServletInputStream(cachedInputStream);
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public BufferedReader getReader() throws IOException{
+		return new BufferedReader(new InputStreamReader(getInputStream()));
+	}
+
+	/**
+	 * Cache the inputstream in order to read it multiple times. For
+	 * convenience, I use apache.commons IOUtils
+	 */
+	private void cacheInputStream() throws IOException {
+		cachedInputStream = new ByteArrayOutputStream();
+		IOUtils.copy(super.getInputStream(), cachedInputStream);
+	}
+
+}

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcMessage.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcMessage.java
@@ -109,8 +109,6 @@ public class OgcMessage {
 		this.endPoint = endPoint;
 	}
 
-
-
 	/**
 	 * @return the requestRule
 	 */

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcMessage.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcMessage.java
@@ -12,27 +12,34 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 public class OgcMessage {
 
 	/**
-	 * E.g. 'WMS'
+	 * The OGC service type, e.g. WMS, WFS or WCS.
 	 */
 	private String service;
 
 	/**
-	 * E.g. 'GetMap'
+	 * The OGC operation type, e.g. GetMap.
 	 */
 	private String operation;
 
 	/**
-	 * E.g. 'workspace:layername'
+	 * The OGC/GeoServer endPoint (a generalization for layer, featureType,
+	 * coverage or namespace), e.g. SHOGUN:SHINJI.
 	 */
 	private String endPoint;
 
 	/**
-	 *
+	 * The rule type for this request, possible rules are:
+	 *   * ALLOW
+	 *   * DENY
+	 *   * MODIFY
 	 */
 	private String requestRule;
 
 	/**
-	 *
+	 * The rule type for this response, possible rules are:
+	 *   * ALLOW
+	 *   * DENY
+	 *   * MODIFY
 	 */
 	private String responseRule;
 
@@ -137,8 +144,8 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isWms() {
-		return (this.getService().equalsIgnoreCase(OgcNaming.SERVICE_WMS)) ?
-				true : false;
+		return this.getService() != null &&
+				this.getService().equalsIgnoreCase(OgcNaming.SERVICE_WMS);
 	}
 
 	/**
@@ -146,8 +153,8 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isWfs() {
-		return (this.getService().equalsIgnoreCase(OgcNaming.SERVICE_WFS)) ?
-				true : false;
+		return this.getService() != null &&
+				this.getService().equalsIgnoreCase(OgcNaming.SERVICE_WFS);
 	}
 
 	/**
@@ -155,8 +162,8 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isWcs() {
-		return (this.getService().equalsIgnoreCase(OgcNaming.SERVICE_WCS)) ?
-				true : false;
+		return this.getService() != null &&
+				this.getService().equalsIgnoreCase(OgcNaming.SERVICE_WCS);
 	}
 
 	/**
@@ -164,9 +171,9 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isWmsGetCapabilities() {
-		return (this.isWms() &&
-				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_CAPABILITIES)) ?
-				true : false;
+		return this.isWms() &&
+				this.getOperation() != null &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_CAPABILITIES);
 	}
 
 	/**
@@ -174,9 +181,9 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isWmsGetMap() {
-		return (this.isWms() &&
-				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_MAP)) ?
-				true : false;
+		return this.isWms() &&
+				this.getOperation() != null &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_MAP);
 	}
 
 	/**
@@ -184,9 +191,9 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isWmsGetFeatureInfo() {
-		return (this.isWms() &&
-				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_FEATURE_INFO)) ?
-				true : false;
+		return this.isWms() &&
+				this.getOperation() != null &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_FEATURE_INFO);
 	}
 
 	/**
@@ -194,9 +201,9 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isWmsDescribeLayer() {
-		return (this.isWms() &&
-				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_DESCRIBE_LAYER)) ?
-				true : false;
+		return this.isWms() &&
+				this.getOperation() != null &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_DESCRIBE_LAYER);
 	}
 
 	/**
@@ -204,9 +211,9 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isWmsGetLegendGraphic() {
-		return (this.isWms() &&
-				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_LEGEND_GRAPHIC)) ?
-				true : false;
+		return this.isWms() &&
+				this.getOperation() != null &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_LEGEND_GRAPHIC);
 	}
 
 	/**
@@ -214,9 +221,9 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isWmsGetStyles() {
-		return (this.isWms() &&
-				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_STYLES)) ?
-				true : false;
+		return this.isWms() &&
+				this.getOperation() != null &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_STYLES);
 	}
 
 	/**
@@ -224,9 +231,9 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isWfsGetCapabilities() {
-		return (this.isWfs() &&
-				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_CAPABILITIES)) ?
-				true : false;
+		return this.isWfs() &&
+				this.getOperation() != null &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_CAPABILITIES);
 	}
 
 	/**
@@ -234,9 +241,9 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isWfsDescribeFeatureType() {
-		return (this.isWfs() &&
-				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_DESCRIBE_FEATURE_TYPE)) ?
-				true : false;
+		return this.isWfs() &&
+				this.getOperation() != null &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_DESCRIBE_FEATURE_TYPE);
 	}
 
 	/**
@@ -244,9 +251,9 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isWfsGetFeature() {
-		return (this.isWfs() &&
-				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_FEATURE)) ?
-				true : false;
+		return this.isWfs() &&
+				this.getOperation() != null &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_FEATURE);
 	}
 
 	/**
@@ -254,9 +261,9 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isWfsLockFeature() {
-		return (this.isWfs() &&
-				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_LOCK_FEATURE)) ?
-				true : false;
+		return this.isWfs() &&
+				this.getOperation() != null &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_LOCK_FEATURE);
 	}
 
 	/**
@@ -264,9 +271,9 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isWfsTransaction() {
-		return (this.isWfs() &&
-				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_TRANSACTION)) ?
-				true : false;
+		return this.isWfs() &&
+				this.getOperation() != null &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_TRANSACTION);
 	}
 
 	/**
@@ -274,9 +281,9 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isWcsGetCapabilities() {
-		return (this.isWcs() &&
-				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_CAPABILITIES)) ?
-				true : false;
+		return this.isWcs() &&
+				this.getOperation() != null &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_CAPABILITIES);
 	}
 
 	/**
@@ -284,9 +291,9 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isWcsDescribeCoverage() {
-		return (this.isWcs() &&
-				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_DESCRIBE_COVERAGE)) ?
-				true : false;
+		return this.isWcs() &&
+				this.getOperation() != null &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_DESCRIBE_COVERAGE);
 	}
 
 	/**
@@ -294,9 +301,9 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isWcsGetCoverage() {
-		return (this.isWcs() &&
-				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_COVERAGE)) ?
-				true : false;
+		return this.isWcs() &&
+				this.getOperation() != null &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_COVERAGE);
 	}
 
 	/**
@@ -304,7 +311,8 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isRequestAllowed() {
-		return this.getRequestRule().equalsIgnoreCase("ALLOW");
+		return this.getRequestRule() != null &&
+				this.getRequestRule().equalsIgnoreCase("ALLOW");
 	}
 
 	/**
@@ -312,7 +320,8 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isResponseAllowed() {
-		return this.getResponseRule().equalsIgnoreCase("ALLOW");
+		return this.getResponseRule() != null &&
+				this.getResponseRule().equalsIgnoreCase("ALLOW");
 	}
 
 	/**
@@ -320,7 +329,8 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isRequestDenied() {
-		return this.getRequestRule().equalsIgnoreCase("DENY");
+		return this.getRequestRule() != null &&
+				this.getRequestRule().equalsIgnoreCase("DENY");
 	}
 
 	/**
@@ -328,7 +338,8 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isResponseDenied() {
-		return this.getResponseRule().equalsIgnoreCase("DENY");
+		return this.getResponseRule() != null &&
+				this.getResponseRule().equalsIgnoreCase("DENY");
 	}
 
 	/**
@@ -336,7 +347,8 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isRequestModified() {
-		return this.getRequestRule().equalsIgnoreCase("MODIFY");
+		return this.getRequestRule() != null &&
+				this.getRequestRule().equalsIgnoreCase("MODIFY");
 	}
 
 	/**
@@ -344,7 +356,8 @@ public class OgcMessage {
 	 * @return
 	 */
 	public boolean isResponseModified() {
-		return this.getResponseRule().equalsIgnoreCase("MODIFY");
+		return this.getResponseRule() != null &&
+				this.getResponseRule().equalsIgnoreCase("MODIFY");
 	}
 
 	/**
@@ -357,10 +370,11 @@ public class OgcMessage {
 		OgcMessage other = (OgcMessage) obj;
 
 		return new EqualsBuilder()
-				.appendSuper(super.equals(other))
 				.append(getService(), other.getService())
 				.append(getOperation(), other.getOperation())
 				.append(getEndPoint(), other.getEndPoint())
+				.append(getRequestRule(), other.getRequestRule())
+				.append(getResponseRule(), other.getResponseRule())
 				.isEquals();
 	}
 
@@ -370,7 +384,6 @@ public class OgcMessage {
 	@Override
 	public String toString() {
 		return new ToStringBuilder(this)
-				.appendSuper(super.toString())
 				.append("service", getService())
 				.append("operation", getOperation())
 				.append("endPoint", getEndPoint())

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcMessage.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcMessage.java
@@ -1,0 +1,382 @@
+package de.terrestris.shogun2.util.interceptor;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class OgcMessage {
+
+	/**
+	 * E.g. 'WMS'
+	 */
+	private String service;
+
+	/**
+	 * E.g. 'GetMap'
+	 */
+	private String operation;
+
+	/**
+	 * E.g. 'workspace:layername'
+	 */
+	private String endPoint;
+
+	/**
+	 *
+	 */
+	private String requestRule;
+
+	/**
+	 *
+	 */
+	private String responseRule;
+
+	/**
+	 * Default constructor
+	 */
+	public OgcMessage() {
+	}
+
+
+	/**
+	 *
+	 * @param service
+	 * @param operation
+	 * @param endPoint
+	 * @param requestRule
+	 * @param responseRule
+	 */
+	public OgcMessage(String service, String operation, String endPoint,
+			String requestRule, String responseRule) {
+		this.service = service;
+		this.operation = operation;
+		this.endPoint = endPoint;
+		this.requestRule = requestRule;
+		this.responseRule = responseRule;
+	}
+
+	/**
+	 * @return the service
+	 */
+	public String getService() {
+		return service;
+	}
+
+	/**
+	 * @param service the service to set
+	 */
+	public void setService(String service) {
+		this.service = service;
+	}
+
+	/**
+	 * @return the operation
+	 */
+	public String getOperation() {
+		return operation;
+	}
+
+	/**
+	 * @param operation the operation to set
+	 */
+	public void setOperation(String operation) {
+		this.operation = operation;
+	}
+
+	/**
+	 * @return the endPoint
+	 */
+	public String getEndPoint() {
+		return endPoint;
+	}
+
+	/**
+	 * @param endPoint the endPoint to set
+	 */
+	public void setEndPoint(String endPoint) {
+		this.endPoint = endPoint;
+	}
+
+
+
+	/**
+	 * @return the requestRule
+	 */
+	public String getRequestRule() {
+		return requestRule;
+	}
+
+	/**
+	 * @param requestRule the requestRule to set
+	 */
+	public void setRequestRule(String requestRule) {
+		this.requestRule = requestRule;
+	}
+
+	/**
+	 * @return the responseRule
+	 */
+	public String getResponseRule() {
+		return responseRule;
+	}
+
+	/**
+	 * @param responseRule the responseRule to set
+	 */
+	public void setResponseRule(String responseRule) {
+		this.responseRule = responseRule;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isWms() {
+		return (this.getService().equalsIgnoreCase(OgcNaming.SERVICE_WMS)) ?
+				true : false;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isWfs() {
+		return (this.getService().equalsIgnoreCase(OgcNaming.SERVICE_WFS)) ?
+				true : false;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isWcs() {
+		return (this.getService().equalsIgnoreCase(OgcNaming.SERVICE_WCS)) ?
+				true : false;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isWmsGetCapabilities() {
+		return (this.isWms() &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_CAPABILITIES)) ?
+				true : false;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isWmsGetMap() {
+		return (this.isWms() &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_MAP)) ?
+				true : false;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isWmsGetFeatureInfo() {
+		return (this.isWms() &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_FEATURE_INFO)) ?
+				true : false;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isWmsDescribeLayer() {
+		return (this.isWms() &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_DESCRIBE_LAYER)) ?
+				true : false;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isWmsGetLegendGraphic() {
+		return (this.isWms() &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_LEGEND_GRAPHIC)) ?
+				true : false;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isWmsGetStyles() {
+		return (this.isWms() &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_STYLES)) ?
+				true : false;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isWfsGetCapabilities() {
+		return (this.isWfs() &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_CAPABILITIES)) ?
+				true : false;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isWfsDescribeFeatureType() {
+		return (this.isWfs() &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_DESCRIBE_FEATURE_TYPE)) ?
+				true : false;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isWfsGetFeature() {
+		return (this.isWfs() &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_FEATURE)) ?
+				true : false;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isWfsLockFeature() {
+		return (this.isWfs() &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_LOCK_FEATURE)) ?
+				true : false;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isWfsTransaction() {
+		return (this.isWfs() &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_TRANSACTION)) ?
+				true : false;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isWcsGetCapabilities() {
+		return (this.isWcs() &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_CAPABILITIES)) ?
+				true : false;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isWcsDescribeCoverage() {
+		return (this.isWcs() &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_DESCRIBE_COVERAGE)) ?
+				true : false;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isWcsGetCoverage() {
+		return (this.isWcs() &&
+				this.getOperation().equalsIgnoreCase(OgcNaming.OPERATION_GET_COVERAGE)) ?
+				true : false;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isRequestAllowed() {
+		return this.getRequestRule().equalsIgnoreCase("ALLOW");
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isResponseAllowed() {
+		return this.getResponseRule().equalsIgnoreCase("ALLOW");
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isRequestDenied() {
+		return this.getRequestRule().equalsIgnoreCase("DENY");
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isResponseDenied() {
+		return this.getResponseRule().equalsIgnoreCase("DENY");
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isRequestModified() {
+		return this.getRequestRule().equalsIgnoreCase("MODIFY");
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isResponseModified() {
+		return this.getResponseRule().equalsIgnoreCase("MODIFY");
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof OgcMessage))
+			return false;
+		OgcMessage other = (OgcMessage) obj;
+
+		return new EqualsBuilder()
+				.appendSuper(super.equals(other))
+				.append(getService(), other.getService())
+				.append(getOperation(), other.getOperation())
+				.append(getEndPoint(), other.getEndPoint())
+				.isEquals();
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this)
+				.appendSuper(super.toString())
+				.append("service", getService())
+				.append("operation", getOperation())
+				.append("endPoint", getEndPoint())
+				.append("requestRule", getRequestRule())
+				.append("responseRule", getResponseRule())
+				.toString();
+	}
+
+}

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcMessageDistributor.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcMessageDistributor.java
@@ -1,0 +1,370 @@
+package de.terrestris.shogun2.util.interceptor;
+
+import java.text.MessageFormat;
+
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import de.terrestris.shogun2.util.model.Response;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+@Component
+public class OgcMessageDistributor {
+
+	/**
+	 * The Logger.
+	 */
+	private static final Logger LOG = Logger.getLogger(
+			OgcMessageDistributor.class);
+
+	/**
+	 *
+	 */
+	private static final String MODIFYING_REQUEST_MSG =
+			"Modifying a {0} {1} request";
+
+	/**
+	 *
+	 */
+	private static final String MODIFYING_RESPONSE_MSG =
+			"Modifying a {0} {1} response";
+
+	/**
+	 *
+	 */
+	private static final String REQUEST_IMPLEMENTATION_NOT_FOUND_MSG =
+			"No interceptor class implementation for request {0} {1} found. " +
+			"Forwarding the original request.";
+
+	/**
+	 *
+	 */
+	private static final String RESPONSE_IMPLEMENTATION_NOT_FOUND_MSG =
+			"No interceptor class implementation for response {0} {1} found. " +
+			"Returning the original response.";
+
+	/**
+	 *
+	 */
+	private static final String REQUEST_NOT_SUPPORTED_MSG = "The request type " +
+			"{0} is not supported";
+
+	/**
+	 *
+	 */
+	@Autowired(required = false)
+	@Qualifier("wmsRequestInterceptor")
+	private WmsRequestInterceptorInterface wmsRequestInterceptor;
+
+	/**
+	 *
+	 */
+	@Autowired(required = false)
+	@Qualifier("wfsRequestInterceptor")
+	private WfsRequestInterceptorInterface wfsRequestInterceptor;
+
+	/**
+	 *
+	 */
+	@Autowired(required = false)
+	@Qualifier("wcsRequestInterceptor")
+	private WcsRequestInterceptorInterface wcsRequestInterceptor;
+
+	/**
+	 *
+	 */
+	@Autowired(required = false)
+	@Qualifier("wmsResponseInterceptor")
+	private WmsResponseInterceptorInterface wmsResponseInterceptor;
+
+	/**
+	 *
+	 */
+	@Autowired(required = false)
+	@Qualifier("wfsResponseInterceptor")
+	private WfsResponseInterceptorInterface wfsResponseInterceptor;
+
+	/**
+	 *
+	 */
+	@Autowired(required = false)
+	@Qualifier("wcsResponseInterceptor")
+	private WcsResponseInterceptorInterface wcsResponseInterceptor;
+
+	/**
+	 *
+	 * @param request
+	 * @param message
+	 * @return
+	 * @throws InterceptorException
+	 */
+	public MutableHttpServletRequest distributeToRequestInterceptor(
+			MutableHttpServletRequest request, OgcMessage message)
+					throws InterceptorException {
+
+		if (message.isRequestAllowed()) {
+			LOG.debug("Request is ALLOWED, not intercepting the request.");
+			return request;
+		} else if (message.isRequestDenied()) {
+			throw new InterceptorException("Request is DENIED, blocking the request.");
+		} else if (message.isRequestModified()) {
+			LOG.debug("Request is to be MODIFIED, intercepting the request.");
+		}
+
+		String implErrMsg = MessageFormat.format(REQUEST_IMPLEMENTATION_NOT_FOUND_MSG,
+				message.getService(), message.getOperation());
+		String infoMsg = MessageFormat.format(MODIFYING_REQUEST_MSG,
+				message.getService(), message.getOperation());
+		String serviceErrMsg = MessageFormat.format(REQUEST_NOT_SUPPORTED_MSG,
+				message.getService());
+		String operationErrMsg = MessageFormat.format(REQUEST_NOT_SUPPORTED_MSG,
+				message.getOperation());
+
+		if (message.isWms()) {
+
+			// check if the wmsRequestInterceptor is available
+			if (this.wmsRequestInterceptor == null) {
+				LOG.debug(implErrMsg);
+				return request;
+			}
+
+			LOG.debug(infoMsg);
+
+			if (message.isWmsGetCapabilities()) {
+				request = this.wmsRequestInterceptor.interceptGetCapabilities(request);
+			} else if (message.isWmsGetMap()) {
+				request = this.wmsRequestInterceptor.interceptGetMap(request);
+			} else if (message.isWmsGetFeatureInfo()) {
+				request = this.wmsRequestInterceptor.interceptGetFeatureInfo(request);
+			} else if (message.isWmsGetLegendGraphic()) {
+				request = this.wmsRequestInterceptor.interceptGetLegendGraphic(request);
+			} else if (message.isWmsGetStyles()) {
+				request = this.wmsRequestInterceptor.interceptGetStyles(request);
+			} else if (message.isWmsDescribeLayer()) {
+				request = this.wmsRequestInterceptor.interceptDescribeLayer(request);
+			} else {
+				throw new InterceptorException(operationErrMsg);
+			}
+
+		} else if (message.isWfs()) {
+
+			// check if the wfsRequestInterceptor is available
+			if (this.wfsRequestInterceptor == null) {
+				LOG.debug(implErrMsg);
+				return request;
+			}
+
+			LOG.debug(infoMsg);
+
+			if (message.isWfsGetCapabilities()) {
+				request = this.wfsRequestInterceptor.interceptGetCapabilities(request);
+			} else if (message.isWfsGetFeature()) {
+				request = this.wfsRequestInterceptor.interceptGetFeature(request);
+			} else if (message.isWfsDescribeFeatureType()) {
+				request = this.wfsRequestInterceptor.interceptDescribeFeatureType(request);
+			} else if (message.isWfsTransaction()) {
+				request = this.wfsRequestInterceptor.interceptTransaction(request);
+			} else if (message.isWfsLockFeature()) {
+				request = this.wfsRequestInterceptor.interceptLockFeature(request);
+			} else {
+				throw new InterceptorException(operationErrMsg);
+			}
+
+		} else if (message.isWcs()) {
+
+			// check if the wcsRequestInterceptor is available
+			if (this.wcsRequestInterceptor == null) {
+				LOG.debug(implErrMsg);
+				return request;
+			}
+
+			LOG.debug(infoMsg);
+
+			if (message.isWcsGetCapabilities()) {
+				request = this.wcsRequestInterceptor.interceptGetCapabilities(request);
+			} else if (message.isWcsDescribeCoverage()) {
+				request = this.wcsRequestInterceptor.interceptDescribeCoverage(request);
+			} else if (message.isWcsGetCoverage()) {
+				request = this.wcsRequestInterceptor.interceptGetCoverage(request);
+			} else {
+				throw new InterceptorException(operationErrMsg);
+			}
+
+		} else {
+			throw new InterceptorException(serviceErrMsg);
+		}
+
+		if (request == null) {
+			throw new InterceptorException("The request object is null. " +
+					"Please check your RequestInterceptor implementation.");
+		}
+
+		return request;
+
+	}
+
+	/**
+	 *
+	 * @param response
+	 * @param message
+	 * @return
+	 * @throws InterceptorException
+	 */
+	public Response distributeToResponeInterceptor(Response response,
+			OgcMessage message) throws InterceptorException {
+
+		if (message.isResponseAllowed()) {
+			LOG.debug("Response is ALLOWED, not intercepting the response.");
+			return response;
+		} else if (message.isResponseDenied()) {
+			throw new InterceptorException("Request is DENIED, blocking the response.");
+		} else if (message.isResponseModified()) {
+			LOG.debug("Response is to be MODIFIED, intercepting the response.");
+		}
+
+		String implErrMsg = MessageFormat.format(REQUEST_IMPLEMENTATION_NOT_FOUND_MSG,
+				message.getService(), message.getOperation());
+		String infoMsg = MessageFormat.format(MODIFYING_RESPONSE_MSG,
+				message.getService(), message.getOperation());
+		String serviceErrMsg = MessageFormat.format(REQUEST_NOT_SUPPORTED_MSG,
+				message.getService());
+		String operationErrMsg = MessageFormat.format(REQUEST_NOT_SUPPORTED_MSG,
+				message.getOperation());
+
+		if (message.isWms()) {
+
+			// check if the wmsResponseInterceptor is available
+			if (this.wmsResponseInterceptor == null) {
+				LOG.debug(implErrMsg);
+				return response;
+			}
+
+			LOG.debug(infoMsg);
+
+			if (message.isWmsGetCapabilities()) {
+				response = this.wmsResponseInterceptor.interceptGetCapabilities(response);
+			} else if (message.isWmsGetMap()) {
+				response = this.wmsResponseInterceptor.interceptGetMap(response);
+			} else if (message.isWmsGetFeatureInfo()) {
+				response = this.wmsResponseInterceptor.interceptGetFeatureInfo(response);
+			} else if (message.isWmsGetLegendGraphic()) {
+				response = this.wmsResponseInterceptor.interceptGetLegendGraphic(response);
+			} else if (message.isWmsGetStyles()) {
+				response = this.wmsResponseInterceptor.interceptGetStyles(response);
+			} else if (message.isWmsDescribeLayer()) {
+				response = this.wmsResponseInterceptor.interceptDescribeLayer(response);
+			} else {
+				throw new InterceptorException(operationErrMsg);
+			}
+
+		} else if (message.isWfs()) {
+
+			// check if the wfsResponseInterceptor is available
+			if (this.wfsResponseInterceptor == null) {
+				LOG.debug(implErrMsg);
+				return response;
+			}
+
+			LOG.debug(infoMsg);
+
+			if (message.isWfsGetCapabilities()) {
+				response = this.wfsResponseInterceptor.interceptGetCapabilities(response);
+			} else if (message.isWfsGetFeature()) {
+				response = this.wfsResponseInterceptor.interceptGetFeature(response);
+			} else if (message.isWfsDescribeFeatureType()) {
+				response = this.wfsResponseInterceptor.interceptDescribeFeatureType(response);
+			} else if (message.isWfsTransaction()) {
+				response = this.wfsResponseInterceptor.interceptTransaction(response);
+			} else if (message.isWfsLockFeature()) {
+				response = this.wfsResponseInterceptor.interceptLockFeature(response);
+			} else {
+				throw new InterceptorException(operationErrMsg);
+			}
+
+		} else if (message.isWcs()) {
+
+			// check if the wcsResponseInterceptor is available
+			if (this.wcsResponseInterceptor == null) {
+				LOG.debug(implErrMsg);
+				return response;
+			}
+
+			LOG.debug(infoMsg);
+
+			if (message.isWcsGetCapabilities()) {
+				response = this.wcsResponseInterceptor.interceptGetCapabilities(response);
+			} else if (message.isWcsDescribeCoverage()) {
+				response = this.wcsResponseInterceptor.interceptDescribeCoverage(response);
+			} else if (message.isWcsGetCoverage()) {
+				response = this.wcsResponseInterceptor.interceptGetCoverage(response);
+			} else {
+				throw new InterceptorException(operationErrMsg);
+			}
+
+		} else {
+			throw new InterceptorException(serviceErrMsg);
+		}
+
+		if (response == null) {
+			throw new InterceptorException("The response object is null. " +
+					"Please check your RequestInterceptor implementation.");
+		}
+
+		return response;
+	}
+
+	/**
+	 * @param wmsRequestInterceptor the wmsRequestInterceptor to set
+	 */
+	public void setWmsRequestInterceptor(
+			WmsRequestInterceptorInterface wmsRequestInterceptor) {
+		this.wmsRequestInterceptor = wmsRequestInterceptor;
+	}
+
+	/**
+	 * @param wfsRequestInterceptor the wfsRequestInterceptor to set
+	 */
+	public void setWfsRequestInterceptor(
+			WfsRequestInterceptorInterface wfsRequestInterceptor) {
+		this.wfsRequestInterceptor = wfsRequestInterceptor;
+	}
+
+	/**
+	 * @param wcsRequestInterceptor the wcsRequestInterceptor to set
+	 */
+	public void setWcsRequestInterceptor(
+			WcsRequestInterceptorInterface wcsRequestInterceptor) {
+		this.wcsRequestInterceptor = wcsRequestInterceptor;
+	}
+
+	/**
+	 * @param wmsResponseInterceptor the wmsResponseInterceptor to set
+	 */
+	public void setWmsResponseInterceptor(
+			WmsResponseInterceptorInterface wmsResponseInterceptor) {
+		this.wmsResponseInterceptor = wmsResponseInterceptor;
+	}
+
+	/**
+	 * @param wfsResponseInterceptor the wfsResponseInterceptor to set
+	 */
+	public void setWfsResponseInterceptor(
+			WfsResponseInterceptorInterface wfsResponseInterceptor) {
+		this.wfsResponseInterceptor = wfsResponseInterceptor;
+	}
+
+	/**
+	 * @param wcsResponseInterceptor the wcsResponseInterceptor to set
+	 */
+	public void setWcsResponseInterceptor(
+			WcsResponseInterceptorInterface wcsResponseInterceptor) {
+		this.wcsResponseInterceptor = wcsResponseInterceptor;
+	}
+}

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcMessageDistributor.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcMessageDistributor.java
@@ -59,6 +59,12 @@ public class OgcMessageDistributor {
 	/**
 	 *
 	 */
+	private static final String RESPONSE_NOT_SUPPORTED_MSG = "The response type " +
+			"{0} is not supported";
+
+	/**
+	 *
+	 */
 	@Autowired(required = false)
 	@Qualifier("wmsRequestInterceptor")
 	private WmsRequestInterceptorInterface wmsRequestInterceptor;
@@ -163,6 +169,7 @@ public class OgcMessageDistributor {
 
 			LOG.debug(infoMsg);
 
+			// Note: WFS 2.0.0 operations are not supported yet!
 			if (message.isWfsGetCapabilities()) {
 				request = this.wfsRequestInterceptor.interceptGetCapabilities(request);
 			} else if (message.isWfsGetFeature()) {
@@ -217,25 +224,25 @@ public class OgcMessageDistributor {
 	 * @return
 	 * @throws InterceptorException
 	 */
-	public Response distributeToResponeInterceptor(Response response,
+	public Response distributeToResponseInterceptor(Response response,
 			OgcMessage message) throws InterceptorException {
 
 		if (message.isResponseAllowed()) {
 			LOG.debug("Response is ALLOWED, not intercepting the response.");
 			return response;
 		} else if (message.isResponseDenied()) {
-			throw new InterceptorException("Request is DENIED, blocking the response.");
+			throw new InterceptorException("Response is DENIED, blocking the response.");
 		} else if (message.isResponseModified()) {
 			LOG.debug("Response is to be MODIFIED, intercepting the response.");
 		}
 
-		String implErrMsg = MessageFormat.format(REQUEST_IMPLEMENTATION_NOT_FOUND_MSG,
+		String implErrMsg = MessageFormat.format(RESPONSE_IMPLEMENTATION_NOT_FOUND_MSG,
 				message.getService(), message.getOperation());
 		String infoMsg = MessageFormat.format(MODIFYING_RESPONSE_MSG,
 				message.getService(), message.getOperation());
-		String serviceErrMsg = MessageFormat.format(REQUEST_NOT_SUPPORTED_MSG,
+		String serviceErrMsg = MessageFormat.format(RESPONSE_NOT_SUPPORTED_MSG,
 				message.getService());
-		String operationErrMsg = MessageFormat.format(REQUEST_NOT_SUPPORTED_MSG,
+		String operationErrMsg = MessageFormat.format(RESPONSE_NOT_SUPPORTED_MSG,
 				message.getOperation());
 
 		if (message.isWms()) {
@@ -274,6 +281,7 @@ public class OgcMessageDistributor {
 
 			LOG.debug(infoMsg);
 
+			// Note: WFS 2.0.0 operations are not supported yet!
 			if (message.isWfsGetCapabilities()) {
 				response = this.wfsResponseInterceptor.interceptGetCapabilities(response);
 			} else if (message.isWfsGetFeature()) {
@@ -314,7 +322,7 @@ public class OgcMessageDistributor {
 
 		if (response == null) {
 			throw new InterceptorException("The response object is null. " +
-					"Please check your RequestInterceptor implementation.");
+					"Please check your ResponseInterceptor implementation.");
 		}
 
 		return response;

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcNaming.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcNaming.java
@@ -1,0 +1,101 @@
+package de.terrestris.shogun2.util.interceptor;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class OgcNaming {
+
+	/**
+	 *
+	 */
+	public static final String PARAMETER_SERVICE = "SERVICE";
+
+	/**
+	 *
+	 */
+	public static final String PARAMETER_OPERATION = "REQUEST";
+
+	/**
+	 *
+	 */
+	public static final String[] PARAMETER_ENDPOINT = {"LAYERS", "LAYER", "NAMESPACE"};
+
+	/**
+	 *
+	 */
+	public static final String SERVICE_WMS = "WMS";
+
+	/**
+	 *
+	 */
+	public static final String SERVICE_WFS = "WFS";
+
+	/**
+	 *
+	 */
+	public static final String SERVICE_WCS = "WCS";
+
+	/**
+	 *
+	 */
+	public static final String OPERATION_GET_MAP = "GetMap";
+
+	/**
+	 *
+	 */
+	public static final String OPERATION_GET_CAPABILITIES = "GetCapabilities";
+
+	/**
+	 *
+	 */
+	public static final String OPERATION_GET_FEATURE_INFO = "GetFeatureInfo";
+
+	/**
+	 *
+	 */
+	public static final String OPERATION_DESCRIBE_LAYER = "DescribeLayer";
+
+	/**
+	 *
+	 */
+	public static final String OPERATION_GET_LEGEND_GRAPHIC = "GetLegendGraphic";
+
+	/**
+	 *
+	 */
+	public static final String OPERATION_GET_STYLES = "GetStyles";
+
+	/**
+	 *
+	 */
+	public static final String OPERATION_DESCRIBE_FEATURE_TYPE = "DescribeFeatureType";
+
+	/**
+	 *
+	 */
+	public static final String OPERATION_GET_FEATURE = "GetFeature";
+
+	/**
+	 *
+	 */
+	public static final String OPERATION_LOCK_FEATURE = "LockFeature";
+
+	/**
+	 *
+	 */
+	public static final String OPERATION_TRANSACTION = "Transaction";
+
+	/**
+	 *
+	 */
+	public static final String OPERATION_DESCRIBE_COVERAGE = "DescribeCoverage";
+
+	/**
+	 *
+	 */
+	public static final String OPERATION_GET_COVERAGE = "GetCoverage";
+
+}

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcXmlUtil.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcXmlUtil.java
@@ -5,6 +5,7 @@ import java.io.StringReader;
 import java.nio.charset.Charset;
 
 import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -36,11 +37,16 @@ public class OgcXmlUtil {
 	private static final Logger LOG = Logger.getLogger(OgcXmlUtil.class);
 
 	/**
+	 * The default charset.
+	 */
+	private static final String DEFAULT_CHARSET = "UTF-8";
+
+	/**
 	 *
 	 * @param request
 	 * @return
 	 */
-	public static String getRequestBody(MutableHttpServletRequest request){
+	public static String getRequestBody(HttpServletRequest request){
 
 		ServletInputStream in = null;
 		String body = null;
@@ -53,7 +59,7 @@ public class OgcXmlUtil {
 			if (!StringUtils.isEmpty(encoding)) {
 				charset = Charset.forName(encoding);
 			} else {
-				charset = Charset.forName("UTF-8");
+				charset = Charset.forName(DEFAULT_CHARSET);
 			}
 			body = StreamUtils.copyToString(in, charset);
 		} catch (IOException e) {

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcXmlUtil.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcXmlUtil.java
@@ -1,0 +1,130 @@
+package de.terrestris.shogun2.util.interceptor;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.Charset;
+
+import javax.servlet.ServletInputStream;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
+import org.springframework.util.StreamUtils;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class OgcXmlUtil {
+
+	/**
+	 * The Logger.
+	 */
+	private static final Logger LOG = Logger.getLogger(OgcXmlUtil.class);
+
+	/**
+	 *
+	 * @param request
+	 * @return
+	 */
+	public static String getRequestBody(MutableHttpServletRequest request){
+
+		ServletInputStream in = null;
+		String body = null;
+
+		try {
+			in = request.getInputStream();
+
+			String encoding = request.getCharacterEncoding();
+			Charset charset;
+			if (!StringUtils.isEmpty(encoding)) {
+				charset = Charset.forName(encoding);
+			} else {
+				charset = Charset.forName("UTF-8");
+			}
+			body = StreamUtils.copyToString(in, charset);
+		} catch (IOException e) {
+			LOG.error("Could not read the InputStream as String: " +
+					e.getMessage());
+		} finally {
+			IOUtils.closeQuietly(in);
+		}
+
+		return body;
+
+	}
+
+	/**
+	 *
+	 * @param xml
+	 * @return
+	 * @throws InterceptorException
+	 * @throws IOException
+	 * @throws SAXException
+	 * @throws ParserConfigurationException
+	 */
+	public static Document getDocumentFromString(String xml) throws InterceptorException {
+
+		Document document = null;
+
+		try {
+			InputSource source = new InputSource(new StringReader(xml));
+			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			DocumentBuilder builder = factory.newDocumentBuilder();
+			document = builder.parse(source);
+		} catch (ParserConfigurationException | SAXException | IOException e) {
+			throw new InterceptorException("Could not parse input body " +
+					"as XML: " + e.getMessage());
+		}
+
+		return document;
+
+	}
+
+	/**
+	 *
+	 * @param document
+	 * @param path
+	 * @return
+	 * @throws InterceptorException
+	 */
+	public static String getPathInDocument(Document document, String path)
+			throws InterceptorException {
+
+		if (document == null) {
+			throw new InterceptorException("document may not be null");
+		}
+
+		if (StringUtils.isEmpty(path)) {
+			throw new InterceptorException("Missing parameter path");
+		}
+
+		String result;
+
+		try {
+			XPathFactory xPathfactory = XPathFactory.newInstance();
+			XPath xpath = xPathfactory.newXPath();
+			XPathExpression expr = xpath.compile(path);
+			result = expr.evaluate(document, XPathConstants.STRING).toString();
+		} catch (XPathExpressionException e) {
+			throw new InterceptorException("Could not : " + e.getMessage());
+		}
+
+		return result;
+
+	}
+
+}

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcXmlUtil.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcXmlUtil.java
@@ -108,7 +108,7 @@ public class OgcXmlUtil {
 			throws InterceptorException {
 
 		if (document == null) {
-			throw new InterceptorException("document may not be null");
+			throw new InterceptorException("Document may not be null");
 		}
 
 		if (StringUtils.isEmpty(path)) {
@@ -123,7 +123,8 @@ public class OgcXmlUtil {
 			XPathExpression expr = xpath.compile(path);
 			result = expr.evaluate(document, XPathConstants.STRING).toString();
 		} catch (XPathExpressionException e) {
-			throw new InterceptorException("Could not : " + e.getMessage());
+			throw new InterceptorException("Error while selecting document " +
+					"element with XPath: " + e.getMessage());
 		}
 
 		return result;

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcXmlUtil.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/OgcXmlUtil.java
@@ -77,12 +77,9 @@ public class OgcXmlUtil {
 	 *
 	 * @param xml
 	 * @return
-	 * @throws InterceptorException
 	 * @throws IOException
-	 * @throws SAXException
-	 * @throws ParserConfigurationException
 	 */
-	public static Document getDocumentFromString(String xml) throws InterceptorException {
+	public static Document getDocumentFromString(String xml) throws IOException {
 
 		Document document = null;
 
@@ -92,7 +89,7 @@ public class OgcXmlUtil {
 			DocumentBuilder builder = factory.newDocumentBuilder();
 			document = builder.parse(source);
 		} catch (ParserConfigurationException | SAXException | IOException e) {
-			throw new InterceptorException("Could not parse input body " +
+			throw new IOException("Could not parse input body " +
 					"as XML: " + e.getMessage());
 		}
 

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/WcsRequestInterceptorInterface.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/WcsRequestInterceptorInterface.java
@@ -1,0 +1,14 @@
+package de.terrestris.shogun2.util.interceptor;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public interface WcsRequestInterceptorInterface {
+
+	public MutableHttpServletRequest interceptGetCapabilities(MutableHttpServletRequest request);
+
+	public MutableHttpServletRequest interceptDescribeCoverage(MutableHttpServletRequest request);
+
+	public MutableHttpServletRequest interceptGetCoverage(MutableHttpServletRequest request);
+
+}

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/WcsResponseInterceptorInterface.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/WcsResponseInterceptorInterface.java
@@ -1,0 +1,16 @@
+package de.terrestris.shogun2.util.interceptor;
+
+import org.springframework.stereotype.Component;
+
+import de.terrestris.shogun2.util.model.Response;
+
+@Component
+public interface WcsResponseInterceptorInterface {
+
+	public Response interceptGetCapabilities(Response response);
+
+	public Response interceptDescribeCoverage(Response response);
+
+	public Response interceptGetCoverage(Response response);
+
+}

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/WfsRequestInterceptorInterface.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/WfsRequestInterceptorInterface.java
@@ -1,0 +1,18 @@
+package de.terrestris.shogun2.util.interceptor;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public interface WfsRequestInterceptorInterface {
+
+	public MutableHttpServletRequest interceptGetCapabilities(MutableHttpServletRequest request);
+
+	public MutableHttpServletRequest interceptDescribeFeatureType(MutableHttpServletRequest request);
+
+	public MutableHttpServletRequest interceptGetFeature(MutableHttpServletRequest request);
+
+	public MutableHttpServletRequest interceptLockFeature(MutableHttpServletRequest request);
+
+	public MutableHttpServletRequest interceptTransaction(MutableHttpServletRequest request);
+
+}

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/WfsResponseInterceptorInterface.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/WfsResponseInterceptorInterface.java
@@ -1,0 +1,20 @@
+package de.terrestris.shogun2.util.interceptor;
+
+import org.springframework.stereotype.Component;
+
+import de.terrestris.shogun2.util.model.Response;
+
+@Component
+public interface WfsResponseInterceptorInterface {
+
+	public Response interceptGetCapabilities(Response response);
+
+	public Response interceptDescribeFeatureType(Response response);
+
+	public Response interceptGetFeature(Response response);
+
+	public Response interceptLockFeature(Response response);
+
+	public Response interceptTransaction(Response response);
+
+}

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/WmsRequestInterceptorInterface.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/WmsRequestInterceptorInterface.java
@@ -1,0 +1,20 @@
+package de.terrestris.shogun2.util.interceptor;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public interface WmsRequestInterceptorInterface {
+
+	public MutableHttpServletRequest interceptGetMap(MutableHttpServletRequest request);
+
+	public MutableHttpServletRequest interceptGetCapabilities(MutableHttpServletRequest request);
+
+	public MutableHttpServletRequest interceptGetFeatureInfo(MutableHttpServletRequest request);
+
+	public MutableHttpServletRequest interceptDescribeLayer(MutableHttpServletRequest request);
+
+	public MutableHttpServletRequest interceptGetLegendGraphic(MutableHttpServletRequest request);
+
+	public MutableHttpServletRequest interceptGetStyles(MutableHttpServletRequest request);
+
+}

--- a/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/WmsResponseInterceptorInterface.java
+++ b/src/shogun2-util/src/main/java/de/terrestris/shogun2/util/interceptor/WmsResponseInterceptorInterface.java
@@ -1,0 +1,22 @@
+package de.terrestris.shogun2.util.interceptor;
+
+import org.springframework.stereotype.Component;
+
+import de.terrestris.shogun2.util.model.Response;
+
+@Component
+public interface WmsResponseInterceptorInterface {
+
+	public Response interceptGetMap(Response response);
+
+	public Response interceptGetCapabilities(Response response);
+
+	public Response interceptGetFeatureInfo(Response response);
+
+	public Response interceptDescribeLayer(Response response);
+
+	public Response interceptGetLegendGraphic(Response response);
+
+	public Response interceptGetStyles(Response response);
+
+}

--- a/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/http/HttpUtilTest.java
+++ b/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/http/HttpUtilTest.java
@@ -14,12 +14,17 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.bootstrap.HttpServer;
 import org.apache.http.impl.bootstrap.ServerBootstrap;
 import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpRequestHandler;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -121,10 +126,22 @@ public class HttpUtilTest {
 	@BeforeClass
 	public static void setUp() throws IOException, URISyntaxException {
 
+		// simple implementation of the HttpRequestHandler
+		class TestRequestHandler implements HttpRequestHandler {
+			@Override
+			public void handle(HttpRequest request, HttpResponse response,
+					HttpContext context) throws HttpException, IOException {
+				response.setEntity(new StringEntity("SHOGun2 rocks!", "UTF-8"));
+			}
+		};
+
+		TestRequestHandler handler = new TestRequestHandler();
+
 		HttpUtilTest.server = ServerBootstrap.bootstrap()
 				.setLocalAddress(InetAddress.getByName(TEST_SERVER_HOST))
 				.setListenerPort(TEST_SERVER_PORT)
 				.setServerInfo(TEST_SERVER_INFO)
+				.registerHandler("/", handler)
 				.create();
 
 		HttpUtilTest.server.start();

--- a/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/interceptor/InterceptorExceptionTest.java
+++ b/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/interceptor/InterceptorExceptionTest.java
@@ -1,0 +1,28 @@
+package de.terrestris.shogun2.util.interceptor;
+
+import org.junit.Test;
+
+public class InterceptorExceptionTest {
+
+	private static final String EXCEPTION_MESSAGE = "Shinji!";
+
+	@Test(expected = InterceptorException.class)
+	public void throw_exception_empty() throws InterceptorException {
+		throw new InterceptorException();
+	}
+
+	@Test(expected = InterceptorException.class)
+	public void throw_exception_message() throws InterceptorException {
+		throw new InterceptorException(EXCEPTION_MESSAGE);
+	}
+
+	@Test(expected = InterceptorException.class)
+	public void throw_exception_throwable() throws InterceptorException {
+		throw new InterceptorException(new Throwable());
+	}
+
+	@Test(expected = InterceptorException.class)
+	public void throw_exception_message_throwable() throws InterceptorException {
+		throw new InterceptorException(EXCEPTION_MESSAGE, new Throwable());
+	}
+}

--- a/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequestTest.java
+++ b/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequestTest.java
@@ -1,0 +1,103 @@
+package de.terrestris.shogun2.util.interceptor;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.servlet.ServletInputStream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+public class MutableHttpServletRequestTest {
+
+	private static final String DEFAULT_REQUEST_URI = "http://www.the-unity.de";
+
+	private static final String DEFAULT_REQUEST_PARAMETER_KEY = "defaultKey";
+
+	private static final String DEFAULT_REQUEST_PARAMETER_VALUE = "defaultVal";
+
+	private static final String CUSTOM_REQUEST_URL = "http://www.schwatzgelb.de";
+
+	private static final String CUSTOM_REQUEST_PARAMETER_KEY = "Shinji";
+
+	private static final String CUSTOM_REQUEST_PARAMETER_VALUE = "Kagawa";
+
+	private MutableHttpServletRequest mutableRequest;
+
+	@Before
+	public void set_up() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setRequestURI(DEFAULT_REQUEST_URI);
+		request.addParameter(DEFAULT_REQUEST_PARAMETER_KEY,
+				DEFAULT_REQUEST_PARAMETER_VALUE);
+		mutableRequest = new MutableHttpServletRequest(request);
+	}
+
+	@Test
+	public void wrap_request() {
+		assertNotNull(mutableRequest);
+	}
+
+	@Test
+	public void set_request_uri() throws URISyntaxException {
+		mutableRequest.setRequestURI(new URI(CUSTOM_REQUEST_URL));
+		assertEquals(CUSTOM_REQUEST_URL, mutableRequest.getRequestURI());
+	}
+
+	@Test
+	public void set_request_url() {
+		mutableRequest.setRequestURI(CUSTOM_REQUEST_URL);
+		assertEquals(CUSTOM_REQUEST_URL, mutableRequest.getRequestURI());
+	}
+
+	@Test
+	public void set_query_parameter() {
+		mutableRequest.setParameter(DEFAULT_REQUEST_PARAMETER_KEY, CUSTOM_REQUEST_PARAMETER_VALUE);
+		assertEquals(CUSTOM_REQUEST_PARAMETER_VALUE,
+				mutableRequest.getParameter(DEFAULT_REQUEST_PARAMETER_KEY));
+	}
+
+	@Test
+	public void set_query_parameter_array() {
+		String[] param = new String[]{CUSTOM_REQUEST_PARAMETER_VALUE, CUSTOM_REQUEST_PARAMETER_VALUE};
+		mutableRequest.setParameter(DEFAULT_REQUEST_PARAMETER_KEY, param);
+		assertEquals(StringUtils.join(param, ","),
+				mutableRequest.getParameter(DEFAULT_REQUEST_PARAMETER_KEY));
+	}
+
+	@Test
+	public void add_query_parameter() {
+		mutableRequest.addParameter(CUSTOM_REQUEST_PARAMETER_KEY, CUSTOM_REQUEST_PARAMETER_VALUE);
+		assertEquals(CUSTOM_REQUEST_PARAMETER_VALUE, mutableRequest.getParameter(CUSTOM_REQUEST_PARAMETER_KEY));
+	}
+
+	@Test
+	public void add_query_parameter_array() {
+		String[] param = new String[]{CUSTOM_REQUEST_PARAMETER_VALUE, CUSTOM_REQUEST_PARAMETER_VALUE};
+		mutableRequest.addParameter(CUSTOM_REQUEST_PARAMETER_KEY, param);
+		assertEquals(StringUtils.join(param, ","),
+				mutableRequest.getParameter(CUSTOM_REQUEST_PARAMETER_KEY));
+	}
+
+	@Test
+	public void get_parameter_map() {
+		Map<String, String[]> params = mutableRequest.getParameterMap();
+		assertNotNull(params.get(DEFAULT_REQUEST_PARAMETER_KEY));
+	}
+	
+	@Test
+	public void get_rereadable_input_stream() throws IOException {
+		ServletInputStream is = mutableRequest.getInputStream();
+		assertNotNull(is);
+		ServletInputStream is_again = mutableRequest.getInputStream();
+		assertNotNull(is_again);
+	}
+
+}

--- a/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/interceptor/OgcMessageDistributorTest.java
+++ b/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/interceptor/OgcMessageDistributorTest.java
@@ -1,0 +1,108 @@
+package de.terrestris.shogun2.util.interceptor;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import de.terrestris.shogun2.util.model.Response;
+
+public class OgcMessageDistributorTest {
+
+	@Autowired
+	private OgcMessageDistributor distributor;
+
+	public static final String ENDPOINT = "Shinji:Kagawa";
+
+	public static final String SERVICE_WMS = "WMS";
+
+	public static final String OPERATION_GET_MAP = "GetMap";
+
+	public static final String RULE_ALLOW = "ALLOW";
+	public static final String RULE_DENY = "DENY";
+	public static final String RULE_MODIFY = "MODIFY";
+
+	@Before
+	public void set_up() {
+		distributor = new OgcMessageDistributor();
+	}
+
+	@Test
+	public void intercept_request_allowed() throws InterceptorException {
+
+		OgcMessage message = new OgcMessage(null, null, null, RULE_ALLOW, null);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(request);
+
+		MutableHttpServletRequest returnedRequest =
+				distributor.distributeToRequestInterceptor(mutableRequest, message);
+
+		assertNotNull(returnedRequest);
+	}
+
+	@Test(expected=InterceptorException.class)
+	public void intercept_request_denied() throws InterceptorException {
+
+		OgcMessage message = new OgcMessage(null, null, null, RULE_DENY, null);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(request);
+
+		distributor.distributeToRequestInterceptor(mutableRequest, message);
+	}
+
+	@Test
+	public void intercept_request_modified_no_implementation() throws InterceptorException {
+
+		OgcMessage message = new OgcMessage(SERVICE_WMS, OPERATION_GET_MAP, ENDPOINT, RULE_MODIFY, null);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(request);
+
+		MutableHttpServletRequest returnedRequest =
+				distributor.distributeToRequestInterceptor(mutableRequest, message);
+
+		assertNotNull(returnedRequest);
+	}
+
+	@Test
+	public void intercept_response_allowed() throws InterceptorException {
+
+		OgcMessage message = new OgcMessage(null, null, null, null, RULE_ALLOW);
+
+		Response response = new Response();
+
+		Response returnedRequest =
+				distributor.distributeToResponseInterceptor(response, message);
+
+		assertNotNull(returnedRequest);
+	}
+
+	@Test(expected=InterceptorException.class)
+	public void intercept_response_denied() throws InterceptorException {
+
+		OgcMessage message = new OgcMessage(null, null, null, null, RULE_DENY);
+
+		Response response = new Response();
+
+		distributor.distributeToResponseInterceptor(response, message);
+	}
+
+	@Test
+	public void intercept_response_modified_no_implementation() throws InterceptorException {
+
+		OgcMessage message = new OgcMessage(SERVICE_WMS, OPERATION_GET_MAP, ENDPOINT, null, RULE_MODIFY);
+
+		Response response = new Response();
+
+		Response returnedResponse =
+				distributor.distributeToResponseInterceptor(response, message);
+
+		assertNotNull(returnedResponse);
+	}
+
+
+}

--- a/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/interceptor/OgcMessageTest.java
+++ b/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/interceptor/OgcMessageTest.java
@@ -1,0 +1,195 @@
+package de.terrestris.shogun2.util.interceptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class OgcMessageTest {
+
+	public static final String ENDPOINT = "Shinji:Kagawa";
+
+	public static final String SERVICE_WMS = "WMS";
+	public static final String SERVICE_WFS = "WFS";
+	public static final String SERVICE_WCS = "WCS";
+
+	public static final String OPERATION_GET_MAP = "GetMap";
+	public static final String OPERATION_GET_CAPABILITIES = "GetCapabilities";
+	public static final String OPERATION_GET_FEATURE_INFO = "GetFeatureInfo";
+	public static final String OPERATION_DESCRIBE_LAYER = "DescribeLayer";
+	public static final String OPERATION_GET_LEGEND_GRAPHIC = "GetLegendGraphic";
+	public static final String OPERATION_GET_STYLES = "GetStyles";
+	public static final String OPERATION_DESCRIBE_FEATURE_TYPE = "DescribeFeatureType";
+	public static final String OPERATION_GET_FEATURE = "GetFeature";
+	public static final String OPERATION_LOCK_FEATURE = "LockFeature";
+	public static final String OPERATION_TRANSACTION = "Transaction";
+	public static final String OPERATION_DESCRIBE_COVERAGE = "DescribeCoverage";
+	public static final String OPERATION_GET_COVERAGE = "GetCoverage";
+
+	public static final String RULE_ALLOW = "ALLOW";
+	public static final String RULE_DENY = "DENY";
+	public static final String RULE_MODIFY = "MODIFY";
+
+	@Test
+	public void can_be_instantiated() {
+
+		OgcMessage message;
+
+		message = new OgcMessage();
+
+		assertNotNull(message);
+
+		message = new OgcMessage(SERVICE_WMS, OPERATION_GET_MAP, ENDPOINT, RULE_ALLOW, RULE_ALLOW);
+
+		assertEquals(SERVICE_WMS, message.getService());
+		assertEquals(OPERATION_GET_MAP, message.getOperation());
+		assertEquals(ENDPOINT, message.getEndPoint());
+		assertEquals(RULE_ALLOW, message.getRequestRule());
+		assertEquals(RULE_ALLOW, message.getResponseRule());
+	}
+
+	@Test
+	public void is_wms() {
+		OgcMessage message = new OgcMessage(SERVICE_WMS, null, null, null, null);
+		assertEquals(true, message.isWms());
+	}
+
+	@Test
+	public void is_wfs() {
+		OgcMessage message = new OgcMessage(SERVICE_WFS, null, null, null, null);
+		assertEquals(true, message.isWfs());
+	}
+
+	@Test
+	public void is_wcs() {
+		OgcMessage message = new OgcMessage(SERVICE_WCS, null, null, null, null);
+		assertEquals(true, message.isWcs());
+	}
+
+	@Test
+	public void is_wms_get_capabilities() {
+		OgcMessage message = new OgcMessage(SERVICE_WMS, OPERATION_GET_CAPABILITIES, null, null, null);
+		assertEquals(true, message.isWmsGetCapabilities());
+	}
+
+	@Test
+	public void is_wms_get_map() {
+		OgcMessage message = new OgcMessage(SERVICE_WMS, OPERATION_GET_MAP, null, null, null);
+		assertEquals(true, message.isWmsGetMap());
+	}
+
+	@Test
+	public void is_wms_get_feature_info() {
+		OgcMessage message = new OgcMessage(SERVICE_WMS, OPERATION_GET_FEATURE_INFO, null, null, null);
+		assertEquals(true, message.isWmsGetFeatureInfo());
+	}
+
+	@Test
+	public void is_wms_describe_layer() {
+		OgcMessage message = new OgcMessage(SERVICE_WMS, OPERATION_DESCRIBE_LAYER, null, null, null);
+		assertEquals(true, message.isWmsDescribeLayer());
+	}
+
+	@Test
+	public void is_wms_get_legend_graphic() {
+		OgcMessage message = new OgcMessage(SERVICE_WMS, OPERATION_GET_LEGEND_GRAPHIC, null, null, null);
+		assertEquals(true, message.isWmsGetLegendGraphic());
+	}
+
+	@Test
+	public void is_wms_get_styles() {
+		OgcMessage message = new OgcMessage(SERVICE_WMS, OPERATION_GET_STYLES, null, null, null);
+		assertEquals(true, message.isWmsGetStyles());
+	}
+
+	@Test
+	public void is_wfs_get_capabilities() {
+		OgcMessage message = new OgcMessage(SERVICE_WFS, OPERATION_GET_CAPABILITIES, null, null, null);
+		assertEquals(true, message.isWfsGetCapabilities());
+	}
+
+	@Test
+	public void is_wfs_describe_feature_type() {
+		OgcMessage message = new OgcMessage(SERVICE_WFS, OPERATION_DESCRIBE_FEATURE_TYPE, null, null, null);
+		assertEquals(true, message.isWfsDescribeFeatureType());
+	}
+
+	@Test
+	public void is_wfs_get_feature() {
+		OgcMessage message = new OgcMessage(SERVICE_WFS, OPERATION_GET_FEATURE, null, null, null);
+		assertEquals(true, message.isWfsGetFeature());
+	}
+
+	@Test
+	public void is_wfs_lock_feature() {
+		OgcMessage message = new OgcMessage(SERVICE_WFS, OPERATION_LOCK_FEATURE, null, null, null);
+		assertEquals(true, message.isWfsLockFeature());
+	}
+
+	@Test
+	public void is_wfs_transaction() {
+		OgcMessage message = new OgcMessage(SERVICE_WFS, OPERATION_TRANSACTION, null, null, null);
+		assertEquals(true, message.isWfsTransaction());
+	}
+
+	@Test
+	public void is_wcs_get_capabilities() {
+		OgcMessage message = new OgcMessage(SERVICE_WCS, OPERATION_GET_CAPABILITIES, null, null, null);
+		assertEquals(true, message.isWcsGetCapabilities());
+	}
+
+	@Test
+	public void is_wcs_describe_coverage() {
+		OgcMessage message = new OgcMessage(SERVICE_WCS, OPERATION_DESCRIBE_COVERAGE, null, null, null);
+		assertEquals(true, message.isWcsDescribeCoverage());
+	}
+
+	@Test
+	public void is_wcs_get_coverage() {
+		OgcMessage message = new OgcMessage(SERVICE_WCS, OPERATION_GET_COVERAGE, null, null, null);
+		assertEquals(true, message.isWcsGetCoverage());
+	}
+
+	@Test
+	public void is_request_allowed() {
+		OgcMessage message = new OgcMessage(null, null, null, RULE_ALLOW, null);
+		assertEquals(true, message.isRequestAllowed());
+	}
+
+	@Test
+	public void is_response_allowed() {
+		OgcMessage message = new OgcMessage(null, null, null, null, RULE_ALLOW);
+		assertEquals(true, message.isResponseAllowed());
+	}
+
+	@Test
+	public void is_request_denied() {
+		OgcMessage message = new OgcMessage(null, null, null, RULE_DENY, null);
+		assertEquals(true, message.isRequestDenied());
+	}
+
+	@Test
+	public void is_response_denied() {
+		OgcMessage message = new OgcMessage(null, null, null, null, RULE_DENY);
+		assertEquals(true, message.isResponseDenied());
+	}
+
+	@Test
+	public void is_request_modified() {
+		OgcMessage message = new OgcMessage(null, null, null, RULE_MODIFY, null);
+		assertEquals(true, message.isRequestModified());
+	}
+
+	@Test
+	public void is_response_modified() {
+		OgcMessage message = new OgcMessage(null, null, null, null, RULE_MODIFY);
+		assertEquals(true, message.isResponseModified());
+	}
+
+}

--- a/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/interceptor/OgcNamingTest.java
+++ b/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/interceptor/OgcNamingTest.java
@@ -1,0 +1,61 @@
+package de.terrestris.shogun2.util.interceptor;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+public class OgcNamingTest {
+
+	public static final String PARAMETER_SERVICE = "SERVICE";
+	public static final String PARAMETER_OPERATION = "REQUEST";
+	public static final String[] PARAMETER_ENDPOINT = {"LAYERS", "LAYER", "NAMESPACE"};
+
+	public static final String SERVICE_WMS = "WMS";
+	public static final String SERVICE_WFS = "WFS";
+	public static final String SERVICE_WCS = "WCS";
+
+	public static final String OPERATION_GET_MAP = "GetMap";
+	public static final String OPERATION_GET_CAPABILITIES = "GetCapabilities";
+	public static final String OPERATION_GET_FEATURE_INFO = "GetFeatureInfo";
+	public static final String OPERATION_DESCRIBE_LAYER = "DescribeLayer";
+	public static final String OPERATION_GET_LEGEND_GRAPHIC = "GetLegendGraphic";
+	public static final String OPERATION_GET_STYLES = "GetStyles";
+	public static final String OPERATION_DESCRIBE_FEATURE_TYPE = "DescribeFeatureType";
+	public static final String OPERATION_GET_FEATURE = "GetFeature";
+	public static final String OPERATION_LOCK_FEATURE = "LockFeature";
+	public static final String OPERATION_TRANSACTION = "Transaction";
+	public static final String OPERATION_DESCRIBE_COVERAGE = "DescribeCoverage";
+	public static final String OPERATION_GET_COVERAGE = "GetCoverage";
+
+	@Test
+	public void can_be_instantiated() {
+		OgcNaming ogcNaming = new OgcNaming();
+		assertNotNull(ogcNaming);
+	}
+
+	@Test
+	public void correct_ogc_values_present() {
+		assertEquals(PARAMETER_SERVICE, OgcNaming.PARAMETER_SERVICE);
+		assertEquals(PARAMETER_OPERATION, OgcNaming.PARAMETER_OPERATION);
+		assertArrayEquals(PARAMETER_ENDPOINT, OgcNaming.PARAMETER_ENDPOINT);
+
+		assertEquals(SERVICE_WMS, OgcNaming.SERVICE_WMS);
+		assertEquals(SERVICE_WFS, OgcNaming.SERVICE_WFS);
+		assertEquals(SERVICE_WCS, OgcNaming.SERVICE_WCS);
+
+		assertEquals(OPERATION_GET_MAP, OgcNaming.OPERATION_GET_MAP);
+		assertEquals(OPERATION_GET_CAPABILITIES, OgcNaming.OPERATION_GET_CAPABILITIES);
+		assertEquals(OPERATION_GET_FEATURE_INFO, OgcNaming.OPERATION_GET_FEATURE_INFO);
+		assertEquals(OPERATION_DESCRIBE_LAYER, OgcNaming.OPERATION_DESCRIBE_LAYER);
+		assertEquals(OPERATION_GET_LEGEND_GRAPHIC, OgcNaming.OPERATION_GET_LEGEND_GRAPHIC);
+		assertEquals(OPERATION_GET_STYLES, OgcNaming.OPERATION_GET_STYLES);
+		assertEquals(OPERATION_DESCRIBE_FEATURE_TYPE, OgcNaming.OPERATION_DESCRIBE_FEATURE_TYPE);
+		assertEquals(OPERATION_GET_FEATURE, OgcNaming.OPERATION_GET_FEATURE);
+		assertEquals(OPERATION_LOCK_FEATURE, OgcNaming.OPERATION_LOCK_FEATURE);
+		assertEquals(OPERATION_TRANSACTION, OgcNaming.OPERATION_TRANSACTION);
+		assertEquals(OPERATION_DESCRIBE_COVERAGE, OgcNaming.OPERATION_DESCRIBE_COVERAGE);
+		assertEquals(OPERATION_GET_COVERAGE, OgcNaming.OPERATION_GET_COVERAGE);
+	}
+}

--- a/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/interceptor/OgcXmlUtilTest.java
+++ b/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/interceptor/OgcXmlUtilTest.java
@@ -1,0 +1,97 @@
+package de.terrestris.shogun2.util.interceptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.w3c.dom.Document;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class OgcXmlUtilTest {
+
+	public static final String XML_STRING = "<root attribute=\"value\"><element>text</element></root>";
+
+	public static final String CORRUPTED_XML_STRING = "<root><element></not-matching-element></root>";
+
+	@Test
+	public void get_request_body_default_charset() {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+
+		request.setContent(XML_STRING.getBytes());
+
+		String body = OgcXmlUtil.getRequestBody(request);
+
+		assertEquals(XML_STRING, body);
+	}
+
+	@Test
+	public void get_request_body_utf8() {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+
+		request.setContent(XML_STRING.getBytes());
+		request.setCharacterEncoding("UTF-8");
+
+		String body = OgcXmlUtil.getRequestBody(request);
+
+		assertEquals(XML_STRING, body);
+	}
+
+	@Test
+	public void get_document_from_string() throws IOException {
+
+		Document doc = OgcXmlUtil.getDocumentFromString(XML_STRING);
+
+		assertNotNull(doc);
+	}
+
+	@Test(expected=IOException.class)
+	public void get_document_from_string_throws_exception() throws IOException {
+
+		OgcXmlUtil.getDocumentFromString(CORRUPTED_XML_STRING);
+	}
+
+	@Test
+	public void get_path_in_document_root_name() throws InterceptorException, IOException {
+
+		Document doc = OgcXmlUtil.getDocumentFromString(XML_STRING);
+
+		assertNotNull(doc);
+
+		String res = OgcXmlUtil.getPathInDocument(doc, "name(/*)");
+
+		assertEquals("root", res);
+	}
+
+	@Test
+	public void get_path_in_document_attribute_value() throws InterceptorException, IOException {
+
+		Document doc = OgcXmlUtil.getDocumentFromString(XML_STRING);
+
+		assertNotNull(doc);
+
+		String res = OgcXmlUtil.getPathInDocument(doc, "/*/@attribute");
+
+		assertEquals("value", res);
+	}
+
+	@Test(expected=InterceptorException.class)
+	public void get_path_in_document_throws_exception() throws InterceptorException, IOException {
+
+		Document doc = OgcXmlUtil.getDocumentFromString(XML_STRING);
+
+		assertNotNull(doc);
+
+		OgcXmlUtil.getPathInDocument(doc, "invalid XPath selector");
+	}
+
+}

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/GeoServerInterceptorController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/web/GeoServerInterceptorController.java
@@ -1,0 +1,97 @@
+package de.terrestris.shogun2.web;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import de.terrestris.shogun2.service.GeoServerInterceptorService;
+import de.terrestris.shogun2.util.data.ResultSet;
+import de.terrestris.shogun2.util.model.Response;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author Kai Volland
+ * @author terrestris GmbH & Co. KG
+ *
+ * @param <S>
+ */
+@Controller
+public class GeoServerInterceptorController<S extends GeoServerInterceptorService> {
+
+	/**
+	 * The Logger.
+	 */
+	private static final Logger LOG = Logger.getLogger(
+			GeoServerInterceptorController.class);
+
+	/**
+	 *
+	 */
+	protected S service;
+
+	/**
+	 *
+	 */
+	private static final String ERROR_MESSAGE = "Error while requesting a " +
+			"GeoServer resource: ";
+
+	/**
+	 *
+	 * @param request
+	 * @return
+	 * @throws IOException
+	 */
+	@RequestMapping(value = "/geoserver.action", method = {
+			RequestMethod.GET, RequestMethod.POST })
+	public ResponseEntity<?> interceptGeoServerRequest(HttpServletRequest request) {
+
+		HttpHeaders responseHeaders = new HttpHeaders();
+		HttpStatus responseStatus = HttpStatus.OK;
+		byte[] responseBody = null;
+		Response httpResponse = null;
+
+		try {
+
+			httpResponse = this.service.interceptGeoServerRequest(request);
+
+			responseStatus = httpResponse.getStatusCode();
+			responseBody = httpResponse.getBody();
+			responseHeaders = httpResponse.getHeaders();
+
+			return new ResponseEntity<byte[]>(responseBody,
+					responseHeaders, responseStatus);
+
+		} catch (Exception e) {
+			LOG.error(ERROR_MESSAGE + e.getMessage());
+
+			responseHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+			Map<String, Object> responseMsg = ResultSet.error(
+					ERROR_MESSAGE + e.getMessage());
+
+			return new ResponseEntity<Map<String, Object>>(responseMsg,
+					responseHeaders, responseStatus);
+		}
+
+	}
+
+	/**
+	 * @param service the service to set
+	 */
+	@Autowired
+	public void setService(S service) {
+		this.service = service;
+	}
+}

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/util/WcsRequestInterceptor.java
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/util/WcsRequestInterceptor.java
@@ -1,0 +1,36 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package}.util;
+
+import de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest;
+import de.terrestris.shogun2.util.interceptor.WcsRequestInterceptorInterface;
+
+/**
+ * This class demonstrates how to implement the WcsRequestInterceptorInterface.
+ * 
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class WcsRequestInterceptor implements WcsRequestInterceptorInterface {
+
+	@Override
+	public MutableHttpServletRequest interceptGetCapabilities(
+			MutableHttpServletRequest request) {
+		return request;
+	}
+
+	@Override
+	public MutableHttpServletRequest interceptDescribeCoverage(
+			MutableHttpServletRequest request) {
+		return request;
+	}
+
+	@Override
+	public MutableHttpServletRequest interceptGetCoverage(
+			MutableHttpServletRequest request) {
+		return request;
+	}
+
+}

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/util/WcsResponseInterceptor.java
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/util/WcsResponseInterceptor.java
@@ -1,0 +1,33 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package}.util;
+
+import de.terrestris.shogun2.util.interceptor.WcsResponseInterceptorInterface;
+import de.terrestris.shogun2.util.model.Response;
+
+/**
+ * This class demonstrates how to implement the WcsResponseInterceptorInterface.
+ * 
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class WcsResponseInterceptor implements WcsResponseInterceptorInterface{
+
+	@Override
+	public Response interceptGetCapabilities(Response response) {
+		return response;
+	}
+
+	@Override
+	public Response interceptDescribeCoverage(Response response) {
+		return response;
+	}
+
+	@Override
+	public Response interceptGetCoverage(Response response) {
+		return response;
+	}
+
+}

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/util/WfsRequestInterceptor.java
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/util/WfsRequestInterceptor.java
@@ -1,0 +1,48 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package}.util;
+
+import de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest;
+import de.terrestris.shogun2.util.interceptor.WfsRequestInterceptorInterface;
+
+/**
+ * This class demonstrates how to implement the WfsRequestInterceptorInterface.
+ * 
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class WfsRequestInterceptor implements WfsRequestInterceptorInterface {
+
+	@Override
+	public MutableHttpServletRequest interceptGetCapabilities(
+			MutableHttpServletRequest request) {
+		return request;
+	}
+
+	@Override
+	public MutableHttpServletRequest interceptDescribeFeatureType(
+			MutableHttpServletRequest request) {
+		return request;
+	}
+
+	@Override
+	public MutableHttpServletRequest interceptGetFeature(
+			MutableHttpServletRequest request) {
+		return request;
+	}
+
+	@Override
+	public MutableHttpServletRequest interceptLockFeature(
+			MutableHttpServletRequest request) {
+		return request;
+	}
+
+	@Override
+	public MutableHttpServletRequest interceptTransaction(
+			MutableHttpServletRequest request) {
+		return request;
+	}
+
+}

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/util/WfsResponseInterceptor.java
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/util/WfsResponseInterceptor.java
@@ -1,0 +1,43 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package}.util;
+
+import de.terrestris.shogun2.util.interceptor.WfsResponseInterceptorInterface;
+import de.terrestris.shogun2.util.model.Response;
+
+/**
+ * This class demonstrates how to implement the WfsResponseInterceptorInterface.
+ * 
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class WfsResponseInterceptor implements WfsResponseInterceptorInterface{
+
+	@Override
+	public Response interceptGetCapabilities(Response response) {
+		return response;
+	}
+
+	@Override
+	public Response interceptDescribeFeatureType(Response response) {
+		return response;
+	}
+
+	@Override
+	public Response interceptGetFeature(Response response) {
+		return response;
+	}
+
+	@Override
+	public Response interceptLockFeature(Response response) {
+		return response;
+	}
+
+	@Override
+	public Response interceptTransaction(Response response) {
+		return response;
+	}
+
+}

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/util/WmsRequestInterceptor.java
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/util/WmsRequestInterceptor.java
@@ -1,0 +1,55 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package}.util;
+
+import de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest;
+import de.terrestris.shogun2.util.interceptor.WmsRequestInterceptorInterface;
+
+/**
+ * This class demonstrates how to implement the WmsRequestInterceptorInterface.
+ * 
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class WmsRequestInterceptor implements WmsRequestInterceptorInterface {
+
+	@Override
+	public MutableHttpServletRequest interceptGetMap(
+			MutableHttpServletRequest request) {
+		request.setParameter("LAYERS", "peter");
+		return request;
+	}
+
+	@Override
+	public MutableHttpServletRequest interceptGetCapabilities(
+			MutableHttpServletRequest request) {
+		return request;
+	}
+
+	@Override
+	public MutableHttpServletRequest interceptGetFeatureInfo(
+			MutableHttpServletRequest request) {
+		return request;
+	}
+
+	@Override
+	public MutableHttpServletRequest interceptDescribeLayer(
+			MutableHttpServletRequest request) {
+		return request;
+	}
+
+	@Override
+	public MutableHttpServletRequest interceptGetLegendGraphic(
+			MutableHttpServletRequest request) {
+		return request;
+	}
+
+	@Override
+	public MutableHttpServletRequest interceptGetStyles(
+			MutableHttpServletRequest request) {
+		return request;
+	}
+
+}

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/util/WmsResponseInterceptor.java
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/util/WmsResponseInterceptor.java
@@ -1,0 +1,48 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package}.util;
+
+import de.terrestris.shogun2.util.interceptor.WmsResponseInterceptorInterface;
+import de.terrestris.shogun2.util.model.Response;
+
+/**
+ * This class demonstrates how to implement the WmsResponseInterceptorInterface.
+ * 
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class WmsResponseInterceptor implements WmsResponseInterceptorInterface {
+
+	@Override
+	public Response interceptGetMap(Response response) {
+		return response;
+	}
+
+	@Override
+	public Response interceptGetCapabilities(Response response) {
+		return response;
+	}
+
+	@Override
+	public Response interceptGetFeatureInfo(Response response) {
+		return response;
+	}
+
+	@Override
+	public Response interceptDescribeLayer(Response response) {
+		return response;
+	}
+
+	@Override
+	public Response interceptGetLegendGraphic(Response response) {
+		return response;
+	}
+
+	@Override
+	public Response interceptGetStyles(Response response) {
+		return response;
+	}
+
+}

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/geoServerNameSpaces.properties
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/geoServerNameSpaces.properties
@@ -1,0 +1,1 @@
+topp=http://localhost:8080/geoserver/topp/ows

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-initialize-beans.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-initialize-beans.xml
@@ -548,4 +548,41 @@
         </property>
     </bean>
 
+    <!-- The default interceptor roles -->
+    <bean id="defaultWMSRequestInterceptorRule" class="de.terrestris.shogun2.model.interceptor.InterceptorRule">
+        <property name="event" value="REQUEST"/>
+        <property name="rule" value="ALLOW"/>
+        <property name="service" value="WMS"/>
+    </bean>
+
+    <bean id="defaultWMSResponseInterceptorRule" class="de.terrestris.shogun2.model.interceptor.InterceptorRule">
+        <property name="event" value="RESPONSE"/>
+        <property name="rule" value="ALLOW"/>
+        <property name="service" value="WMS"/>
+    </bean>
+
+    <bean id="defaultWFSRequestInterceptorRule" class="de.terrestris.shogun2.model.interceptor.InterceptorRule">
+        <property name="event" value="REQUEST"/>
+        <property name="rule" value="ALLOW"/>
+        <property name="service" value="WFS"/>
+    </bean>
+
+    <bean id="defaultWFSResponseInterceptorRule" class="de.terrestris.shogun2.model.interceptor.InterceptorRule">
+        <property name="event" value="RESPONSE"/>
+        <property name="rule" value="ALLOW"/>
+        <property name="service" value="WFS"/>
+    </bean>
+
+    <bean id="defaultWCSRequestInterceptorRule" class="de.terrestris.shogun2.model.interceptor.InterceptorRule">
+        <property name="event" value="REQUEST"/>
+        <property name="rule" value="ALLOW"/>
+        <property name="service" value="WCS"/>
+    </bean>
+
+    <bean id="defaultWCSResponseInterceptorRule" class="de.terrestris.shogun2.model.interceptor.InterceptorRule">
+        <property name="event" value="RESPONSE"/>
+        <property name="rule" value="ALLOW"/>
+        <property name="service" value="WCS"/>
+    </bean>
+
 </beans>

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-initialize-beans.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-initialize-beans.xml
@@ -72,6 +72,14 @@
         <!-- Permissions -->
         <ref bean="defaultUserPermissionCollection" />
 
+        <!-- GeoServer Interceptor Rules -->
+        <ref bean="defaultWMSRequestInterceptorRule" />
+        <ref bean="defaultWMSResponseInterceptorRule" />
+        <ref bean="defaultWFSRequestInterceptorRule" />
+        <ref bean="defaultWFSResponseInterceptorRule" />
+        <ref bean="defaultWCSRequestInterceptorRule" />
+        <ref bean="defaultWCSResponseInterceptorRule" />
+
         <!-- Applications -->
         <ref bean="defaultApplication"/>
     </util:list>

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context.xml
@@ -11,10 +11,14 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:aop="http://www.springframework.org/schema/aop"
+       xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
                            http://www.springframework.org/schema/beans/spring-beans.xsd
                            http://www.springframework.org/schema/context
-                           http://www.springframework.org/schema/context/spring-context.xsd">
+                           http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/util
+                           http://www.springframework.org/schema/util/spring-util.xsd">
+
 
     <context:property-placeholder location="classpath*:META-INF/*.properties" />
 
@@ -70,5 +74,8 @@
     <bean id="changePasswordPath" class="java.lang.String">
         <constructor-arg value="${login.changePasswordPath}"></constructor-arg>
     </bean>
+
+    <!-- The GeoServer Namespace to URI map used in the Interceptor -->
+    <util:properties id="geoServerNameSpaces" location="classpath*:META-INF/geoServerNameSpaces.properties" />
 
 </beans>

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/__artifactId__-servlet.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/__artifactId__-servlet.xml
@@ -25,6 +25,9 @@ ${shogun2-parent-package}.*.web" )
 			serialization -->
 		<mvc:message-converters>
 			<beans:bean
+				class="org.springframework.http.converter.ByteArrayHttpMessageConverter">
+			</beans:bean>
+			<beans:bean
 				class="org.springframework.http.converter.json.MappingJackson2HttpMessageConverter">
 				<beans:property name="objectMapper" ref="jacksonObjectMapper" />
 			</beans:bean>

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/log4j.properties
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/log4j.properties
@@ -40,6 +40,9 @@ log4j.logger.com.mchange.v2=INFO
 ${symbol_pound} configure the extdirectspring logging
 log4j.logger.ch.ralscha.extdirectspring=INFO
 
+${symbol_pound} configure the org.apache.http logging
+log4j.logger.org.apache.http=INFO
+
 ${symbol_pound}${symbol_pound}${symbol_pound} log HQL query parser activity
 ${symbol_pound}log4j.logger.org.hibernate.hql.ast.AST=debug
 


### PR DESCRIPTION
This PR includes a proposal of a GeoServer OGC interceptor (see #134 as well).

In principal the interceptor deals as a proxy for a single or set of GeoServer instances and allows the SHOGun2 based application to orchestrate any request made to these instances individually on the basis of so called *InterceptorRules*. 

To make use of simply send a request to the newly created controller `geoserver.action` and append the default OGC request to it, e.g. `http:localhost:8080/myApp/geoserver.action?SERVICE=WMS&REQUEST=DescribeLayer&VERSION=1.1.1&LAYERS=topp:states`. For the moment the interceptor can handle all supported GeoServer WMS, WFS and WCS operations for GET and POST requests. The proxy part of the controller will forward the request to the defined location of the GeoServer instance based on the `Namespace` found in the request. The lookup is to defined in the `geoServerNameSpaces.properties` file (see webapp-archetype resources for a example).

Interception of events (request or response) is highly configurable on the basis of rules. A rule is thereby defined on the service, operation and endPoint of the request or response, where the highest rule rank is determined by the *most specific path* of a rule. In general a rule can have three states/permissions: *ALLOW* (no application side modification of the request/response), *DENY* (block the request/response), *MODIFY* (modify the response/request according to the interceptor implementation in your project application). In the latter case one has to implement the interceptor interfaces (e.g. `WmsRequestInterceptorInterface`) with the needed functionality.

Please review!