### PR TITLE
Fix constructor

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Map.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Map.java
@@ -86,7 +86,7 @@ public class Map extends Module {
 	 * @param mapLayers
 	 */
 	public Map(String name, MapConfig mapConfig, List<AbstractLayer> mapLayers) {
-		super();
+		super(name);
 		this.mapConfig = mapConfig;
 		this.mapLayers = mapLayers;
 	}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Module.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Module.java
@@ -76,6 +76,13 @@ public class Module extends PersistentObject {
 	}
 
 	/**
+	 * 
+	 */
+	public Module(String name) {
+		this.name = name;
+	}
+
+	/**
 	 * @return the name
 	 */
 	public String getName() {


### PR DESCRIPTION
The `name` property of the Map constructor was not used. This PR fixes this.

Please merge after review!