### PR TITLE
Fix Layer hierarchy

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/AbstractLayerDao.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/AbstractLayerDao.java
@@ -1,15 +1,18 @@
 package de.terrestris.shogun2.dao;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import org.hibernate.Criteria;
-import org.hibernate.HibernateException;
-import org.hibernate.criterion.Restrictions;
 import org.springframework.stereotype.Repository;
 
 import de.terrestris.shogun2.model.layer.AbstractLayer;
 
+/**
+ * This DAO is not abstract (even though the {@link AbstractLayer} class is)
+ * because we need to use it for subclasses of {@link AbstractLayer} at some
+ * point.
+ *
+ * @author Nils Bühner
+ *
+ * @param <E>
+ */
 @Repository("abstractLayerDao")
 public class AbstractLayerDao<E extends AbstractLayer> extends
 		GenericHibernateDao<E, Integer> {
@@ -31,16 +34,4 @@ public class AbstractLayerDao<E extends AbstractLayer> extends
 		super(clazz);
 	}
 
-	/**
-	 *
-	 */
-	@SuppressWarnings("unchecked")
-	public Set<E> findLayerGroupsOfAbstractLayer(AbstractLayer abstractLayer) throws HibernateException {
-		Criteria criteria = createDistinctRootEntityCriteria();
-
-		criteria.createAlias("layers", "lyr");
-		criteria.add(Restrictions.eq("lyr.id", abstractLayer.getId()));
-
-		return new HashSet<E>(criteria.list());
-	}
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/LayerDao.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/LayerDao.java
@@ -5,8 +5,7 @@ import org.springframework.stereotype.Repository;
 import de.terrestris.shogun2.model.layer.Layer;
 
 @Repository("layerDao")
