### PR TITLE
Added Group REST Controller; extended User REST Controller and Service

### DIFF
--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserGroupService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserGroupService.java
@@ -1,16 +1,21 @@
 package de.terrestris.shogun2.service;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import de.terrestris.shogun2.dao.UserGroupDao;
+import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.model.UserGroup;
 
 /**
  * Service class for the {@link UserGroup} model.
  *
  * @author Nils Bühner
+ * @author Johannes Weskamm
  * @see AbstractCrudService
  *
  */
@@ -44,6 +49,26 @@ public class UserGroupService<E extends UserGroup, D extends UserGroupDao<E>>
 	@Qualifier("userGroupDao")
 	public void setDao(D dao) {
 		this.dao = dao;
+	}
+
+	/**
+	 *
+	 * @param groupId
+	 * @return
+	 * @throws Exception
+	 */
+	public Set<User> getUsersOfGroup(Integer groupId) throws Exception {
+
+		Set<User> groupUsersSet = new HashSet<User>();
+		UserGroup userGroup = this.findById(groupId);
+		if (userGroup != null) {
+			LOG.trace("Found group with ID " + userGroup.getId());
+			groupUsersSet = userGroup.getMembers();
+		} else {
+			throw new Exception("The group with id " + groupId + " could not be found");
+		}
+
+		return groupUsersSet;
 	}
 
 }

--- a/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserService.java
+++ b/src/shogun2-core/shogun2-service/src/main/java/de/terrestris/shogun2/service/UserService.java
@@ -1,5 +1,8 @@
 package de.terrestris.shogun2.service;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.servlet.http.HttpServletRequest;
 
 import org.hibernate.criterion.Restrictions;
@@ -15,6 +18,7 @@ import de.terrestris.shogun2.dao.RoleDao;
 import de.terrestris.shogun2.dao.UserDao;
 import de.terrestris.shogun2.model.Role;
 import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.UserGroup;
 import de.terrestris.shogun2.model.token.RegistrationToken;
 
 /**
@@ -247,6 +251,26 @@ public class UserService<E extends User, D extends UserDao<E>> extends
 		Integer id = loggedInUser.getId();
 
 		return dao.findById(id);
+	}
+
+	/**
+	 *
+	 * @param userId
+	 * @return
+	 * @throws Exception
+	 */
+	public Set<UserGroup> getGroupsOfUser(Integer userId) throws Exception {
+
+		Set<UserGroup> userGroupsSet = new HashSet<UserGroup>();
+		User user = this.findById(userId);
+		if (user != null) {
+			LOG.trace("Found user with ID " + user.getId());
+			userGroupsSet = user.getUserGroups();
+		} else {
+			throw new Exception("The user with id " + userId + " could not be found");
+		}
+
+		return userGroupsSet;
 	}
 
 	/**

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/GroupRestController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/GroupRestController.java
@@ -11,35 +11,35 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import de.terrestris.shogun2.dao.UserDao;
+import de.terrestris.shogun2.dao.UserGroupDao;
 import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.model.UserGroup;
-import de.terrestris.shogun2.service.UserService;
+import de.terrestris.shogun2.service.UserGroupService;
 import de.terrestris.shogun2.util.data.ResultSet;
 
 /**
- * @author Kai Volland
+ * @author Johannes Weskamm
  * @author Nils Bühner
  *
  */
 @RestController
