### PR TITLE
Load entities from the DB when resolving by IDs

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/converter/LayerIdResolver.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/converter/LayerIdResolver.java
@@ -1,30 +1,25 @@
 package de.terrestris.shogun2.converter;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import de.terrestris.shogun2.dao.LayerDao;
 import de.terrestris.shogun2.model.layer.Layer;
+import de.terrestris.shogun2.service.LayerService;
 
 /**
  *
  * @author Nils Buehner
  *
  */
-public class LayerIdResolver<E extends Layer> extends
-		PersistentObjectIdResolver<Layer> {
+public class LayerIdResolver<E extends Layer, D extends LayerDao<E>, S extends LayerService<E, D>> extends
+		PersistentObjectIdResolver<E, D, S> {
 
-	/**
-	 * Default Constructor
-	 */
-	public LayerIdResolver() {
-		super(Layer.class);
-	}
-
-	/**
-	 * Constructor that has to be called by subclasses.
-	 *
-	 * @param entityClass
-	 */
-	@SuppressWarnings("unchecked")
-	protected LayerIdResolver(Class<E> entityClass) {
-		super((Class<Layer>) entityClass);
+	@Override
+	@Autowired
+	@Qualifier("layerService")
+	public void setService(S service) {
+		this.service = service;
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/converter/PersistentObjectIdResolver.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/converter/PersistentObjectIdResolver.java
@@ -1,50 +1,75 @@
 package de.terrestris.shogun2.converter;
 
 import org.apache.log4j.Logger;
+import org.springframework.web.context.support.SpringBeanAutowiringSupport;
 
 import com.fasterxml.jackson.annotation.ObjectIdGenerator.IdKey;
 import com.fasterxml.jackson.annotation.ObjectIdResolver;
 import com.fasterxml.jackson.annotation.SimpleObjectIdResolver;
 
-import de.terrestris.shogun2.helper.IdHelper;
+import de.terrestris.shogun2.dao.GenericHibernateDao;
 import de.terrestris.shogun2.model.PersistentObject;
+import de.terrestris.shogun2.service.AbstractCrudService;
 
 /**
  *
- * An ID resolver for {@link PersistentObject}s when deserializing only on the base
- * of ID values. Extends the default implementation.
+ * An ID resolver for {@link PersistentObject}s when deserializing only on the
+ * base of ID values. Based on a given ID, this resolver will load the whole
+ * entity from the database. Extends the default implementation.
  *
  * @author Nils Buehner
  *
  */
-public abstract class PersistentObjectIdResolver<E extends PersistentObject> extends SimpleObjectIdResolver {
+public abstract class PersistentObjectIdResolver<E extends PersistentObject, D extends GenericHibernateDao<E, Integer>, S extends AbstractCrudService<E, D>>
+		extends SimpleObjectIdResolver {
 
 	protected final Logger LOG = Logger.getLogger(getClass());
 
-	protected final Class<E> entityClass;
+	protected S service;
 
 	/**
-	 * Constructor that has to be called by subclasses.
+	 * Default Constructor that injects beans automatically.
 	 *
 	 * @param entityClass
 	 */
-	protected PersistentObjectIdResolver(Class<E> entityClass) {
-		this.entityClass = entityClass;
+	protected PersistentObjectIdResolver() {
+		// As subclasses of this class are used in the resolver property of an
+		// JsonIdentityInfo annotation, we cannot easily autowire components
+		// (like the service for the current). For that reason, we use this
+		// helper method to process the injection of the services
+		SpringBeanAutowiringSupport.processInjectionBasedOnCurrentContext(this);
 	}
 
+	/**
+	 * Has to be implemented by subclasses to autowire and set the correct
+	 * service class.
+	 *
+	 * @param service
+	 *            the service to set
+	 */
+	public abstract void setService(S service);
+
+	/**
+	 *
+	 */
 	@Override
 	public void bindItem(IdKey id, Object ob) {
 		super.bindItem(id, ob);
 	}
 
+	/**
+	 *
+	 */
 	@Override
-	public E resolveId(IdKey id) {
+	public E resolveId(IdKey idKey) {
 		try {
-			if (id.key instanceof Integer) {
-				// return a "dummy" object, which only has the correct ID value
-				E entity = getEntityClass().newInstance();
-				IdHelper.setIdOnPersistentObject(entity, (Integer) id.key);
-				return entity;
+			if (idKey.key instanceof Integer) {
+				final Integer id = (Integer) idKey.key;
+				// we only "load" the entity to follow a lazy approach, i.e.
+				// requests to the database will only be queried if any properties
+				// of the entity will (later) be accessed (which may already
+				// the case when jackson is doing some magic)
+				return service.loadById(id);
 			} else {
 				throw new Exception("ID is not of type Integer.");
 			}
@@ -55,11 +80,17 @@ public abstract class PersistentObjectIdResolver<E extends PersistentObject> ext
 
 	}
 
+	/**
+	 *
+	 */
 	@Override
 	public boolean canUseFor(ObjectIdResolver resolverType) {
 		return super.canUseFor(resolverType);
 	}
 
+	/**
+	 *
+	 */
 	@Override
 	public ObjectIdResolver newForDeserialization(Object context) {
 		try {
@@ -71,9 +102,9 @@ public abstract class PersistentObjectIdResolver<E extends PersistentObject> ext
 	}
 
 	/**
-	 * @return the entityClass
+	 * @return the service
 	 */
-	public Class<E> getEntityClass() {
-		return entityClass;
+	public S getService() {
+		return service;
 	}
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/converter/UserGroupIdResolver.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/converter/UserGroupIdResolver.java
@@ -1,30 +1,25 @@
 package de.terrestris.shogun2.converter;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import de.terrestris.shogun2.dao.UserGroupDao;
 import de.terrestris.shogun2.model.UserGroup;
+import de.terrestris.shogun2.service.UserGroupService;
 
 /**
  *
  * @author Nils Buehner
  *
  */
-public class UserGroupIdResolver<E extends UserGroup> extends
-		PersistentObjectIdResolver<UserGroup> {
+public class UserGroupIdResolver<E extends UserGroup, D extends UserGroupDao<E>, S extends UserGroupService<E, D>> extends
+		PersistentObjectIdResolver<E, D, S> {
 
-	/**
-	 * Default Constructor
-	 */
-	public UserGroupIdResolver() {
-		super(UserGroup.class);
-	}
-
-	/**
-	 * Constructor that has to be called by subclasses.
-	 *
-	 * @param entityClass
-	 */
-	@SuppressWarnings("unchecked")
-	protected UserGroupIdResolver(Class<E> entityClass) {
-		super((Class<UserGroup>) entityClass);
+	@Override
+	@Autowired
+	@Qualifier("userGroupService")
+	public void setService(S service) {
+		this.service = service;
 	}
 
 }


### PR DESCRIPTION
Here is a nice enhancement of the current implementation of the Property-/ID-Resolver classes:

We are using the `@JsonIdentityInfo` annotation to serialize objects as their ID representation. For the other direction, we already have a basic implementation of ID resolvers to deserialize such IDs to POJOs. But the current implementation only creates some "dummy" objects that only contain the ID value (but nothing else). This is sufficient to assign objects to Collections (as only the IDs are persisted in some join tables), but the current status may lead to problems with HashCodes/Sets and one would have to "manually" load such objects from the database to get full access to the object.

This PR enhances the existing ID resolvers by loading the correct entity from the database, which means that you can send IDs to the backend, but in the first line of your code, you will have the full entity available!

Feel free to merge.