### PR TITLE
Optimize permission handling

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,10 @@
 # Release Notes
 
 ## 0.1.0 (not finally released yet)
+
+* New features:
+  * An `AbstractSecuredPersistentObjectService` has been introduced. This service provides useful methods to add and remove permissions for certain objects. `PermissionCollection`s will be persisted in the database when using these methods. All services of entities that extend `SecuredPersistentObject` should extend the abstract service mentioned above.
+
 Existing projects (that were possibly created with an old version of the webapp archetype) need adaptions regarding the following points:
 * Adapt the ``pom.xml`` of your existing SHOGun2 project
   * Remove the dependency with the artifactID ``shogun2-web``

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractSecuredPersistentObjectService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractSecuredPersistentObjectService.java
@@ -56,65 +56,67 @@ public abstract class AbstractSecuredPersistentObjectService<E extends SecuredPe
 	 * @param permissions The permissions the user gets for the entity
 	 */
 	public void addAndSaveUserPermissions(E entity, User user, Permission... permissions) {
-		if(entity != null) {
-			// create a set from the passed array
-			final HashSet<Permission> permissionsSet = new HashSet<Permission>(Arrays.asList(permissions));
-
-			if(permissionsSet != null && !permissionsSet.isEmpty()) {
-				// get the existing permission
-				PermissionCollection userPermissionCollection = entity.getUserPermissions().get(user);
-
-				// whether or not we have to persist the permission collection (which is only
-				// the case if it is new or its size has changed)
-				boolean persistPermissionCollection = false;
-
-				// whether or not we have to persist the entity (which is only the case
-				// if a new permission collection will be created in the next step)
-				boolean persistEntity = false;
-
-				if(userPermissionCollection == null) {
-					// create a new user permission collection and attach it to the user
-					userPermissionCollection = new PermissionCollection(permissionsSet);
-					entity.getUserPermissions().put(user, userPermissionCollection);
-					LOG.debug("Attached a new permission collection for a user: " + permissionsSet);
-
-					// persist permission collection and the entity as a new permission
-					// collection has been attached
-					persistPermissionCollection = true;
-					persistEntity = true;
-				} else {
-					Set<Permission> userPermissions = userPermissionCollection.getPermissions();
-					int originalNrOfPermissions = userPermissions.size();
-
-					// add the passed permissions to the the existing permission collection
-					userPermissions.addAll(permissionsSet);
-
-					int newNrOfPermissions = userPermissions.size();
-
-					if(newNrOfPermissions > originalNrOfPermissions) {
-						// persist the collection as we have "really" added new permission(s)
-						persistPermissionCollection = true;
-						LOG.debug("Added the following permissions to an existing permission collection: "
-								+ permissionsSet);
-					}
-				}
-
-				if(persistPermissionCollection) {
-					// persist the permission collection
-					permissionCollectionService.saveOrUpdate(userPermissionCollection);
-					LOG.debug("Persisted a permission collection");
-
-					// persist the entity if necessary
-					if(persistEntity) {
-						this.saveOrUpdate(entity);
-						LOG.debug("Persisted the entity with a new permission collection.");
-					}
-				}
-			} else {
-				LOG.error("Could not add permissions: No permissions have been passed." );
-			}
-		} else {
+		if(entity == null) {
 			LOG.error("Could not add permissions: The passed entity is NULL.");
+			return;
+		}
+
+		// create a set from the passed array
+		final HashSet<Permission> permissionsSet = new HashSet<Permission>(Arrays.asList(permissions));
+
+		if(permissionsSet == null || permissionsSet.isEmpty()) {
+			LOG.error("Could not add permissions: No permissions have been passed." );
+			return;
+		}
+
+		// get the existing permission
+		PermissionCollection userPermissionCollection = entity.getUserPermissions().get(user);
+
+		// whether or not we have to persist the permission collection (which is only
+		// the case if it is new or its size has changed)
+		boolean persistPermissionCollection = false;
+
+		// whether or not we have to persist the entity (which is only the case
+		// if a new permission collection will be created in the next step)
+		boolean persistEntity = false;
+
+		if(userPermissionCollection == null) {
+			// create a new user permission collection and attach it to the user
+			userPermissionCollection = new PermissionCollection(permissionsSet);
+			entity.getUserPermissions().put(user, userPermissionCollection);
+			LOG.debug("Attached a new permission collection for a user: " + permissionsSet);
+
+			// persist permission collection and the entity as a new permission
+			// collection has been attached
+			persistPermissionCollection = true;
+			persistEntity = true;
+		} else {
+			Set<Permission> userPermissions = userPermissionCollection.getPermissions();
+			int originalNrOfPermissions = userPermissions.size();
+
+			// add the passed permissions to the the existing permission collection
+			userPermissions.addAll(permissionsSet);
+
+			int newNrOfPermissions = userPermissions.size();
+
+			if(newNrOfPermissions > originalNrOfPermissions) {
+				// persist the collection as we have "really" added new permission(s)
+				persistPermissionCollection = true;
+				LOG.debug("Added the following permissions to an existing permission collection: "
+						+ permissionsSet);
+			}
+		}
+
+		if(persistPermissionCollection) {
+			// persist the permission collection
+			permissionCollectionService.saveOrUpdate(userPermissionCollection);
+			LOG.debug("Persisted a permission collection");
+
+			// persist the entity if necessary
+			if(persistEntity) {
+				this.saveOrUpdate(entity);
+				LOG.debug("Persisted the entity with a new permission collection.");
+			}
 		}
 	}
 
@@ -127,40 +129,43 @@ public abstract class AbstractSecuredPersistentObjectService<E extends SecuredPe
 	 * @param permissions The permissions to remove
 	 */
 	public void removeAndSaveUserPermissions(E entity, User user, Permission... permissions) {
-		if(entity != null) {
-			// create a set from the passed array
-			final HashSet<Permission> permissionsSet = new HashSet<Permission>(Arrays.asList(permissions));
-
-			if(permissionsSet != null && !permissionsSet.isEmpty()) {
-				// get the existing permission
-				PermissionCollection userPermissionCollection = entity.getUserPermissions().get(user);
-
-				if(userPermissionCollection != null) {
-					Set<Permission> userPermissions = userPermissionCollection.getPermissions();
-
-					int originalNrOfPermissions = userPermissions.size();
-
-					// remove the passed permissions from the the existing permission collection
-					userPermissions.removeAll(permissionsSet);
-
-					int newNrOfPermissions = userPermissions.size();
-
-					// only persist if we have "really" removed something
-					if(newNrOfPermissions < originalNrOfPermissions) {
-						LOG.debug("Removed the following permissions from an existing permission collection: "
-								+ permissionsSet);
-						// persist the permission collection
-						permissionCollectionService.saveOrUpdate(userPermissionCollection);
-						LOG.debug("Persisted a permission collection");
-					}
-				} else {
-					LOG.error("Could not remove permissions as there is no attached permission collection.");
-				}
-			} else {
-				LOG.error("Could not remove permissions: No permissions have been passed." );
-			}
-		} else {
+		if(entity == null) {
 			LOG.error("Could not remove permissions: The passed entity is NULL.");
+			return;
+		}
+
+		// create a set from the passed array
+		final HashSet<Permission> permissionsSet = new HashSet<Permission>(Arrays.asList(permissions));
+
+		if(permissionsSet == null || permissionsSet.isEmpty()) {
+			LOG.error("Could not remove permissions: No permissions have been passed." );
+			return;
+		}
+
+		// get the existing permission
+		PermissionCollection userPermissionCollection = entity.getUserPermissions().get(user);
+
+		if(userPermissionCollection == null) {
+			LOG.error("Could not remove permissions as there is no attached permission collection.");
+			return;
+		}
+
+		Set<Permission> userPermissions = userPermissionCollection.getPermissions();
+
+		int originalNrOfPermissions = userPermissions.size();
+
+		// remove the passed permissions from the the existing permission collection
+		userPermissions.removeAll(permissionsSet);
+
+		int newNrOfPermissions = userPermissions.size();
+
+		// only persist if we have "really" removed something
+		if(newNrOfPermissions < originalNrOfPermissions) {
+			LOG.debug("Removed the following permissions from an existing permission collection: "
+					+ permissionsSet);
+			// persist the permission collection
+			permissionCollectionService.saveOrUpdate(userPermissionCollection);
+			LOG.debug("Persisted a permission collection");
 		}
 	}
 
@@ -176,66 +181,68 @@ public abstract class AbstractSecuredPersistentObjectService<E extends SecuredPe
 	 * @param permissions The permissions the user group gets for the entity
 	 */
 	public void addAndSaveGroupPermissions(E entity, UserGroup userGroup, Permission... permissions) {
-		if(entity != null) {
-			// create a set from the passed array
-			final HashSet<Permission> permissionsSet = new HashSet<Permission>(Arrays.asList(permissions));
-
-			if(permissionsSet != null && !permissionsSet.isEmpty()) {
-				// get the existing permission
-				PermissionCollection groupPermissionCollection = entity.getGroupPermissions().get(userGroup);
-
-				// whether or not we have to persist the permission collection (which is only
-				// the case if it is new or its size has changed)
-				boolean persistPermissionCollection = false;
-
-				// whether or not we have to persist the entity (which is only the case
-				// if a new permission collection will be created in the next step)
-				boolean persistEntity = false;
-
-				if(groupPermissionCollection == null) {
-					// create a new user permission collection and attach it to the user
-					groupPermissionCollection = new PermissionCollection(permissionsSet);
-
-					entity.getGroupPermissions().put(userGroup, groupPermissionCollection);
-					LOG.debug("Attached a new permission collection for a group: " + permissionsSet);
-
-					// persist permission collection and the entity as a new permission
-					// collection has been attached
-					persistPermissionCollection = true;
-					persistEntity = true;
-				} else {
-					Set<Permission> groupPermissions = groupPermissionCollection.getPermissions();
-					int originalNrOfPermissions = groupPermissions.size();
-
-					// add the passed permissions to the the existing permission collection
-					groupPermissions.addAll(permissionsSet);
-
-					int newNrOfPermissions = groupPermissions.size();
-
-					if(newNrOfPermissions > originalNrOfPermissions) {
-						// persist the collection as we have "really" added new permission(s)
-						persistPermissionCollection = true;
-						LOG.debug("Added the following permissions to an existing permission collection: "
-								+ permissionsSet);
-					}
-				}
-
-				if(persistPermissionCollection) {
-					// persist the permission collection
-					permissionCollectionService.saveOrUpdate(groupPermissionCollection);
-					LOG.debug("Persisted a permission collection");
-
-					// persist the entity if necessary
-					if(persistEntity) {
-						this.saveOrUpdate(entity);
-						LOG.debug("Persisted the entity with a new permission collection.");
-					}
-				}
-			} else {
-				LOG.error("Could not add permissions: No permissions have been passed." );
-			}
-		} else {
+		if(entity == null) {
 			LOG.error("Could not add permissions: The passed entity is NULL.");
+			return;
+		}
+
+		// create a set from the passed array
+		final HashSet<Permission> permissionsSet = new HashSet<Permission>(Arrays.asList(permissions));
+
+		if(permissionsSet == null || permissionsSet.isEmpty()) {
+			LOG.error("Could not add permissions: No permissions have been passed." );
+			return;
+		}
+
+		// get the existing permission
+		PermissionCollection groupPermissionCollection = entity.getGroupPermissions().get(userGroup);
+
+		// whether or not we have to persist the permission collection (which is only
+		// the case if it is new or its size has changed)
+		boolean persistPermissionCollection = false;
+
+		// whether or not we have to persist the entity (which is only the case
+		// if a new permission collection will be created in the next step)
+		boolean persistEntity = false;
+
+		if(groupPermissionCollection == null) {
+			// create a new user permission collection and attach it to the user
+			groupPermissionCollection = new PermissionCollection(permissionsSet);
+
+			entity.getGroupPermissions().put(userGroup, groupPermissionCollection);
+			LOG.debug("Attached a new permission collection for a group: " + permissionsSet);
+
+			// persist permission collection and the entity as a new permission
+			// collection has been attached
+			persistPermissionCollection = true;
+			persistEntity = true;
+		} else {
+			Set<Permission> groupPermissions = groupPermissionCollection.getPermissions();
+			int originalNrOfPermissions = groupPermissions.size();
+
+			// add the passed permissions to the the existing permission collection
+			groupPermissions.addAll(permissionsSet);
+
+			int newNrOfPermissions = groupPermissions.size();
+
+			if(newNrOfPermissions > originalNrOfPermissions) {
+				// persist the collection as we have "really" added new permission(s)
+				persistPermissionCollection = true;
+				LOG.debug("Added the following permissions to an existing permission collection: "
+						+ permissionsSet);
+			}
+		}
+
+		if(persistPermissionCollection) {
+			// persist the permission collection
+			permissionCollectionService.saveOrUpdate(groupPermissionCollection);
+			LOG.debug("Persisted a permission collection");
+
+			// persist the entity if necessary
+			if(persistEntity) {
+				this.saveOrUpdate(entity);
+				LOG.debug("Persisted the entity with a new permission collection.");
+			}
 		}
 	}
 
@@ -248,40 +255,43 @@ public abstract class AbstractSecuredPersistentObjectService<E extends SecuredPe
 	 * @param permissions The permissions to remove
 	 */
 	public void removeAndSaveGroupPermissions(E entity, UserGroup userGroup, Permission... permissions) {
-		if(entity != null) {
-			// create a set from the passed array
-			final HashSet<Permission> permissionsSet = new HashSet<Permission>(Arrays.asList(permissions));
-
-			if(permissionsSet != null && !permissionsSet.isEmpty()) {
-				// get the existing permission
-				PermissionCollection groupPermissionCollection = entity.getGroupPermissions().get(userGroup);
-
-				if(groupPermissionCollection != null) {
-					Set<Permission> groupPermissions = groupPermissionCollection.getPermissions();
-
-					int originalNrOfPermissions = groupPermissions.size();
-
-					// remove the passed permissions from the the existing permission collection
-					groupPermissions.removeAll(permissionsSet);
-
-					int newNrOfPermissions = groupPermissions.size();
-
-					// only persist if we have "really" removed something
-					if(newNrOfPermissions < originalNrOfPermissions) {
-						LOG.debug("Removed the following permissions from an existing permission collection: "
-								+ permissionsSet);
-						// persist the permission collection
-						permissionCollectionService.saveOrUpdate(groupPermissionCollection);
-						LOG.debug("Persisted a permission collection");
-					}
-				} else {
-					LOG.error("Could not remove permissions as there is no attached permission collection.");
-				}
-			} else {
-				LOG.error("Could not remove permissions: No permissions have been passed." );
-			}
-		} else {
+		if(entity == null) {
 			LOG.error("Could not remove permissions: The passed entity is NULL.");
+			return;
+		}
+
+		// create a set from the passed array
+		final HashSet<Permission> permissionsSet = new HashSet<Permission>(Arrays.asList(permissions));
+
+		if(permissionsSet == null || permissionsSet.isEmpty()) {
+			LOG.error("Could not remove permissions: No permissions have been passed." );
+			return;
+		}
+
+		// get the existing permission
+		PermissionCollection groupPermissionCollection = entity.getGroupPermissions().get(userGroup);
+
+		if(groupPermissionCollection == null) {
+			LOG.error("Could not remove permissions as there is no attached permission collection.");
+			return;
+		}
+
+		Set<Permission> groupPermissions = groupPermissionCollection.getPermissions();
+
+		int originalNrOfPermissions = groupPermissions.size();
+
+		// remove the passed permissions from the the existing permission collection
+		groupPermissions.removeAll(permissionsSet);
+
+		int newNrOfPermissions = groupPermissions.size();
+
+		// only persist if we have "really" removed something
+		if(newNrOfPermissions < originalNrOfPermissions) {
+			LOG.debug("Removed the following permissions from an existing permission collection: "
+					+ permissionsSet);
+			// persist the permission collection
+			permissionCollectionService.saveOrUpdate(groupPermissionCollection);
+			LOG.debug("Persisted a permission collection");
 		}
 	}
 

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractSecuredPersistentObjectService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractSecuredPersistentObjectService.java
@@ -74,7 +74,8 @@ public abstract class AbstractSecuredPersistentObjectService<E extends SecuredPe
 
 				if(userPermissionCollection == null) {
 					// create a new user permission collection and attach it to the user
-					entity.getUserPermissions().put(user, new PermissionCollection(permissionsSet));
+					userPermissionCollection = new PermissionCollection(permissionsSet);
+					entity.getUserPermissions().put(user, userPermissionCollection);
 					LOG.debug("Attached a new permission collection for a user: " + permissionsSet);
 
 					// persist permission collection and the entity as a new permission
@@ -193,7 +194,9 @@ public abstract class AbstractSecuredPersistentObjectService<E extends SecuredPe
 
 				if(groupPermissionCollection == null) {
 					// create a new user permission collection and attach it to the user
-					entity.getGroupPermissions().put(userGroup, new PermissionCollection(permissionsSet));
+					groupPermissionCollection = new PermissionCollection(permissionsSet);
+
+					entity.getGroupPermissions().put(userGroup, groupPermissionCollection);
 					LOG.debug("Attached a new permission collection for a group: " + permissionsSet);
 
 					// persist permission collection and the entity as a new permission


### PR DESCRIPTION
Based on the comments of @marcjansen in #164, this PR optimizes the handling of permissions in the `AbstractSecuredPersistentObjectService`:

* Renamed methods to be more meaningful (e.g. `addAndSaveUserPermissions(...)`)
* Only persist permission collections, if the number of elements in the set has really changed

I also added tests for the new case.

Please review and merge