### PR TITLE
Prepare interceptor beans in archetype resources

### DIFF
--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context.xml
@@ -69,4 +69,16 @@
     <!-- The GeoServer Namespace to URI map used in the Interceptor -->
     <util:properties id="geoServerNameSpaces" location="classpath*:META-INF/geoServerNameSpaces.properties" />
 
+    <!--
+     | The interceptor beans, uncomment to be able to use the interceptor
+     | classes for OGC requests
+     |
+    <bean id="wmsRequestInterceptor" class="${package}.util.WmsRequestInterceptor" />
+    <bean id="wmsResponseInterceptor" class="${package}.util.WmsResponseInterceptor" />
+    <bean id="wfsRequestInterceptor" class="${package}.util.WfsRequestInterceptor" />
+    <bean id="wfsResponseInterceptor" class="${package}.util.WfsResponseInterceptor" />
+    <bean id="wcsRequestInterceptor" class="${package}.util.WcsRequestInterceptor" />
+    <bean id="wcsResponseInterceptor" class="${package}.util.WcsResponseInterceptor" />
+     |
+     +-->
 </beans>


### PR DESCRIPTION
This makes it easier for people to actually use the already existing package
classes for the various interceptors; they simply have to uncomment some lines
and are then ready to implement project or artifact specific interceptor
behaviour.

Please review.

/cc @buehner @dnlkoch