### PR TITLE
Fix hibernate annotations

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,3 +9,4 @@
   * In the file `src/main/webapp/WEB-INF/{{your-project}}-servlet.xml`, the package `ch.ralscha.extdirectspring` can be removed from the `<component-scan>` element.
   * In the file `src/main/webapp/WEB-INF/log4j.properties`, the config for `log4j.logger.ch.ralscha.extdirectspring` can be removed
   * In the file `src/main/webapp/WEB-INF/web.xml`, the `<servlet-mapping>` with `<url-pattern>/action/*</url-pattern>` can be removed
+* Existing projects should (once) boot with the `hibernate.hbm2ddl.auto` property set to `UPDATE` or `CREATE` to make use of the new tables `ABSTR_LAYERS_USERPERMISSIONS` and `ABSTR_LAYERS_GROUPPERMISSIONS` ([#155](https://github.com/terrestris/shogun2/pull/155)).

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/AbstractLayer.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/layer/AbstractLayer.java
@@ -1,7 +1,12 @@
 package de.terrestris.shogun2.model.layer;
 
+import javax.persistence.AssociationOverride;
+import javax.persistence.AssociationOverrides;
 import javax.persistence.Entity;
-import javax.persistence.Table;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -17,12 +22,24 @@ import de.terrestris.shogun2.model.layer.source.LayerDataSource;
  * Representation of a layer which consists a corresponding data source
  * and an appearance
  *
- * @author Andre Henn
+ * @author Kai Volland
+ * @author Nils Bühner
  * @author terrestris GmbH & Co. KG
  *
  */
 @Entity
-@Table
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@AssociationOverrides({
+	@AssociationOverride(
+			name="userPermissions",
+			joinTable=@JoinTable(name="ABSTR_LAYERS_USERPERMISSIONS",
+			joinColumns = @JoinColumn(name = "LAYER_ID"))),
+
+	@AssociationOverride(
+			name="groupPermissions",
+			joinTable=@JoinTable(name="ABSTR_LAYERS_GROUPPERMISSIONS",
+			joinColumns = @JoinColumn(name = "LAYER_ID")))
+})
 public abstract class AbstractLayer extends SecuredPersistentObject {
 
 	/**


### PR DESCRIPTION
This PR eliminates the following WARNING:
`HHH000139: Illegal use of @Table in a subclass of a SINGLE_TABLE hierarchy`

On top of that, the missing `@AssociationOverrides` annotation has been added to the `AbstractLayer` class to ensure that user- and group permissions can be used correctly for the `AbstractLayer` hierarchy.

Existing projects should (once) boot with the `hibernate.hbm2ddl.auto` property set to `UPDATE` or `CREATE`