### PR TITLE
Json identity info deserialization

### DIFF
--- a/src/shogun2-core/shogun2-dao/pom.xml
+++ b/src/shogun2-core/shogun2-dao/pom.xml
@@ -23,6 +23,12 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- Hibernate -->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+        </dependency>
+
         <!-- JUnit -->
         <dependency>
             <groupId>junit</groupId>
@@ -70,6 +76,12 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
+        </dependency>
+
+        <!-- Utils -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
 
     </dependencies>

--- a/src/shogun2-core/shogun2-model/pom.xml
+++ b/src/shogun2-core/shogun2-model/pom.xml
@@ -27,11 +27,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>
@@ -44,6 +39,11 @@
         <dependency>
             <groupId>ch.rasc</groupId>
             <artifactId>extclassgenerator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
     </dependencies>
 

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/converter/LayerIdResolver.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/converter/LayerIdResolver.java
@@ -1,0 +1,30 @@
+package de.terrestris.shogun2.converter;
+
+import de.terrestris.shogun2.model.layer.Layer;
+
+/**
+ *
+ * @author Nils Buehner
+ *
+ */
+public class LayerIdResolver<E extends Layer> extends
+		PersistentObjectIdResolver<Layer> {
+
+	/**
+	 * Default Constructor
+	 */
+	public LayerIdResolver() {
+		super(Layer.class);
+	}
+
+	/**
+	 * Constructor that has to be called by subclasses.
+	 *
+	 * @param entityClass
+	 */
+	@SuppressWarnings("unchecked")
+	protected LayerIdResolver(Class<E> entityClass) {
+		super((Class<Layer>) entityClass);
+	}
+
+}

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/converter/PersistentObjectIdResolver.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/converter/PersistentObjectIdResolver.java
@@ -1,0 +1,79 @@
+package de.terrestris.shogun2.converter;
+
+import org.apache.log4j.Logger;
+
+import com.fasterxml.jackson.annotation.ObjectIdGenerator.IdKey;
+import com.fasterxml.jackson.annotation.ObjectIdResolver;
+import com.fasterxml.jackson.annotation.SimpleObjectIdResolver;
+
+import de.terrestris.shogun2.helper.IdHelper;
+import de.terrestris.shogun2.model.PersistentObject;
+
+/**
+ *
+ * An ID resolver for {@link PersistentObject}s when deserializing only on the base
+ * of ID values. Extends the default implementation.
+ *
+ * @author Nils Buehner
+ *
+ */
+public abstract class PersistentObjectIdResolver<E extends PersistentObject> extends SimpleObjectIdResolver {
+
+	protected final Logger LOG = Logger.getLogger(getClass());
+
+	protected final Class<E> entityClass;
+
+	/**
+	 * Constructor that has to be called by subclasses.
+	 *
+	 * @param entityClass
+	 */
+	protected PersistentObjectIdResolver(Class<E> entityClass) {
+		this.entityClass = entityClass;
+	}
+
+	@Override
+	public void bindItem(IdKey id, Object ob) {
+		super.bindItem(id, ob);
+	}
+
+	@Override
+	public E resolveId(IdKey id) {
+		try {
+			if (id.key instanceof Integer) {
+				// return a "dummy" object, which only has the correct ID value
+				E entity = getEntityClass().newInstance();
+				IdHelper.setIdOnPersistentObject(entity, (Integer) id.key);
+				return entity;
+			} else {
+				throw new Exception("ID is not of type Integer.");
+			}
+		} catch (Exception e) {
+			LOG.error("Could not resolve object by ID: " + e.getMessage());
+			return null;
+		}
+
+	}
+
+	@Override
+	public boolean canUseFor(ObjectIdResolver resolverType) {
+		return super.canUseFor(resolverType);
+	}
+
+	@Override
+	public ObjectIdResolver newForDeserialization(Object context) {
+		try {
+			return getClass().newInstance();
+		} catch (InstantiationException | IllegalAccessException e) {
+			LOG.error("Error instantiating ObjectIdResolver: " + e.getMessage());
+		}
+		return null;
+	}
+
+	/**
+	 * @return the entityClass
+	 */
+	public Class<E> getEntityClass() {
+		return entityClass;
+	}
+}

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/converter/UserGroupIdResolver.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/converter/UserGroupIdResolver.java
@@ -1,0 +1,60 @@
+package de.terrestris.shogun2.converter;
+
+import org.apache.log4j.Logger;
+
+import com.fasterxml.jackson.annotation.ObjectIdGenerator.IdKey;
+import com.fasterxml.jackson.annotation.ObjectIdResolver;
+import com.fasterxml.jackson.annotation.SimpleObjectIdResolver;
+
+import de.terrestris.shogun2.helper.IdHelper;
+import de.terrestris.shogun2.model.UserGroup;
+
+/**
+ * 
+ * An ID resolver for the {@link UserGroup} when deserializing only on the base
+ * of ID values. Extends the default implementation.
+ *
+ * @author Nils Buehner
+ *
+ */
+public class UserGroupIdResolver extends SimpleObjectIdResolver {
+
+	protected final Logger LOG = Logger.getLogger(getClass());
+
+	public UserGroupIdResolver() {
+	}
+
+	@Override
+	public void bindItem(IdKey id, Object ob) {
+		super.bindItem(id, ob);
+	}
+
+	@Override
+	public Object resolveId(IdKey id) {
+
+		try {
+			if (id.key instanceof Integer) {
+				// return a "dummy" object, which only has the correct ID value
+				UserGroup userGroup = new UserGroup();
+				IdHelper.setIdOnPersistentObject(userGroup, (Integer) id.key);
+				return userGroup;
+			} else {
+				throw new Exception("ID is not of type Integer.");
+			}
+		} catch (Exception e) {
+			LOG.error("Could not resolve object by ID: " + e.getMessage());
+			return null;
+		}
+
+	}
+
+	@Override
+	public boolean canUseFor(ObjectIdResolver resolverType) {
+		return super.canUseFor(resolverType);
+	}
+
+	@Override
+	public ObjectIdResolver newForDeserialization(Object context) {
+		return new UserGroupIdResolver();
+	}
+}

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/converter/UserGroupIdResolver.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/converter/UserGroupIdResolver.java
@@ -1,60 +1,30 @@
 package de.terrestris.shogun2.converter;
 
