### PR TITLE
Use full user object when evaluating permissions

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/security/access/entity/UserPermissionEvaluator.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/security/access/entity/UserPermissionEvaluator.java
@@ -32,17 +32,17 @@ public class UserPermissionEvaluator<E extends User> extends
 	 * user. Uses default implementation otherwise.
 	 */
 	@Override
-	public boolean hasPermission(Integer userId, E entity, Permission permission) {
+	public boolean hasPermission(User user, E entity, Permission permission) {
 
 		// always grant READ access to own user object (of the logged in user)
-		if (userId != null && userId.equals(entity.getId())
+		if (user != null && user.equals(entity)
 				&& permission.equals(Permission.READ)) {
 			LOG.trace("Granting READ access on own user object");
 			return true;
 		}
 
 		// call parent implementation
-		return super.hasPermission(userId, entity, permission);
+		return super.hasPermission(user, entity, permission);
 	}
 
 }

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/security/access/entity/AbstractSecuredObjectPermissionEvaluatorTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/security/access/entity/AbstractSecuredObjectPermissionEvaluatorTest.java
@@ -40,19 +40,22 @@ public abstract class AbstractSecuredObjectPermissionEvaluatorTest<E extends Sec
 	}
 
 	/**
+	 * @throws IllegalAccessException 
+	 * @throws NoSuchFieldException 
 	 *
 	 */
 	@Test