-@RequestMapping("/users")
-public class UserRestController<E extends User, D extends UserDao<E>, S extends UserService<E, D>>
+@RequestMapping("/groups")
+public class GroupRestController<E extends UserGroup, D extends UserGroupDao<E>, S extends UserGroupService<E, D>>
 		extends AbstractRestController<E, D, S> {
 
 	/**
 	 * Default constructor, which calls the type-constructor
 	 */
 	@SuppressWarnings("unchecked")
-	public UserRestController() {
-		this((Class<E>) User.class);
+	public GroupRestController() {
+		this((Class<E>) UserGroup.class);
 	}
 
 	/**
 	 * Constructor that sets the concrete entity class for the controller.
 	 * Subclasses MUST call this constructor.
 	 */
-	protected UserRestController(Class<E> entityClass) {
+	protected GroupRestController(Class<E> entityClass) {
 		super(entityClass);
 	}
 
@@ -50,27 +50,27 @@ public class UserRestController<E extends User, D extends UserDao<E>, S extends 
 	 */
 	@Override
 	@Autowired
-	@Qualifier("userService")
+	@Qualifier("userGroupService")
 	public void setService(S service) {
 		this.service = service;
 	}
 
 	/**
-	 * Get the groups of a specific user.
+	 * Get the users of a specific group.
 	 *
-	 * @param userId
+	 * @param groupId
 	 * @return
 	 */
-	@RequestMapping(value = "/{userId}/userGroups", method = RequestMethod.GET)
-	public @ResponseBody Map<String, Object> findGroupsOfUser(@PathVariable Integer userId) {
+	@RequestMapping(value = "/{groupId}/users", method = RequestMethod.GET)
+	public @ResponseBody Map<String, Object> findUsersOfGroup(@PathVariable Integer groupId) {
 
 		try {
-			Set<UserGroup> userGroupsSet = this.service.getGroupsOfUser(userId);
-			return ResultSet.success(userGroupsSet);
+			Set<User> groupUsersSet = this.service.getUsersOfGroup(groupId);
+			return ResultSet.success(groupUsersSet);
 		} catch (Exception e) {
-			LOG.error("Error finding user with id " + userId + ": "
+			LOG.error("Error finding group with id " + groupId + ": "
 					+ e.getMessage());
-			return ResultSet.error("Error finding user with id " + userId);
+			return ResultSet.error("Error finding group with id " + groupId);
 		}
 	}
 }

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/UserGroupRestController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/UserGroupRestController.java
@@ -1,21 +1,20 @@
 package de.terrestris.shogun2.rest;
 
-import java.util.Map;
 import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import de.terrestris.shogun2.dao.UserGroupDao;
 import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.model.UserGroup;
 import de.terrestris.shogun2.service.UserGroupService;
-import de.terrestris.shogun2.util.data.ResultSet;
 
 /**
  * @author Johannes Weskamm
@@ -24,14 +23,14 @@ import de.terrestris.shogun2.util.data.ResultSet;
  */
 @RestController
 @RequestMapping("/groups")
-public class GroupRestController<E extends UserGroup, D extends UserGroupDao<E>, S extends UserGroupService<E, D>>
+public class UserGroupRestController<E extends UserGroup, D extends UserGroupDao<E>, S extends UserGroupService<E, D>>
 		extends AbstractRestController<E, D, S> {
 
 	/**
 	 * Default constructor, which calls the type-constructor
 	 */
 	@SuppressWarnings("unchecked")
-	public GroupRestController() {
+	public UserGroupRestController() {
 		this((Class<E>) UserGroup.class);
 	}
 
@@ -39,7 +38,7 @@ public class GroupRestController<E extends UserGroup, D extends UserGroupDao<E>,
 	 * Constructor that sets the concrete entity class for the controller.
 	 * Subclasses MUST call this constructor.
 	 */
-	protected GroupRestController(Class<E> entityClass) {
+	protected UserGroupRestController(Class<E> entityClass) {
 		super(entityClass);
 	}
 
@@ -62,15 +61,15 @@ public class GroupRestController<E extends UserGroup, D extends UserGroupDao<E>,
 	 * @return
 	 */
 	@RequestMapping(value = "/{groupId}/users", method = RequestMethod.GET)
-	public @ResponseBody Map<String, Object> findUsersOfGroup(@PathVariable Integer groupId) {
+	public ResponseEntity<Set<User>> findUsersOfGroup(@PathVariable Integer groupId) {
 
 		try {
 			Set<User> groupUsersSet = this.service.getUsersOfGroup(groupId);
-			return ResultSet.success(groupUsersSet);
+			return new ResponseEntity<Set<User>>(groupUsersSet, HttpStatus.OK);
 		} catch (Exception e) {
 			LOG.error("Error finding group with id " + groupId + ": "
 					+ e.getMessage());
-			return ResultSet.error("Error finding group with id " + groupId);
+			return new ResponseEntity<Set<User>>(HttpStatus.NOT_FOUND);
 		}
 	}
 }

--- a/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/UserRestController.java
+++ b/src/shogun2-web/src/main/java/de/terrestris/shogun2/rest/UserRestController.java
@@ -1,21 +1,20 @@
 package de.terrestris.shogun2.rest;
 
-import java.util.Map;
 import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import de.terrestris.shogun2.dao.UserDao;
 import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.model.UserGroup;
 import de.terrestris.shogun2.service.UserService;
-import de.terrestris.shogun2.util.data.ResultSet;
 
 /**
  * @author Kai Volland
@@ -62,15 +61,15 @@ public class UserRestController<E extends User, D extends UserDao<E>, S extends 
 	 * @return
 	 */
 	@RequestMapping(value = "/{userId}/userGroups", method = RequestMethod.GET)
-	public @ResponseBody Map<String, Object> findGroupsOfUser(@PathVariable Integer userId) {
+	public ResponseEntity<Set<UserGroup>> findGroupsOfUser(@PathVariable Integer userId) {
 
 		try {
 			Set<UserGroup> userGroupsSet = this.service.getGroupsOfUser(userId);
-			return ResultSet.success(userGroupsSet);
+			return new ResponseEntity<Set<UserGroup>>(userGroupsSet, HttpStatus.OK);
 		} catch (Exception e) {
 			LOG.error("Error finding user with id " + userId + ": "
 					+ e.getMessage());
-			return ResultSet.error("Error finding user with id " + userId);
+			return new ResponseEntity<Set<UserGroup>>(HttpStatus.NOT_FOUND);
 		}
 	}
 }


### PR DESCRIPTION
This PR adds a REST Controller for UserGroups. The User and UserGroup REST Controller have been extended to support queries of subentities by pathvariables. This means you can now get the groups of a user by specifying the request like `rest/users/{id}/userGroups` or `rest/groups/{id}/users`