-import org.apache.log4j.Logger;
-
-import com.fasterxml.jackson.annotation.ObjectIdGenerator.IdKey;
-import com.fasterxml.jackson.annotation.ObjectIdResolver;
-import com.fasterxml.jackson.annotation.SimpleObjectIdResolver;
-
-import de.terrestris.shogun2.helper.IdHelper;
 import de.terrestris.shogun2.model.UserGroup;
 
 /**
- * 
- * An ID resolver for the {@link UserGroup} when deserializing only on the base
- * of ID values. Extends the default implementation.
  *
  * @author Nils Buehner
  *
  */
-public class UserGroupIdResolver extends SimpleObjectIdResolver {
+public class UserGroupIdResolver<E extends UserGroup> extends
+		PersistentObjectIdResolver<UserGroup> {
 
-	protected final Logger LOG = Logger.getLogger(getClass());
-
+	/**
+	 * Default Constructor
+	 */
 	public UserGroupIdResolver() {
+		super(UserGroup.class);
 	}
 
-	@Override
-	public void bindItem(IdKey id, Object ob) {
-		super.bindItem(id, ob);
+	/**
+	 * Constructor that has to be called by subclasses.
+	 *
+	 * @param entityClass
+	 */
+	@SuppressWarnings("unchecked")
+	protected UserGroupIdResolver(Class<E> entityClass) {
+		super((Class<UserGroup>) entityClass);
 	}
 
-	@Override
-	public Object resolveId(IdKey id) {
-
-		try {
-			if (id.key instanceof Integer) {
-				// return a "dummy" object, which only has the correct ID value
-				UserGroup userGroup = new UserGroup();
-				IdHelper.setIdOnPersistentObject(userGroup, (Integer) id.key);
-				return userGroup;
-			} else {
-				throw new Exception("ID is not of type Integer.");
-			}
-		} catch (Exception e) {
-			LOG.error("Could not resolve object by ID: " + e.getMessage());
-			return null;
-		}
-
-	}
-
-	@Override
-	public boolean canUseFor(ObjectIdResolver resolverType) {
-		return super.canUseFor(resolverType);
-	}
-
-	@Override
-	public ObjectIdResolver newForDeserialization(Object context) {
-		return new UserGroupIdResolver();
-	}
 }

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/helper/IdHelper.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/helper/IdHelper.java
@@ -1,10 +1,10 @@
-package de.terrestris.shogun2.util.test;
+package de.terrestris.shogun2.helper;
 
 import java.lang.reflect.Field;
 
 import de.terrestris.shogun2.model.PersistentObject;
 
-public class TestUtil {
+public class IdHelper {
 
 	/**
 	 * Helper method that uses reflection to set the (inaccessible) id field of

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/User.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/User.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 
 import ch.rasc.extclassgenerator.Model;
+import de.terrestris.shogun2.converter.UserGroupIdResolver;
 
 /**
  * @author Nils Bühner
@@ -64,7 +65,8 @@ public class User extends Person {
 	@OrderColumn(name = "IDX")
 	@JsonIdentityInfo(
 		generator = ObjectIdGenerators.PropertyGenerator.class,
-		property = "id"
+		property = "id",
+		resolver = UserGroupIdResolver.class
 	)
 	@JsonIdentityReference(alwaysAsId = true)
 	private Set<UserGroup> userGroups = new HashSet<UserGroup>();

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/WfsSearch.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/module/WfsSearch.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 
+import de.terrestris.shogun2.converter.LayerIdResolver;
 import de.terrestris.shogun2.model.layer.Layer;
 
 /**
@@ -75,7 +76,8 @@ public class WfsSearch extends Module {
 	// The List of layers will be serialized (JSON) as an array of ID values
 	@JsonIdentityInfo(
 		generator = ObjectIdGenerators.PropertyGenerator.class,
-		property = "id"
+		property = "id",
+		resolver = LayerIdResolver.class
 	)
 	@JsonIdentityReference(alwaysAsId = true)
 	private List<Layer> layers = new ArrayList<Layer>();

--- a/src/shogun2-core/shogun2-service/src/test/java/de/terrestris/shogun2/service/AbstractExtDirectCrudServiceTest.java
+++ b/src/shogun2-core/shogun2-service/src/test/java/de/terrestris/shogun2/service/AbstractExtDirectCrudServiceTest.java
@@ -43,9 +43,9 @@ import ch.ralscha.extdirectspring.bean.ExtDirectStoreResult;
 import ch.ralscha.extdirectspring.bean.SortDirection;
 import ch.ralscha.extdirectspring.bean.SortInfo;
 import de.terrestris.shogun2.dao.GenericHibernateDao;
+import de.terrestris.shogun2.helper.IdHelper;
 import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.paging.PagingResult;
-import de.terrestris.shogun2.util.test.TestUtil;
 
 /**
  * Test for the {@link AbstractExtDirectCrudService}.
@@ -121,7 +121,7 @@ public abstract class AbstractExtDirectCrudServiceTest<E extends PersistentObjec
 				E po = (E) invocation.getArguments()[0];
 
 				// set id like the dao does
-				TestUtil.setIdOnPersistentObject(po, 1);
+				IdHelper.setIdOnPersistentObject(po, 1);
 
 				return po;
 			}
@@ -162,7 +162,7 @@ public abstract class AbstractExtDirectCrudServiceTest<E extends PersistentObjec
 		ReadableDateTime created = implToTest.getCreated();
 		ReadableDateTime modified = implToTest.getModified();
 
-		TestUtil.setIdOnPersistentObject(implToTest, id);
+		IdHelper.setIdOnPersistentObject(implToTest, id);
 
 		doAnswer(new Answer<E>() {
 			public E answer(InvocationOnMock invocation)
@@ -204,7 +204,7 @@ public abstract class AbstractExtDirectCrudServiceTest<E extends PersistentObjec
 
 		Integer existingId = 17;
 
-		TestUtil.setIdOnPersistentObject(implToTest, existingId);
+		IdHelper.setIdOnPersistentObject(implToTest, existingId);
 
 		// mock dao behavior
 		doReturn(implToTest).when(dao).findById(existingId);
@@ -260,8 +260,8 @@ public abstract class AbstractExtDirectCrudServiceTest<E extends PersistentObjec
 		E obj1 = (E) implToTest;
 		E obj2 = (E) BeanUtils.cloneBean(obj1);
 
-		TestUtil.setIdOnPersistentObject(obj1, id1);
-		TestUtil.setIdOnPersistentObject(obj2, id2);
+		IdHelper.setIdOnPersistentObject(obj1, id1);
+		IdHelper.setIdOnPersistentObject(obj2, id2);
 
 		persistedObjectList.add((E) obj1);
 		persistedObjectList.add((E) obj2);
@@ -320,7 +320,7 @@ public abstract class AbstractExtDirectCrudServiceTest<E extends PersistentObjec
 
 		Integer existingId = 17;
 
-		TestUtil.setIdOnPersistentObject(implToTest, existingId);
+		IdHelper.setIdOnPersistentObject(implToTest, existingId);
 
 		// mock dao behavior
 		doReturn(implToTest).when(dao).findById(existingId);
@@ -383,7 +383,7 @@ public abstract class AbstractExtDirectCrudServiceTest<E extends PersistentObjec
 				E po = (E) invocation.getArguments()[0];
 
 				// set id like the dao does
-				TestUtil.setIdOnPersistentObject(po, nextId);
+				IdHelper.setIdOnPersistentObject(po, nextId);
 				nextId++;
 
 				return po;
@@ -537,7 +537,7 @@ public abstract class AbstractExtDirectCrudServiceTest<E extends PersistentObjec
 			InvocationTargetException, NoSuchMethodException {
 		@SuppressWarnings("unchecked")
 		E obj = (E) BeanUtils.cloneBean(implToTest);
-		TestUtil.setIdOnPersistentObject(obj, id);
+		IdHelper.setIdOnPersistentObject(obj, id);
 		return obj;
 	}
 

--- a/src/shogun2-core/shogun2-service/src/test/java/de/terrestris/shogun2/service/UserServiceTest.java
+++ b/src/shogun2-core/shogun2-service/src/test/java/de/terrestris/shogun2/service/UserServiceTest.java
@@ -29,10 +29,10 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import de.terrestris.shogun2.dao.RegistrationTokenDao;
 import de.terrestris.shogun2.dao.RoleDao;
 import de.terrestris.shogun2.dao.UserDao;
+import de.terrestris.shogun2.helper.IdHelper;
 import de.terrestris.shogun2.model.Role;
 import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.model.token.RegistrationToken;
-import de.terrestris.shogun2.util.test.TestUtil;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath*:META-INF/spring/test-encoder-bean.xml" })
@@ -403,7 +403,7 @@ public class UserServiceTest extends AbstractExtDirectCrudServiceTest<User, User
 		User unpersistedUser = new User("Dummy", "User", "dummyuser");
 		unpersistedUser.setPassword(rawPassword);
 
-		TestUtil.setIdOnPersistentObject(unpersistedUser, userId);
+		IdHelper.setIdOnPersistentObject(unpersistedUser, userId);
 
 		// finally call the method that is tested here
 		User persistedUser = crudService.persistNewUser(unpersistedUser, encryptPassword);
@@ -425,7 +425,7 @@ public class UserServiceTest extends AbstractExtDirectCrudServiceTest<User, User
 		User user = new User();
 		user.setPassword(oldPassword);
 
-		TestUtil.setIdOnPersistentObject(user, userId );
+		IdHelper.setIdOnPersistentObject(user, userId );
 
 		// mock the dao
 		doNothing().when(dao).saveOrUpdate(any(User.class));

--- a/src/shogun2-security/src/main/java/de/terrestris/shogun2/security/Shogun2AuthenticationProvider.java
+++ b/src/shogun2-security/src/main/java/de/terrestris/shogun2/security/Shogun2AuthenticationProvider.java
@@ -19,11 +19,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.shogun2.dao.UserDao;
-import de.terrestris.shogun2.dao.UserGroupDao;
 import de.terrestris.shogun2.model.Role;
 import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.model.UserGroup;
-import de.terrestris.shogun2.service.UserGroupService;
 import de.terrestris.shogun2.service.UserService;
 
 /**
@@ -40,9 +38,6 @@ public class Shogun2AuthenticationProvider implements AuthenticationProvider {
 
 	@Autowired
 	private UserService<User, UserDao<User>> userService;
-
-	@Autowired
-	private UserGroupService<UserGroup, UserGroupDao<UserGroup>> userGroupService;
 
 	@Autowired
 	private PasswordEncoder passwordEncoder;

--- a/src/shogun2-security/src/test/java/de/terrestris/shogun2/security/access/Shogun2PermissionEvaluatorTest.java
+++ b/src/shogun2-security/src/test/java/de/terrestris/shogun2/security/access/Shogun2PermissionEvaluatorTest.java
@@ -21,7 +21,7 @@ import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.model.security.Permission;
 import de.terrestris.shogun2.security.access.entity.PersistentObjectPermissionEvaluator;
 import de.terrestris.shogun2.security.access.factory.EntityPermissionEvaluatorFactory;
-import de.terrestris.shogun2.util.test.TestUtil;
+import de.terrestris.shogun2.helper.IdHelper;
 
 /**
  * @author Nils Bühner
@@ -157,7 +157,7 @@ public class Shogun2PermissionEvaluatorTest {
 		// mock auth object with user
 		Authentication authenticationMock = mock(Authentication.class);
 		final User user = new User("First name", "Last Name", "accountName");
-		TestUtil.setIdOnPersistentObject(user, 42);
+		IdHelper.setIdOnPersistentObject(user, 42);
 		final Integer userId = user.getId();
 		when(authenticationMock.getPrincipal()).thenReturn(user);
 
@@ -203,7 +203,7 @@ public class Shogun2PermissionEvaluatorTest {
 		// mock auth object with user
 		Authentication authenticationMock = mock(Authentication.class);
 		final User user = new User("First name", "Last Name", "accountName");
-		TestUtil.setIdOnPersistentObject(user, 42);
+		IdHelper.setIdOnPersistentObject(user, 42);
 		final Integer userId = user.getId();
 		when(authenticationMock.getPrincipal()).thenReturn(user);
 

--- a/src/shogun2-security/src/test/java/de/terrestris/shogun2/security/access/entity/AbstractSecuredObjectPermissionEvaluatorTest.java
+++ b/src/shogun2-security/src/test/java/de/terrestris/shogun2/security/access/entity/AbstractSecuredObjectPermissionEvaluatorTest.java
@@ -11,12 +11,12 @@ import java.util.Set;
 
 import org.junit.Test;
 
+import de.terrestris.shogun2.helper.IdHelper;
 import de.terrestris.shogun2.model.SecuredPersistentObject;
 import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.model.UserGroup;
 import de.terrestris.shogun2.model.security.Permission;
 import de.terrestris.shogun2.model.security.PermissionCollection;
-import de.terrestris.shogun2.util.test.TestUtil;
 
 /**
  * @author Nils Bühner
@@ -69,7 +69,7 @@ public abstract class AbstractSecuredObjectPermissionEvaluatorTest<E extends Sec
 		// prepare a user that gets permissions
 		User user = new User();
 		final int userId = 42;
-		TestUtil.setIdOnPersistentObject(user, userId);
+		IdHelper.setIdOnPersistentObject(user, userId);
 
 		// prepare permission collection/map
 		Map<User, PermissionCollection> userPermissionsMap = new HashMap<User, PermissionCollection>();
@@ -96,7 +96,7 @@ public abstract class AbstractSecuredObjectPermissionEvaluatorTest<E extends Sec
 		// prepare a user
 		User user = new User();
 		final int userId = 42;
-		TestUtil.setIdOnPersistentObject(user, userId);
+		IdHelper.setIdOnPersistentObject(user, userId);
 
 		// add user to a group
 		UserGroup group = new UserGroup();
@@ -132,7 +132,7 @@ public abstract class AbstractSecuredObjectPermissionEvaluatorTest<E extends Sec
 			// prepare a user that gets permissions
 			User user = new User();
 			final int userId = 42;
-			TestUtil.setIdOnPersistentObject(user, userId);
+			IdHelper.setIdOnPersistentObject(user, userId);
 
 			// prepare permission collection/map
 			Map<User, PermissionCollection> userPermissionsMap = new HashMap<User, PermissionCollection>();
@@ -167,7 +167,7 @@ public abstract class AbstractSecuredObjectPermissionEvaluatorTest<E extends Sec
 		// prepare a user
 		User user = new User();
 		final int userId = 42;
-		TestUtil.setIdOnPersistentObject(user, userId);
+		IdHelper.setIdOnPersistentObject(user, userId);
 
 		// add user to group
 		UserGroup group = new UserGroup();

--- a/src/shogun2-security/src/test/java/de/terrestris/shogun2/security/access/entity/UserPermissionEvaluatorTest.java
+++ b/src/shogun2-security/src/test/java/de/terrestris/shogun2/security/access/entity/UserPermissionEvaluatorTest.java
@@ -12,9 +12,9 @@ import java.util.Set;
 
 import org.junit.Test;
 
+import de.terrestris.shogun2.helper.IdHelper;
 import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.model.security.Permission;
-import de.terrestris.shogun2.util.test.TestUtil;
 
 /**
  * @author Nils Bühner
@@ -34,7 +34,7 @@ public class UserPermissionEvaluatorTest extends
 		// prepare a user that
 		User user = new User();
 		final int userId = 42;
-		TestUtil.setIdOnPersistentObject(user, userId);
+		IdHelper.setIdOnPersistentObject(user, userId);
 
 		// we do not add any permissions to the user, but expect that he is allowed to READ himself
 		// call method to test
@@ -50,7 +50,7 @@ public class UserPermissionEvaluatorTest extends
 		// prepare a user that
 		User user = new User();
 		final int userId = 42;
-		TestUtil.setIdOnPersistentObject(user, userId);
+		IdHelper.setIdOnPersistentObject(user, userId);
 
 		Set<Permission> permissions = new HashSet<Permission>(Arrays.asList(Permission.values()));
 		permissions.remove(Permission.READ); // everything but READ

--- a/src/shogun2-util/pom.xml
+++ b/src/shogun2-util/pom.xml
@@ -32,6 +32,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
@@ -44,12 +49,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>shogun2-model</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -101,6 +100,11 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
 
     </dependencies>

--- a/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/http/HttpUtilTest.java
+++ b/src/shogun2-util/src/test/java/de/terrestris/shogun2/util/http/HttpUtilTest.java
@@ -23,7 +23,6 @@ import org.apache.http.message.BasicNameValuePair;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import de.terrestris.shogun2.util.model.Response;
 
@@ -34,12 +33,6 @@ import de.terrestris.shogun2.util.model.Response;
  */
 @SuppressWarnings("static-method")
 public class HttpUtilTest {
-
-	/**
-	 * The class to test.
-	 */
-	@Autowired
-	private HttpUtil httpUtil;
 
 	/**
 	 *

--- a/src/shogun2-web/src/test/java/de/terrestris/shogun2/rest/AbstractRestControllerTest.java
+++ b/src/shogun2-web/src/test/java/de/terrestris/shogun2/rest/AbstractRestControllerTest.java
@@ -34,10 +34,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.terrestris.shogun2.dao.GenericHibernateDao;
+import de.terrestris.shogun2.helper.IdHelper;
 import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.service.AbstractCrudService;
 import de.terrestris.shogun2.util.json.Shogun2JsonObjectMapper;
-import de.terrestris.shogun2.util.test.TestUtil;
 
 /**
  *
@@ -176,7 +176,7 @@ public class AbstractRestControllerTest {
 
 		TestModel testInstance = buildTestInstanceWithValue(value);
 
-		TestUtil.setIdOnPersistentObject(testInstance, id);
+		IdHelper.setIdOnPersistentObject(testInstance, id);
 
 		when(serviceMock.findById(id)).thenReturn(testInstance);
 
@@ -473,7 +473,7 @@ public class AbstractRestControllerTest {
 			throws Exception {
 		TestModel tm = buildTestInstanceWithValue(value);
 
-		TestUtil.setIdOnPersistentObject(tm, id);
+		IdHelper.setIdOnPersistentObject(tm, id);
 
 		return tm;
 	}


### PR DESCRIPTION
We are currently using the `@JsonIdentityInfo` annotation to serialize only the IDs of related objects (e.g. the groups of a user will be serialized by Jackson as an array of IDs, but not as complete objects.)

This PR handles the deserialization, i.e. the other direction by implementing
```Java
public class UserGroupIdResolver extends SimpleObjectIdResolver
```
and using this implementation in the `resolver` property of the `@JsonIdentityInfo` annotation.

Example: If a new User should be created, it is sufficient to POST an array of (existing) group IDs the user belongs to (in the `userGroups` property of the user object).

**Important note:** The current implementation only sets the ID value on a "new" UserGroup dummy object, which is enough information for Hibernate to persist the correct relation (in the join table). If we want access to full group objects, additional implementations are necessary (i suggest a follow up PR). E.g. the "load" method of the hibernate API could be a good choice here.