-	public void hasPermission_shouldNeverGrantAnythingWithoutPermissions() {
+	public void hasPermission_shouldNeverGrantAnythingWithoutPermissions() throws NoSuchFieldException, IllegalAccessException {
 		Set<Permission> allPermissions = new HashSet<Permission>(Arrays.asList(Permission.values()));
 
 		// assert that no permission will ever be granted on secured objects
 		// if no permissions are set
 		for (Permission permission : allPermissions) {
-			Integer userId = 42;
+			final User user = new User("First name", "Last Name", "accountName");
+			IdHelper.setIdOnPersistentObject(user, 42);
 
 			// call method to test
-			boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(userId , entityToCheck, permission);
+			boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(user , entityToCheck, permission);
 
 			assertThat(permissionResult, equalTo(false));
 
@@ -67,9 +70,8 @@ public abstract class AbstractSecuredObjectPermissionEvaluatorTest<E extends Sec
 	@Test
 	public void hasPermission_shouldGrantPermissionOnSecuredObjectWithCorrectUserPermission() throws NoSuchFieldException, IllegalAccessException {
 		// prepare a user that gets permissions
-		User user = new User();
-		final int userId = 42;
-		IdHelper.setIdOnPersistentObject(user, userId);
+		final User user = new User("First name", "Last Name", "accountName");
+		IdHelper.setIdOnPersistentObject(user, 42);
 
 		// prepare permission collection/map
 		Map<User, PermissionCollection> userPermissionsMap = new HashMap<User, PermissionCollection>();
@@ -81,7 +83,7 @@ public abstract class AbstractSecuredObjectPermissionEvaluatorTest<E extends Sec
 		entityToCheck.setUserPermissions(userPermissionsMap);
 
 		// call method to test
-		boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(userId , entityToCheck, writePermission);
+		boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(user , entityToCheck, writePermission);
 
 		assertThat(permissionResult, equalTo(true));
 	}
@@ -94,9 +96,8 @@ public abstract class AbstractSecuredObjectPermissionEvaluatorTest<E extends Sec
 	@Test
 	public void hasPermission_shouldGrantPermissionOnSecuredObjectWithCorrectGroupPermission() throws NoSuchFieldException, IllegalAccessException {
 		// prepare a user
-		User user = new User();
-		final int userId = 42;
-		IdHelper.setIdOnPersistentObject(user, userId);
+		final User user = new User("First name", "Last Name", "accountName");
+		IdHelper.setIdOnPersistentObject(user, 42);
 
 		// add user to a group
 		UserGroup group = new UserGroup();
@@ -112,7 +113,7 @@ public abstract class AbstractSecuredObjectPermissionEvaluatorTest<E extends Sec
 		entityToCheck.setGroupPermissions(userGroupPermissionsMap);
 
 		// call method to test
-		boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(userId , entityToCheck, writePermission);
+		boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(user , entityToCheck, writePermission);
 
 		assertThat(permissionResult, equalTo(true));
 	}
@@ -130,9 +131,8 @@ public abstract class AbstractSecuredObjectPermissionEvaluatorTest<E extends Sec
 		if(isSecuredObject == true) {
 
 			// prepare a user that gets permissions
-			User user = new User();
-			final int userId = 42;
-			IdHelper.setIdOnPersistentObject(user, userId);
+			final User user = new User("First name", "Last Name", "accountName");
+			IdHelper.setIdOnPersistentObject(user, 42);
 
 			// prepare permission collection/map
 			Map<User, PermissionCollection> userPermissionsMap = new HashMap<User, PermissionCollection>();
@@ -148,7 +148,7 @@ public abstract class AbstractSecuredObjectPermissionEvaluatorTest<E extends Sec
 			// check that the ADMIN permission allows the user to to everything
 			for (Permission permission : allPermissions) {
 				// call method to test
-				boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(userId , entityToCheck, permission);
+				boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(user , entityToCheck, permission);
 
 				assertThat(permissionResult, equalTo(true));
 			}
@@ -165,9 +165,8 @@ public abstract class AbstractSecuredObjectPermissionEvaluatorTest<E extends Sec
 	public void hasPermission_shouldGrantAnyPermissionOnSecuredObjectWithUserGroupAdminPermission() throws NoSuchFieldException, IllegalAccessException {
 
 		// prepare a user
-		User user = new User();
-		final int userId = 42;
-		IdHelper.setIdOnPersistentObject(user, userId);
+		final User user = new User("First name", "Last Name", "accountName");
+		IdHelper.setIdOnPersistentObject(user, 42);
 
 		// add user to group
 		UserGroup group = new UserGroup();
@@ -187,7 +186,7 @@ public abstract class AbstractSecuredObjectPermissionEvaluatorTest<E extends Sec
 		// check that the ADMIN permission allows the user to to everything
 		for (Permission permission : allPermissions) {
 			// call method to test
-			boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(userId , entityToCheck, permission);
+			boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(user , entityToCheck, permission);
 
 			assertThat(permissionResult, equalTo(true));
 		}

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/security/access/entity/AbstractUnsecuredObjectPermissionEvaluatorTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/security/access/entity/AbstractUnsecuredObjectPermissionEvaluatorTest.java
@@ -10,8 +10,10 @@ import java.util.Set;
 
 import org.junit.Test;
 
+import de.terrestris.shogun2.helper.IdHelper;
 import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.model.SecuredPersistentObject;
+import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.model.security.Permission;
 
 /**
@@ -29,10 +31,12 @@ public abstract class AbstractUnsecuredObjectPermissionEvaluatorTest<E extends P
 	}
 
 	/**
+	 * @throws IllegalAccessException 
+	 * @throws NoSuchFieldException 
 	 *
 	 */
 	@Test
-	public void hasPermission_shouldAlwaysGrantRead() {
+	public void hasPermission_shouldAlwaysGrantRead() throws NoSuchFieldException, IllegalAccessException {
 		final boolean isSecuredObject = SecuredPersistentObject.class.isAssignableFrom(entityClass);
 
 		// test only for unsecured objects
@@ -41,20 +45,23 @@ public abstract class AbstractUnsecuredObjectPermissionEvaluatorTest<E extends P
 		} else {
 			Permission readPermission = Permission.READ;
 
-			Integer userId = 42;
+			final User user = new User("First name", "Last Name", "accountName");
+			IdHelper.setIdOnPersistentObject(user, 42);
 
 			// call method to test
-			boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(userId , entityToCheck, readPermission);
+			boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(user , entityToCheck, readPermission);
 
 			assertThat(permissionResult, equalTo(true));
 		}
 	}
 
 	/**
+	 * @throws IllegalAccessException 
+	 * @throws NoSuchFieldException 
 	 *
 	 */
 	@Test
-	public void hasPermission_shouldNeverGrantAdminDeleteOrWrite() {
+	public void hasPermission_shouldNeverGrantAdminDeleteOrWrite() throws NoSuchFieldException, IllegalAccessException {
 		final boolean isSecuredObject = SecuredPersistentObject.class.isAssignableFrom(entityClass);
 
 		// test only for unsecured objects
@@ -66,10 +73,11 @@ public abstract class AbstractUnsecuredObjectPermissionEvaluatorTest<E extends P
 
 			// assert that these permissions will never be granted on unsecured objects
 			for (Permission permission : permissions) {
-				Integer userId = 42;
+				final User user = new User("First name", "Last Name", "accountName");
+				IdHelper.setIdOnPersistentObject(user, 42);
 
 				// call method to test
-				boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(userId , entityToCheck, permission);
+				boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(user, entityToCheck, permission);
 
 				assertThat(permissionResult, equalTo(false));
 			}

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/security/access/entity/UserPermissionEvaluatorTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/security/access/entity/UserPermissionEvaluatorTest.java
@@ -32,13 +32,12 @@ public class UserPermissionEvaluatorTest extends
 		Permission readPermission = Permission.READ;
 
 		// prepare a user that
-		User user = new User();
-		final int userId = 42;
-		IdHelper.setIdOnPersistentObject(user, userId);
+		final User user = new User("First name", "Last Name", "accountName");
+		IdHelper.setIdOnPersistentObject(user, 42);
 
 		// we do not add any permissions to the user, but expect that he is allowed to READ himself
 		// call method to test
-		boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(userId , user, readPermission);
+		boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(user , user, readPermission);
 
 		assertThat(permissionResult, equalTo(true));
 
@@ -48,16 +47,15 @@ public class UserPermissionEvaluatorTest extends
 	public void hasPermission_shouldNeverGrantAdminDeleteOrWriteOnOwnUserObject() throws NoSuchFieldException, IllegalAccessException {
 
 		// prepare a user that
-		User user = new User();
-		final int userId = 42;
-		IdHelper.setIdOnPersistentObject(user, userId);
+		final User user = new User("First name", "Last Name", "accountName");
+		IdHelper.setIdOnPersistentObject(user, 42);
 
 		Set<Permission> permissions = new HashSet<Permission>(Arrays.asList(Permission.values()));
 		permissions.remove(Permission.READ); // everything but READ
 
 		for (Permission permission : permissions) {
 			// call method to test
-			boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(userId , user, permission);
+			boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(user , user, permission);
 
 			assertThat(permissionResult, equalTo(false));
 		}


### PR DESCRIPTION
This PR is an enhancement of the current permission evaluation.

Until now, we were always evaluating permissions based on a given user ID. This PR changes the code to make use of the full user object (coming from the db).

To realize this, we have to use the `UserDao` in the `Shogun2PermissionEvaluator` class. We can NOT use the `UserService` here as the methods of the user service are secured, which would trigger the permission evaluation again and we would always end up with a StackOverflow error when using the service here.

These changes do not require any adaptions in existing projects!

Please review