### PR TITLE
Cascade nested (Layer-)models while saveOrUpdate

### DIFF
--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/Layer.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/Layer.java
@@ -8,6 +8,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
 
 import de.terrestris.shogun2.model.layer.appearance.LayerAppearance;
 import de.terrestris.shogun2.model.layer.source.LayerDataSource;
@@ -31,9 +33,11 @@ public class Layer extends AbstractLayer {
 	private static final long serialVersionUID = 1L;
 
 	@ManyToOne
+	@Cascade(CascadeType.SAVE_UPDATE)
 	private LayerDataSource source;
 
 	@ManyToOne
+	@Cascade(CascadeType.SAVE_UPDATE)
 	private LayerAppearance appearance;
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/source/TileWmsLayerDataSource.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/source/TileWmsLayerDataSource.java
@@ -8,6 +8,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
 
 import de.terrestris.shogun2.model.layer.util.TileGrid;
 
@@ -28,6 +30,7 @@ public class TileWmsLayerDataSource extends ImageWmsLayerDataSource {
 	private static final long serialVersionUID = 1L;
 
 	@ManyToOne
+	@Cascade(CascadeType.SAVE_UPDATE)
 	private TileGrid tileGrid;
 
 	/**

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/TileGrid.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/util/TileGrid.java
@@ -22,6 +22,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
 
 import de.terrestris.shogun2.model.PersistentObject;
 
@@ -65,6 +67,7 @@ public class TileGrid extends PersistentObject {
 	 * the origin will be set to the top-left corner of the extent.
 	 */
 	@ManyToOne
+	@Cascade(CascadeType.SAVE_UPDATE)
 	private Extent tileGridExtent;
 
 	/**


### PR DESCRIPTION
This PR suggests to (re-)add the `@Cascade(CascadeType.SAVE_UPDATE)` to all `Layer` associated models. In real world applications this seems to be very handy while saving a `Layer` (otherwise all child models would have to be saved manually first).