### PR TITLE
Use findById instead of loadById when deleting

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
@@ -181,10 +181,7 @@ public abstract class AbstractRestController<E extends PersistentObject, D exten
 	public ResponseEntity<E> delete(@PathVariable int id) {
 
 		try {
-			// Use the loadById method to get a proxy that will throw exceptions
-			// when the object can later not be accessed. This is more performant
-			// than using the findById method, which will always hit the database.
-			E entityToDelete = this.service.loadById(id);
+			E entityToDelete = this.service.findById(id);
 
 			this.service.delete(entityToDelete);
 

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/rest/AbstractRestControllerTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/rest/AbstractRestControllerTest.java
@@ -410,14 +410,14 @@ public class AbstractRestControllerTest {
 
 		TestModel entityToDelete = buildTestInstanceWithIdAndValue(id, value);
 
-		when(serviceMock.loadById(id)).thenReturn(entityToDelete);
+		when(serviceMock.findById(id)).thenReturn(entityToDelete);
 		doNothing().when(serviceMock).delete(entityToDelete);
 
 		// Test DELETE method
 		mockMvc.perform(delete("/tests/" + id)).andExpect(
 				status().isNoContent());
 
-		verify(serviceMock, times(1)).loadById(id);
+		verify(serviceMock, times(1)).findById(id);
 		verify(serviceMock, times(1)).delete(entityToDelete);
 		verifyNoMoreInteractions(serviceMock);
 	}
@@ -437,14 +437,14 @@ public class AbstractRestControllerTest {
 
 		TestModel entityToDelete = buildTestInstanceWithIdAndValue(id, value);
 
-		when(serviceMock.loadById(id)).thenReturn(entityToDelete);
+		when(serviceMock.findById(id)).thenReturn(entityToDelete);
 		doThrow(new RuntimeException()).when(serviceMock).delete(entityToDelete);
 
 		// Test DELETE method
 		mockMvc.perform(delete("/tests/" + id)).andExpect(
 				status().isNotFound());
 
-		verify(serviceMock, times(1)).loadById(id);
+		verify(serviceMock, times(1)).findById(id);
 		verify(serviceMock, times(1)).delete(entityToDelete);
 		verifyNoMoreInteractions(serviceMock);
 	}


### PR DESCRIPTION
The `loadById` method creates proxy objects which lead to problems when using the REST-Delete method. Using `findById` fixes this.

Please review.