### PR TITLE
Make saveOrUpdate void

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,8 @@
 
 ## 0.1.0 (not finally released yet)
 
+* Changes:
+  * The `saveOrUpdate` method of the services are now void. Existing projects that are using this method may need some simple adaptions like changes from `PersistentObject newObject = object.saveOrUpdate()` to `object.saveOrUpdate()`
 * New features:
   * An `AbstractSecuredPersistentObjectService` has been introduced. This service provides useful methods to add and remove permissions for certain objects. `PermissionCollection`s will be persisted in the database when using these methods. All services of entities that extend `SecuredPersistentObject` should extend the abstract service mentioned above.
 

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
@@ -109,7 +109,7 @@ public abstract class AbstractRestController<E extends PersistentObject, D exten
 		}
 
 		try {
-			entity = this.service.saveOrUpdate(entity);
+			this.service.saveOrUpdate(entity);
 			LOG.trace("Created " + simpleClassName + " with ID " + entity.getId());
 			return new ResponseEntity<E>(entity, HttpStatus.CREATED);
 		} catch (Exception e) {

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractCrudService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractCrudService.java
@@ -41,9 +41,8 @@ public abstract class AbstractCrudService<E extends PersistentObject, D extends 
 	 * @return
 	 */
 	@PreAuthorize("isAuthenticated()")
-	public E saveOrUpdate(E e) {
+	public void saveOrUpdate(E e) {
 		dao.saveOrUpdate(e);
-		return e;
 	}
 
 	/**

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/AbstractCrudServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/AbstractCrudServiceTest.java
@@ -104,8 +104,8 @@ public abstract class AbstractCrudServiceTest<E extends PersistentObject, D exte
 	@Test
 	public void saveOrUpdate_shouldSave() {
 
-		doAnswer(new Answer<E>() {
-			public E answer(InvocationOnMock invocation)
+		doAnswer(new Answer<Void>() {
+			public Void answer(InvocationOnMock invocation)
 					throws NoSuchFieldException, SecurityException,
 					IllegalArgumentException, IllegalAccessException {
 				E po = (E) invocation.getArguments()[0];
@@ -113,14 +113,14 @@ public abstract class AbstractCrudServiceTest<E extends PersistentObject, D exte
 				// set id like the dao does
 				IdHelper.setIdOnPersistentObject(po, 1);
 
-				return po;
+				return null;
 			}
 		}).when(dao).saveOrUpdate(implToTest);
 
 		// id has to be NULL before the service method is called
 		assertNull(implToTest.getId());
 
-		implToTest = crudService.saveOrUpdate(implToTest);
+		crudService.saveOrUpdate(implToTest);
 
 		// id must not be NULL after the service method is called
 		assertNotNull(implToTest.getId());
@@ -154,8 +154,8 @@ public abstract class AbstractCrudServiceTest<E extends PersistentObject, D exte
 
 		IdHelper.setIdOnPersistentObject(implToTest, id);
 
-		doAnswer(new Answer<E>() {
-			public E answer(InvocationOnMock invocation)
+		doAnswer(new Answer<Void>() {
+			public Void answer(InvocationOnMock invocation)
 					throws NoSuchFieldException, SecurityException,
 					IllegalArgumentException, IllegalAccessException,
 					InterruptedException {
@@ -165,12 +165,12 @@ public abstract class AbstractCrudServiceTest<E extends PersistentObject, D exte
 				Thread.sleep(1);
 				po.setModified(DateTime.now());
 
-				return po;
+				return null;
 			}
 		}).when(dao).saveOrUpdate(implToTest);
 
 		// now call the method to test
-		implToTest = crudService.saveOrUpdate(implToTest);
+		crudService.saveOrUpdate(implToTest);
 
 		// id and created should not have changed
 		assertEquals(id, implToTest.getId());

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/AbstractSecuredPersistentObjectServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/AbstractSecuredPersistentObjectServiceTest.java
@@ -3,8 +3,8 @@ package de.terrestris.shogun2.service;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -14,6 +14,8 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import de.terrestris.shogun2.dao.GenericHibernateDao;
 import de.terrestris.shogun2.dao.PermissionCollectionDao;
@@ -100,7 +102,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 	public void addAndSaveUserPermissions_shouldCreateNewPermissionCollectionWithOneElement() {
 
 		final Permission adminPermission = Permission.ADMIN;
-		PermissionCollection permissionCollection = new PermissionCollection();
+		final PermissionCollection permissionCollection = new PermissionCollection();
 		permissionCollection.getPermissions().add(adminPermission);
 
 		User user = new User("Dummy", "Dummy", "dummy");
@@ -109,7 +111,8 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		assertTrue(implToTest.getUserPermissions().keySet().isEmpty());
 
 		// mock
-		doReturn(permissionCollection).when(permissionCollectionService).saveOrUpdate(any(PermissionCollection.class));
+		mockSaveOrUpdateOfPc(permissionCollection);
+
 		doNothing().when(dao).saveOrUpdate(implToTest);
 
 		// invoke method to test
@@ -136,7 +139,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		final Permission writePermission = Permission.WRITE;
 		final Permission deletePermission = Permission.DELETE;
 
-		PermissionCollection permissionCollection = new PermissionCollection();
+		final PermissionCollection permissionCollection = new PermissionCollection();
 		permissionCollection.getPermissions().add(readPermission);
 		permissionCollection.getPermissions().add(writePermission);
 		permissionCollection.getPermissions().add(deletePermission);
@@ -147,7 +150,8 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		assertTrue(implToTest.getUserPermissions().keySet().isEmpty());
 
 		// mock
-		doReturn(permissionCollection).when(permissionCollectionService).saveOrUpdate(any(PermissionCollection.class));
+		mockSaveOrUpdateOfPc(permissionCollection);
+
 		doNothing().when(dao).saveOrUpdate(implToTest);
 
 		// invoke method to test
@@ -174,7 +178,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		final Permission newPermission = Permission.READ;
 
 		PermissionCollection existingPermissionCollection = new PermissionCollection();
-		PermissionCollection newPermissionCollection = new PermissionCollection();
+		final PermissionCollection newPermissionCollection = new PermissionCollection();
 
 		existingPermissionCollection.getPermissions().add(existingPermission);
 
@@ -194,7 +198,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		assertEquals(existingPermissionCollection.getPermissions().size(), implToTest.getUserPermissions().get(user).getPermissions().size());
 
 		// mock
-		doReturn(newPermissionCollection).when(permissionCollectionService).saveOrUpdate(any(PermissionCollection.class));
+		mockSaveOrUpdateOfPc(newPermissionCollection);
 
 		// invoke method to test
 		crudService.addAndSaveUserPermissions(implToTest, user, newPermission);
@@ -220,7 +224,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		final Permission newPermission = Permission.WRITE;
 
 		PermissionCollection existingPermissionCollection = new PermissionCollection();
-		PermissionCollection newPermissionCollection = new PermissionCollection();
+		final PermissionCollection newPermissionCollection = new PermissionCollection();
 
 		existingPermissionCollection.getPermissions().add(existingPermission);
 
@@ -240,7 +244,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		assertEquals(existingPermissionCollection.getPermissions().size(), implToTest.getUserPermissions().get(user).getPermissions().size());
 
 		// mock
-		doReturn(newPermissionCollection).when(permissionCollectionService).saveOrUpdate(any(PermissionCollection.class));
+		mockSaveOrUpdateOfPc(newPermissionCollection);
 
 		// invoke method to test
 		crudService.addAndSaveUserPermissions(implToTest, user, newPermission);
@@ -413,7 +417,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 	public void addAndSaveGroupPermissions_shouldCreateNewPermissionCollectionWithOneElement() {
 
 		final Permission adminPermission = Permission.ADMIN;
-		PermissionCollection permissionCollection = new PermissionCollection();
+		final PermissionCollection permissionCollection = new PermissionCollection();
 		permissionCollection.getPermissions().add(adminPermission);
 
 		UserGroup userGroup = new UserGroup();
@@ -423,7 +427,8 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		assertTrue(implToTest.getGroupPermissions().keySet().isEmpty());
 
 		// mock
-		doReturn(permissionCollection).when(permissionCollectionService).saveOrUpdate(any(PermissionCollection.class));
+		mockSaveOrUpdateOfPc(permissionCollection);
+
 		doNothing().when(dao).saveOrUpdate(implToTest);
 
 		// invoke method to test
@@ -450,7 +455,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		final Permission writePermission = Permission.WRITE;
 		final Permission deletePermission = Permission.DELETE;
 
-		PermissionCollection permissionCollection = new PermissionCollection();
+		final PermissionCollection permissionCollection = new PermissionCollection();
 		permissionCollection.getPermissions().add(readPermission);
 		permissionCollection.getPermissions().add(writePermission);
 		permissionCollection.getPermissions().add(deletePermission);
@@ -462,7 +467,8 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		assertTrue(implToTest.getGroupPermissions().keySet().isEmpty());
 
 		// mock
-		doReturn(permissionCollection).when(permissionCollectionService).saveOrUpdate(any(PermissionCollection.class));
+		mockSaveOrUpdateOfPc(permissionCollection);
+
 		doNothing().when(dao).saveOrUpdate(implToTest);
 
 		// invoke method to test
@@ -489,7 +495,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		final Permission newPermission = Permission.READ;
 
 		PermissionCollection existingPermissionCollection = new PermissionCollection();
-		PermissionCollection newPermissionCollection = new PermissionCollection();
+		final PermissionCollection newPermissionCollection = new PermissionCollection();
 
 		existingPermissionCollection.getPermissions().add(existingPermission);
 
@@ -510,7 +516,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		assertEquals(existingPermissionCollection.getPermissions().size(), implToTest.getGroupPermissions().get(userGroup).getPermissions().size());
 
 		// mock
-		doReturn(newPermissionCollection).when(permissionCollectionService).saveOrUpdate(any(PermissionCollection.class));
+		mockSaveOrUpdateOfPc(newPermissionCollection);
 
 		// invoke method to test
 		crudService.addAndSaveGroupPermissions(implToTest, userGroup, newPermission);
@@ -536,7 +542,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		final Permission newPermission = Permission.WRITE;
 
 		PermissionCollection existingPermissionCollection = new PermissionCollection();
-		PermissionCollection newPermissionCollection = new PermissionCollection();
+		final PermissionCollection newPermissionCollection = new PermissionCollection();
 
 		existingPermissionCollection.getPermissions().add(existingPermission);
 
@@ -557,7 +563,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		assertEquals(existingPermissionCollection.getPermissions().size(), implToTest.getGroupPermissions().get(userGroup).getPermissions().size());
 
 		// mock
-		doReturn(newPermissionCollection).when(permissionCollectionService).saveOrUpdate(any(PermissionCollection.class));
+		mockSaveOrUpdateOfPc(newPermissionCollection);
 
 		// invoke method to test
 		crudService.addAndSaveGroupPermissions(implToTest, userGroup, newPermission);
@@ -690,6 +696,26 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		verify(dao, times(0)).saveOrUpdate(implToTest);
 
 		assertEquals(1, implToTest.getGroupPermissions().keySet().size());
+	}
+
+	/**
+	 * @param permissionCollection
+	 */
+	private void mockSaveOrUpdateOfPc(
+			final PermissionCollection permissionCollection) {
+		doAnswer(new Answer<Void>() {
+			public Void answer(InvocationOnMock invocation)
+					throws NoSuchFieldException, SecurityException,
+					IllegalArgumentException, IllegalAccessException,
+					InterruptedException {
+				@SuppressWarnings("unused")
+				PermissionCollection pc = (PermissionCollection) invocation.getArguments()[0];
+
+				pc = permissionCollection;
+
+				return null;
+			}
+		}).when(permissionCollectionService).saveOrUpdate(any(PermissionCollection.class));
 	}
 
 }


### PR DESCRIPTION
* The hibernate `saveOrUpdate` method is void.
* Our DAO `saveOrUpdate` method is void.
* Our service `saveOrUpdate` is **NOT** void, but returns the persisted object, which is not necessary and not consistent with the two methods mentioned above. On top of that it misleads developers to create new objects unnecessarily - even though the existing entity (on which `saveOrUpdate` is called) can easily be used in next steps.

This PR makes the `saveOrUpdate` of the services void.

Existing projects may need simple adaptions like changes

from `PersistentObject newObject = oldObject.saveOrUpdate()`
to `oldObject.saveOrUpdate()`

Please review