-public class LayerDao<E extends Layer> extends
-		GenericHibernateDao<E, Integer> {
+public class LayerDao<E extends Layer> extends AbstractLayerDao<E> {
 
 	/**
 	 * Public default constructor for this DAO.

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/LayerGroupDao.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/LayerGroupDao.java
@@ -1,0 +1,46 @@
+package de.terrestris.shogun2.dao;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.hibernate.Criteria;
+import org.hibernate.HibernateException;
+import org.hibernate.criterion.Restrictions;
+import org.springframework.stereotype.Repository;
+
+import de.terrestris.shogun2.model.layer.LayerGroup;
+
+@Repository("layerGroupDao")
+public class LayerGroupDao<E extends LayerGroup> extends AbstractLayerDao<E> {
+
+	/**
+	 * Public default constructor for this DAO.
+	 */
+	@SuppressWarnings("unchecked")
+	public LayerGroupDao() {
+		super((Class<E>) LayerGroup.class);
+	}
+
+	/**
+	 * Constructor that has to be called by subclasses.
+	 *
+	 * @param clazz
+	 */
+	protected LayerGroupDao(Class<E> clazz) {
+		super(clazz);
+	}
+
+	/**
+	 *
+	 */
+	@SuppressWarnings("unchecked")
+	public Set<E> findLayerGroupsOfAbstractLayer(Integer abstractLayerId) throws HibernateException {
+		Criteria criteria = createDistinctRootEntityCriteria();
+
+		criteria.createAlias("layers", "lyr");
+		criteria.add(Restrictions.eq("lyr.id", abstractLayerId));
+
+		return new HashSet<E>(criteria.list());
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/AbstractLayer.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/AbstractLayer.java
@@ -14,8 +14,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.shogun2.model.SecuredPersistentObject;
-import de.terrestris.shogun2.model.layer.appearance.LayerAppearance;
-import de.terrestris.shogun2.model.layer.source.LayerDataSource;
 
 /**
  *
@@ -51,6 +49,10 @@ public abstract class AbstractLayer extends SecuredPersistentObject {
 	 *
 	 */
 	private String name;
+
+	/**
+	 *
+	 */
 	private String type;
 
 	/**
@@ -66,7 +68,7 @@ public abstract class AbstractLayer extends SecuredPersistentObject {
 	 * @param source The data source of the layer
 	 * @param appearance The appearance configuration of the layer
 	 */
-	public AbstractLayer(String name, String type, LayerDataSource source, LayerAppearance appearance) {
+	public AbstractLayer(String name, String type) {
 		super();
 		this.name = name;
 		this.type = type;

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/Layer.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/Layer.java
@@ -54,7 +54,7 @@ public class Layer extends AbstractLayer {
 	 * @param appearance The appearance configuration of the layer
 	 */
 	public Layer(String name, String type, LayerDataSource source, LayerAppearance appearance) {
-		super();
+		super(name, type);
 		this.source = source;
 		this.appearance = appearance;
 	}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Map.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Map.java
@@ -81,7 +81,6 @@ public class Map extends Module {
 
 	/**
 	 * @param name
-	 * @param magnific
 	 * @param mapConfig
 	 * @param mapLayers
 	 */

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/LayerGroupRestController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/LayerGroupRestController.java
@@ -1,0 +1,49 @@
+package de.terrestris.shogun2.rest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import de.terrestris.shogun2.dao.LayerGroupDao;
+import de.terrestris.shogun2.model.layer.LayerGroup;
+import de.terrestris.shogun2.service.LayerGroupService;
+
+/**
+ * @author Kai Volland
+ * @author Nils Bühner
+ *
+ */
+@RestController
+@RequestMapping("/layergroups")
+public class LayerGroupRestController<E extends LayerGroup, D extends LayerGroupDao<E>, S extends LayerGroupService<E, D>>
+		extends AbstractRestController<E, D, S> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public LayerGroupRestController() {
+		this((Class<E>) LayerGroup.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected LayerGroupRestController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct service here.
+	 * Otherwise, spring can not decide which service has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("layerGroupService")
+	public void setService(S service) {
+		this.service = service;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/LayerGroupService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/LayerGroupService.java
@@ -1,0 +1,103 @@
+package de.terrestris.shogun2.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.access.prepost.PostFilter;
+import org.springframework.stereotype.Service;
+
+import de.terrestris.shogun2.dao.AbstractLayerDao;
+import de.terrestris.shogun2.dao.LayerGroupDao;
+import de.terrestris.shogun2.model.layer.AbstractLayer;
+import de.terrestris.shogun2.model.layer.LayerGroup;
+import de.terrestris.shogun2.model.module.Module;
+
+/**
+ * Service class for the {@link Module} model.
+ *
+ * @author Nils Bühner
+ * @see AbstractCrudService
+ *
+ */
+@Service("layerGroupService")
+public class LayerGroupService<E extends LayerGroup, D extends LayerGroupDao<E>> extends
+		AbstractLayerService<E, D> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public LayerGroupService() {
+		this((Class<E>) LayerGroup.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the service.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected LayerGroupService(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct dao here.
+	 * Otherwise, spring can not decide which dao has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("layerGroupDao")
+	public void setDao(D dao) {
+		this.dao = dao;
+	}
+
+	/**
+	 * We need this service for the {@link AbstractLayer}s to retrieve
+	 * all subtypes of {@link AbstractLayer} from here (but not only from
+	 * the {@link LayerGroup} hierarchy.
+	 */
+	@Autowired
+	@Qualifier("abstractLayerService")
+	private AbstractLayerService<AbstractLayer, AbstractLayerDao<AbstractLayer>> abstractLayerService;
+
+	/**
+	 *
+	 * @param abstractLayer
+	 * @return
+	 */
+	@PostFilter("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(returnObject, 'READ')")
+	public Set<E> findLayerGroupsOfAbstractLayer(Integer abstractLayerId) {
+		return dao.findLayerGroupsOfAbstractLayer(abstractLayerId);
+	}
+
+	/**
+	 * TODO secure this method !!?
+	 *
+	 * @param layerGroupId
+	 * @param abstractLayerIds
+	 * @return
+	 * @throws Exception
+	 */
+	public List<AbstractLayer> setLayersForLayerGroup (Integer layerGroupId, List<Integer> abstractLayerIds) {
+		E layerGroup = this.findById(layerGroupId);
+		List<AbstractLayer> layers = new ArrayList<AbstractLayer>();
+
+		for (Integer id : abstractLayerIds) {
+			// this call may throw an AccessDeniedException !?
+			// maybe we should catch and ignore this here?
+			AbstractLayer layer = abstractLayerService.findById(id);
+			if(layer != null){
+				layers.add(layer);
+			}
+		}
+
+		layerGroup.setLayers(layers);
+
+		this.saveOrUpdate(layerGroup);
+
+		return layers;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/LayerService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/LayerService.java
@@ -17,7 +17,7 @@ import de.terrestris.shogun2.model.module.Module;
  */
 @Service("layerService")
 public class LayerService<E extends Layer, D extends LayerDao<E>> extends
-		AbstractCrudService<E, D> {
+		AbstractLayerService<E, D> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/MapService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/MapService.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.stereotype.Service;
 
 import de.terrestris.shogun2.dao.AbstractLayerDao;
@@ -63,11 +64,13 @@ public class MapService<E extends Map, D extends MapDao<E>> extends
 	 * @param user
 	 * @return
 	 */
+	@PostFilter("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(#e, 'READ')")
 	public Set<E> findMapsWithLayer(AbstractLayer layer) {
 		return dao.findMapsWithLayer(layer);
 	}
 
 	/**
+	 * TODO secure this method!?
 	 *
 	 * @param MapModuleId
 	 * @param abstractLayerIds

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/AbstractLayerController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/AbstractLayerController.java
@@ -3,95 +3,26 @@
  */
 package de.terrestris.shogun2.web;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-
 import de.terrestris.shogun2.dao.AbstractLayerDao;
 import de.terrestris.shogun2.model.layer.AbstractLayer;
 import de.terrestris.shogun2.service.AbstractLayerService;
-import de.terrestris.shogun2.util.data.ResultSet;
 
 /**
+ *
  * @author Johannes Weskamm
  * @author Kai Volland
+ * @author Nils Bühner
  *
  */
-@Controller
-@RequestMapping("/abstractlayers")
-public class AbstractLayerController<E extends AbstractLayer, D extends AbstractLayerDao<E>, S extends AbstractLayerService<E, D>>{
-
-	protected S service;
+public abstract class AbstractLayerController<E extends AbstractLayer, D extends AbstractLayerDao<E>, S extends AbstractLayerService<E, D>>
+		extends AbstractWebController<E, D, S> {
 
 	/**
-	 * We have to use {@link Qualifier} to define the correct service here.
-	 * Otherwise, spring can not decide which service has to be autowired here
-	 * as there are multiple candidates.
-	 */
-	@Autowired
-	@Qualifier("abstractLayerService")
-	public void setService(S service) {
-		this.service = service;
-	}
-
-	/**
-	 * Default constructor, which calls the type-constructor
-	 */
-	@SuppressWarnings("unchecked")
-	public AbstractLayerController() {
-		this((Class<E>) AbstractLayer.class);
-	}
-
-	/**
-	 * Constructor that sets the concrete type for this controller.
+	 * Constructor that sets the concrete entity class for the controller.
 	 * Subclasses MUST call this constructor.
 	 */
-	protected AbstractLayerController(Class<E> type) {
-		super();
-	}
-
-	/**
-	 *
-	 * @param abstractLayerId
-	 * @return
-	 */
-	@RequestMapping(value = "/getLayerGroupsOfLayer.action", method = RequestMethod.GET)
-	public @ResponseBody Map<String, Object> getLayerGroupsOfLayer(Integer abstractLayerId) {
-
-		AbstractLayer abstractLayer = this.service.findById(abstractLayerId);
-		try {
-			 Set<E> layergroups = this.service.findLayerGroupsOfAbstractLayer(abstractLayer);
-			return ResultSet.success(layergroups);
-		} catch (Exception e) {
-			return ResultSet.error("Could not get Layergroups of layer " + abstractLayer.getName() + ".");
-		}
-	}
-
-	/**
-	 *
-	 * @param moduleId
-	 * @param toolIds
-	 * @return
-	 */
-	@RequestMapping(value = "/setLayersForLayerGroup.action", method = RequestMethod.POST)
-	public @ResponseBody Map<String, Object> setLayersForLayerGroup(
-			@RequestParam("layerGroupId") Integer layerGroupId,
-			@RequestParam("abstractLayerIds") List<Integer> abstractLayerIds) {
-
-		try {
-			List<AbstractLayer> layers = this.service.setLayersForLayerGroup(layerGroupId, abstractLayerIds);
-			return ResultSet.success(layers);
-		} catch (Exception e) {
-			return ResultSet.error("Could not set Layers for LayerGroup");
-		}
+	protected AbstractLayerController(Class<E> entityClass) {
+		super(entityClass);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/LayerController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/LayerController.java
@@ -1,0 +1,55 @@
+/**
+ *
+ */
+package de.terrestris.shogun2.web;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import de.terrestris.shogun2.dao.LayerDao;
+import de.terrestris.shogun2.model.layer.Layer;
+import de.terrestris.shogun2.service.LayerService;
+
+/**
+ *
+ * @author Johannes Weskamm
+ * @author Kai Volland
+ * @author Nils Bühner
+ *
+ */
+@Controller
+@RequestMapping("/layer")
+public class LayerController<E extends Layer, D extends LayerDao<E>, S extends LayerService<E, D>>
+		extends AbstractLayerController<E, D, S> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public LayerController() {
+		this((Class<E>) Layer.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected LayerController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct service here.
+	 * Otherwise, spring can not decide which service has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("layerService")
+	public void setService(S service) {
+		this.service = service;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/LayerGroupController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/LayerGroupController.java
@@ -1,0 +1,99 @@
+/**
+ *
+ */
+package de.terrestris.shogun2.web;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import de.terrestris.shogun2.dao.LayerGroupDao;
+import de.terrestris.shogun2.model.layer.AbstractLayer;
+import de.terrestris.shogun2.model.layer.LayerGroup;
+import de.terrestris.shogun2.service.LayerGroupService;
+import de.terrestris.shogun2.util.data.ResultSet;
+
+/**
+ *
+ * @author Johannes Weskamm
+ * @author Kai Volland
+ * @author Nils Bühner
+ *
+ */
+@Controller
+@RequestMapping("/layergroup")
+public class LayerGroupController<E extends LayerGroup, D extends LayerGroupDao<E>, S extends LayerGroupService<E, D>>
+		extends AbstractLayerController<E, D, S> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public LayerGroupController() {
+		this((Class<E>) LayerGroup.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected LayerGroupController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct service here.
+	 * Otherwise, spring can not decide which service has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("layerGroupService")
+	public void setService(S service) {
+		this.service = service;
+	}
+
+	/**
+	 *
+	 * @param moduleId
+	 * @param toolIds
+	 * @return
+	 */
+	@RequestMapping(value = "/setLayersForLayerGroup.action", method = RequestMethod.POST)
+	public @ResponseBody Map<String, Object> setLayersForLayerGroup(
+			@RequestParam("layerGroupId") Integer layerGroupId,
+			@RequestParam("abstractLayerIds") List<Integer> abstractLayerIds) {
+
+		try {
+			List<AbstractLayer> layers = this.service.setLayersForLayerGroup(layerGroupId, abstractLayerIds);
+			return ResultSet.success(layers);
+		} catch (Exception e) {
+			return ResultSet.error("Could not set Layers for LayerGroup");
+		}
+	}
+
+	/**
+	 *
+	 * @param abstractLayerId
+	 * @return
+	 */
+	@RequestMapping(value = "/getLayerGroupsOfLayer.action", method = RequestMethod.GET)
+	public @ResponseBody Map<String, Object> getLayerGroupsOfLayer(Integer abstractLayerId) {
+
+		try {
+			 Set<E> layergroups = this.service.findLayerGroupsOfAbstractLayer(abstractLayerId);
+			return ResultSet.success(layergroups);
+		} catch (Exception e) {
+			return ResultSet.error("Could not get Layergroups of layer with id " + abstractLayerId + ".");
+		}
+	}
+
+}


### PR DESCRIPTION
The `AbstractLayer` hierarchy had some drawbacks that should be fixed with this PR.

* General bugfixing (e.g. in constructors)
* The layer services now all extend from `AbstractSecuredPersistentObjectService`, which allows us to make use of the very useful methods from this class
* The methods from the `AbstractLayerService/DAO`  have been moved to the correct (and new) subclass `LayerGroupService/DAO`
* Missing services and controllers and DAOs have been added

Please review