### PR TITLE
Secure user groups

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/UserGroup.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/UserGroup.java
@@ -3,6 +3,8 @@ package de.terrestris.shogun2.model;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.persistence.AssociationOverride;
+import javax.persistence.AssociationOverrides;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Inheritance;
@@ -25,7 +27,18 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @Entity
 @Table
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
-public class UserGroup extends PersistentObject {
+@AssociationOverrides({
+	@AssociationOverride(
+			name="userPermissions",
+			joinTable=@JoinTable(name="USERGROUPS_USERPERMISSIONS",
+			joinColumns = @JoinColumn(name = "USERGROUP_ID"))),
+
+	@AssociationOverride(
+			name="groupPermissions",
+			joinTable=@JoinTable(name="USERGROUPS_GROUPPERMISSIONS",
+			joinColumns = @JoinColumn(name = "USERGROUP_ID")))
+})
+public class UserGroup extends SecuredPersistentObject {
 
 	private static final long serialVersionUID = 1L;
 

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/security/access/entity/UserGroupPermissionEvaluator.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/security/access/entity/UserGroupPermissionEvaluator.java
@@ -33,21 +33,17 @@ public class UserGroupPermissionEvaluator<E extends UserGroup> extends
 	 * Uses default implementation otherwise.
 	 */
 	@Override
-	public boolean hasPermission(Integer userId, E userGroup, Permission permission) {
+	public boolean hasPermission(User user, E userGroup, Permission permission) {
 
 		// always grant READ access to groups in which the user itself is a member
-		if (userId != null && permission.equals(Permission.READ)) {
-
-			for (User member : userGroup.getMembers()) {
-				if(userId.equals(member.getId())) {
-					LOG.trace("Granting READ access on group where the user is member.");
-					return true;
-				}
-			}
+		if (user != null && permission.equals(Permission.READ)
+				&& userGroup.getMembers().contains(user)) {
+			LOG.trace("Granting READ access on group where the user is member.");
+			return true;
 		}
 
 		// call parent implementation
-		return super.hasPermission(userId, userGroup, permission);
+		return super.hasPermission(user, userGroup, permission);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/security/access/entity/UserGroupPermissionEvaluator.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/security/access/entity/UserGroupPermissionEvaluator.java
@@ -1,0 +1,53 @@
+package de.terrestris.shogun2.security.access.entity;
+
+import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.UserGroup;
+import de.terrestris.shogun2.model.security.Permission;
+
+/**
+ * @author Nils Bühner
+ *
+ */
+public class UserGroupPermissionEvaluator<E extends UserGroup> extends
+		PersistentObjectPermissionEvaluator<E> {
+
+	/**
+	 * Default constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public UserGroupPermissionEvaluator() {
+		this((Class<E>) UserGroup.class);
+	}
+
+	/**
+	 * Constructor for subclasses
+	 *
+	 * @param entityClass
+	 */
+	protected UserGroupPermissionEvaluator(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * Grants READ permission on groups where the user is a member.
+	 * Uses default implementation otherwise.
+	 */
+	@Override
+	public boolean hasPermission(Integer userId, E userGroup, Permission permission) {
+
+		// always grant READ access to groups in which the user itself is a member
+		if (userId != null && permission.equals(Permission.READ)) {
+
+			for (User member : userGroup.getMembers()) {
+				if(userId.equals(member.getId())) {
+					LOG.trace("Granting READ access on group where the user is member.");
+					return true;
+				}
+			}
+		}
+
+		// call parent implementation
+		return super.hasPermission(userId, userGroup, permission);
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/security/access/factory/EntityPermissionEvaluatorFactory.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/security/access/factory/EntityPermissionEvaluatorFactory.java
@@ -2,7 +2,9 @@ package de.terrestris.shogun2.security.access.factory;
 
 import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.UserGroup;
 import de.terrestris.shogun2.security.access.entity.PersistentObjectPermissionEvaluator;
+import de.terrestris.shogun2.security.access.entity.UserGroupPermissionEvaluator;
 import de.terrestris.shogun2.security.access.entity.UserPermissionEvaluator;
 
 
@@ -18,6 +20,10 @@ public class EntityPermissionEvaluatorFactory<E extends PersistentObject> {
 
 		if(User.class.isAssignableFrom(entityClass)) {
 			return new UserPermissionEvaluator();
+		}
+
+		if(UserGroup.class.isAssignableFrom(entityClass)) {
+			return new UserGroupPermissionEvaluator();
 		}
 
 		// fall back on default implementation

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/UserGroupService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/UserGroupService.java
@@ -21,7 +21,7 @@ import de.terrestris.shogun2.model.UserGroup;
  */
 @Service("userGroupService")
 public class UserGroupService<E extends UserGroup, D extends UserGroupDao<E>>
-		extends AbstractCrudService<E, D> {
+		extends AbstractSecuredPersistentObjectService<E, D> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/security/access/entity/UserGroupPermissionEvaluatorTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/security/access/entity/UserGroupPermissionEvaluatorTest.java
@@ -1,0 +1,80 @@
+/**
+ *
+ */
+package de.terrestris.shogun2.security.access.entity;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import de.terrestris.shogun2.helper.IdHelper;
+import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.UserGroup;
+import de.terrestris.shogun2.model.security.Permission;
+
+/**
+ * @author Nils Bühner
+ *
+ */
+public class UserGroupPermissionEvaluatorTest extends
+	AbstractSecuredObjectPermissionEvaluatorTest<UserGroup> {
+
+	public UserGroupPermissionEvaluatorTest() {
+		super(UserGroup.class, new UserGroupPermissionEvaluator<>(), new UserGroup());
+	}
+
+	@Test
+	public void hasPermission_shouldAlwaysGrantReadOnGroupsWhereUserIsMember() throws NoSuchFieldException, IllegalAccessException {
+		Permission readPermission = Permission.READ;
+
+		// prepare a user that is member of the group
+		final User user = new User("First name", "Last Name", "accountName");
+		IdHelper.setIdOnPersistentObject(user, 42);
+
+		// prepare a secured group
+		UserGroup userGroup = new UserGroup();
+		IdHelper.setIdOnPersistentObject(user, 17);
+
+		// add the user to the group
+		userGroup.getMembers().add(user);
+
+		// we do not add any permissions to the user, but expect that he is allowed to READ himself
+		// call method to test
+		boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(user , userGroup, readPermission);
+
+		assertThat(permissionResult, equalTo(true));
+
+	}
+
+	@Test
+	public void hasPermission_shouldNeverGrantAdminDeleteOrWriteOnOwnUserObject() throws NoSuchFieldException, IllegalAccessException {
+
+		// prepare a user that
+		final User user = new User("First name", "Last Name", "accountName");
+		IdHelper.setIdOnPersistentObject(user, 42);
+
+		// prepare a secured group
+		UserGroup userGroup = new UserGroup();
+		IdHelper.setIdOnPersistentObject(user, 17);
+
+		// add the user to the group
+		userGroup.getMembers().add(user);
+
+		Set<Permission> permissions = new HashSet<Permission>(Arrays.asList(Permission.values()));
+		permissions.remove(Permission.READ); // everything but READ
+
+		for (Permission permission : permissions) {
+			// call method to test
+			boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(user, userGroup, permission);
+
+			assertThat(permissionResult, equalTo(false));
+		}
+
+	}
+
+}

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/UserGroupServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/UserGroupServiceTest.java
@@ -1,0 +1,28 @@
+package de.terrestris.shogun2.service;
+
+import de.terrestris.shogun2.dao.UserGroupDao;
+import de.terrestris.shogun2.model.UserGroup;
+
+public class UserGroupServiceTest extends
+		AbstractSecuredPersistentObjectServiceTest<UserGroup, UserGroupDao<UserGroup>, UserGroupService<UserGroup, UserGroupDao<UserGroup>>> {
+
+	/**
+	 *
+	 * @throws Exception
+	 */
+	public void setUpImplToTest() throws Exception {
+		implToTest = new UserGroup();
+	}
+
+	@Override
+	protected UserGroupService<UserGroup, UserGroupDao<UserGroup>> getCrudService() {
+		return new UserGroupService<UserGroup, UserGroupDao<UserGroup>>();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected Class<UserGroupDao<UserGroup>> getDaoClass() {
+		return (Class<UserGroupDao<UserGroup>>) new UserGroupDao<UserGroup>().getClass();
+	}
+
+}

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/UserServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/UserServiceTest.java
@@ -39,7 +39,7 @@ import de.terrestris.shogun2.model.token.RegistrationToken;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath*:META-INF/spring/test-encoder-bean.xml" })
-public class UserServiceTest extends AbstractCrudServiceTest<User, UserDao<User>, UserService<User, UserDao<User>>> {
+public class UserServiceTest extends AbstractSecuredPersistentObjectServiceTest<User, UserDao<User>, UserService<User, UserDao<User>>> {
 
 	@Mock
 	private RegistrationTokenService<RegistrationToken, RegistrationTokenDao<RegistrationToken>> registrationTokenService;


### PR DESCRIPTION
This PR makes entities of the type `UserGroup` protectable, i.e. `UserGroup` now extends `SecuredPersistentObject`, which leads to the following changes:

* `UserGroupService` now extends `AbstractSecuredPersistentObjectService`
* A `UserGroupServiceTest` has been introduced. This test class was missing before!
* A `UserGroupPermissionEvaluator` has been introduced. This evaluator will always allow READ access to all groups, where the currently logged in user is a member of.

Please review!