### PR TITLE
Enhance permission handling

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,7 +3,11 @@
 ## 0.1.0 (not finally released yet)
 
 * Changes:
+  * `Permission.WRITE` has been renamed to `Permission.UPDATE`
+  * A new permission `Permission.CREATE` has been introduced
+  * The `saveOrUpdate` method of the `AbstractCrudService` now has a more secure permission/authorization annotation. The `CREATE` case is currently not respected in the permission evaluators of SHOGun2 and should be handled in project specific implementations.
   * The `saveOrUpdate` method of the services are now void. Existing projects that are using this method may need some simple adaptions like changes from `PersistentObject newObject = object.saveOrUpdate()` to `object.saveOrUpdate()`
+  * The webapp-archetype has been extended to demonstrate how custom permission evaluators for project specific solutions can be used.
 * New features:
   * An `AbstractSecuredPersistentObjectService` has been introduced. This service provides useful methods to add and remove permissions for certain objects. `PermissionCollection`s will be persisted in the database when using these methods. All services of entities that extend `SecuredPersistentObject` should extend the abstract service mentioned above.
 

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/security/Permission.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/security/Permission.java
@@ -7,6 +7,7 @@ package de.terrestris.shogun2.model.security;
  */
 public enum Permission {
 	ADMIN("ADMIN"),
+	CREATE("CREATE"),
 	DELETE("DELETE"),
 	UPDATE("UPDATE"),
 	READ("READ");

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/security/Permission.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/security/Permission.java
@@ -8,7 +8,7 @@ package de.terrestris.shogun2.model.security;
 public enum Permission {
 	ADMIN("ADMIN"),
 	DELETE("DELETE"),
-	WRITE("WRITE"),
+	UPDATE("UPDATE"),
 	READ("READ");
 
 	private final String permission;

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractCrudService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractCrudService.java
@@ -40,7 +40,9 @@ public abstract class AbstractCrudService<E extends PersistentObject, D extends 
 	 * @param e
 	 * @return
 	 */
-	@PreAuthorize("isAuthenticated()")
+	@PreAuthorize("hasRole(@configHolder.getSuperAdminRoleName())"
+			+ " or (#e.id == null and hasPermission(#e, 'CREATE'))"
+			+ " or (#e.id != null and hasPermission(#e, 'UPDATE'))")
 	public void saveOrUpdate(E e) {
 		dao.saveOrUpdate(e);
 	}

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/security/access/entity/AbstractSecuredObjectPermissionEvaluatorTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/security/access/entity/AbstractSecuredObjectPermissionEvaluatorTest.java
@@ -76,14 +76,14 @@ public abstract class AbstractSecuredObjectPermissionEvaluatorTest<E extends Sec
 		// prepare permission collection/map
 		Map<User, PermissionCollection> userPermissionsMap = new HashMap<User, PermissionCollection>();
 
-		// WRITE as example permission for the user
-		Permission writePermission = Permission.WRITE;
-		PermissionCollection permissionCollection = buildPermissionCollection(writePermission);
+		// UPDATE as example permission for the user
+		Permission updatePermission = Permission.UPDATE;
+		PermissionCollection permissionCollection = buildPermissionCollection(updatePermission);
 		userPermissionsMap.put(user , permissionCollection);
 		entityToCheck.setUserPermissions(userPermissionsMap);
 
 		// call method to test
-		boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(user , entityToCheck, writePermission);
+		boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(user , entityToCheck, updatePermission);
 
 		assertThat(permissionResult, equalTo(true));
 	}
@@ -106,14 +106,14 @@ public abstract class AbstractSecuredObjectPermissionEvaluatorTest<E extends Sec
 		// prepare permission collection/map for the group
 		Map<UserGroup, PermissionCollection> userGroupPermissionsMap = new HashMap<UserGroup, PermissionCollection>();
 
-		// WRITE as example permission for the group
-		Permission writePermission = Permission.WRITE;
-		PermissionCollection permissionCollection = buildPermissionCollection(writePermission);
+		// UPDATE as example permission for the group
+		Permission updatePermission = Permission.UPDATE;
+		PermissionCollection permissionCollection = buildPermissionCollection(updatePermission);
 		userGroupPermissionsMap.put(group , permissionCollection);
 		entityToCheck.setGroupPermissions(userGroupPermissionsMap);
 
 		// call method to test
-		boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(user , entityToCheck, writePermission);
+		boolean permissionResult = persistentObjectPermissionEvaluator.hasPermission(user , entityToCheck, updatePermission);
 
 		assertThat(permissionResult, equalTo(true));
 	}
@@ -195,8 +195,8 @@ public abstract class AbstractSecuredObjectPermissionEvaluatorTest<E extends Sec
 
 	/**
 	 * Helper method to easily build a {@link PermissionCollection}
-	 *
-	 * @param writePermission
+	 * 
+	 * @param permissions
 	 * @return
 	 */
 	private PermissionCollection buildPermissionCollection(

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/AbstractSecuredPersistentObjectServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/AbstractSecuredPersistentObjectServiceTest.java
@@ -136,12 +136,12 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 	public void addAndSaveUserPermissions_shouldCreateNewPermissionCollectionWithMultipleElements() {
 
 		final Permission readPermission = Permission.READ;
-		final Permission writePermission = Permission.WRITE;
+		final Permission updatePermission = Permission.UPDATE;
 		final Permission deletePermission = Permission.DELETE;
 
 		final PermissionCollection permissionCollection = new PermissionCollection();
 		permissionCollection.getPermissions().add(readPermission);
-		permissionCollection.getPermissions().add(writePermission);
+		permissionCollection.getPermissions().add(updatePermission);
 		permissionCollection.getPermissions().add(deletePermission);
 
 		User user = new User("Dummy", "Dummy", "dummy");
@@ -155,7 +155,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		doNothing().when(dao).saveOrUpdate(implToTest);
 
 		// invoke method to test
-		crudService.addAndSaveUserPermissions(implToTest, user, readPermission, writePermission, deletePermission);
+		crudService.addAndSaveUserPermissions(implToTest, user, readPermission, updatePermission, deletePermission);
 
 		// be sure that the permission collection as well as the entity have been saved
 		verify(permissionCollectionService, times(1)).saveOrUpdate(any(PermissionCollection.class));
@@ -221,7 +221,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 	public void addAndSaveUserPermissions_shouldAddPermissionToExistingPermissionCollection() {
 
 		final Permission existingPermission = Permission.READ;
-		final Permission newPermission = Permission.WRITE;
+		final Permission newPermission = Permission.UPDATE;
 
 		PermissionCollection existingPermissionCollection = new PermissionCollection();
 		final PermissionCollection newPermissionCollection = new PermissionCollection();
@@ -301,11 +301,11 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 	@Test
 	public void removeAndSaveUserPermissions_shouldDoNothingWhenNoPermissionsExist() {
 
-		final Permission writePermission = Permission.WRITE;
+		final Permission updatePermission = Permission.UPDATE;
 
 		User user = new User("Dummy", "Dummy", "dummy");
 
-		crudService.removeAndSaveUserPermissions(implToTest, user, writePermission);
+		crudService.removeAndSaveUserPermissions(implToTest, user, updatePermission);
 
 		// be sure that nothing happened
 		verify(permissionCollectionService, times(0)).saveOrUpdate(any(PermissionCollection.class));
@@ -321,7 +321,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 	public void removeAndSaveUserPermissions_onlyPersistsIfNecessary() {
 
 		final Permission readPermission = Permission.READ;
-		final Permission writePermission = Permission.WRITE;
+		final Permission updatePermission = Permission.UPDATE;
 
 		PermissionCollection existingPermissionCollection = new PermissionCollection();
 		existingPermissionCollection.getPermissions().add(readPermission);
@@ -334,7 +334,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		implToTest.setUserPermissions(existingUserPermissionsMap);
 
 		// remove the permission that does not exist in the current collection
-		crudService.removeAndSaveUserPermissions(implToTest, user, writePermission);
+		crudService.removeAndSaveUserPermissions(implToTest, user, updatePermission);
 
 		// be sure that nothing has been updated
 		verify(permissionCollectionService, times(0)).saveOrUpdate(any(PermissionCollection.class));
@@ -350,12 +350,12 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 	public void removeAndSaveUserPermissions_shouldRemoveExistingPermission() {
 
 		final Permission readPermission = Permission.READ;
-		final Permission writePermission = Permission.WRITE;
+		final Permission updatePermission = Permission.UPDATE;
 
 		PermissionCollection existingPermissionCollection = new PermissionCollection();
 
 		existingPermissionCollection.getPermissions().add(readPermission);
-		existingPermissionCollection.getPermissions().add(writePermission);
+		existingPermissionCollection.getPermissions().add(updatePermission);
 
 		User user = new User("Dummy", "Dummy", "dummy");
 
@@ -364,7 +364,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 
 		implToTest.setUserPermissions(existingUserPermissionsMap);
 
-		crudService.removeAndSaveUserPermissions(implToTest, user, writePermission);
+		crudService.removeAndSaveUserPermissions(implToTest, user, updatePermission);
 
 		// be sure that the permission collection has been updated
 		verify(permissionCollectionService, times(1)).saveOrUpdate(any(PermissionCollection.class));
@@ -452,12 +452,12 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 	public void addAndSaveGroupPermissions_shouldCreateNewPermissionCollectionWithMultipleElements() {
 
 		final Permission readPermission = Permission.READ;
-		final Permission writePermission = Permission.WRITE;
+		final Permission updatePermission = Permission.UPDATE;
 		final Permission deletePermission = Permission.DELETE;
 
 		final PermissionCollection permissionCollection = new PermissionCollection();
 		permissionCollection.getPermissions().add(readPermission);
-		permissionCollection.getPermissions().add(writePermission);
+		permissionCollection.getPermissions().add(updatePermission);
 		permissionCollection.getPermissions().add(deletePermission);
 
 		UserGroup userGroup = new UserGroup();
@@ -472,7 +472,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		doNothing().when(dao).saveOrUpdate(implToTest);
 
 		// invoke method to test
-		crudService.addAndSaveGroupPermissions(implToTest, userGroup, readPermission, writePermission, deletePermission);
+		crudService.addAndSaveGroupPermissions(implToTest, userGroup, readPermission, updatePermission, deletePermission);
 
 		// be sure that the permission collection as well as the entity have been saved
 		verify(permissionCollectionService, times(1)).saveOrUpdate(any(PermissionCollection.class));
@@ -539,7 +539,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 	public void addAndSaveGroupPermissions_shouldAddPermissionToExistingPermissionCollection() {
 
 		final Permission existingPermission = Permission.READ;
-		final Permission newPermission = Permission.WRITE;
+		final Permission newPermission = Permission.UPDATE;
 
 		PermissionCollection existingPermissionCollection = new PermissionCollection();
 		final PermissionCollection newPermissionCollection = new PermissionCollection();
@@ -623,12 +623,12 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 	@Test
 	public void removeAndSaveGroupPermissions_shouldDoNothingWhenNoPermissionsExist() {
 
-		final Permission writePermission = Permission.WRITE;
+		final Permission updatePermission = Permission.UPDATE;
 
 		UserGroup userGroup = new UserGroup();
 		userGroup.setName("test");
 
-		crudService.removeAndSaveGroupPermissions(implToTest, userGroup, writePermission);
+		crudService.removeAndSaveGroupPermissions(implToTest, userGroup, updatePermission);
 
 		// be sure that nothing happened
 		verify(permissionCollectionService, times(0)).saveOrUpdate(any(PermissionCollection.class));
@@ -644,7 +644,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 	public void removeAndSaveGroupPermissions_onlyPersistsIfNecessary() {
 
 		final Permission readPermission = Permission.READ;
-		final Permission writePermission = Permission.WRITE;
+		final Permission updatePermission = Permission.UPDATE;
 
 		PermissionCollection existingPermissionCollection = new PermissionCollection();
 		existingPermissionCollection.getPermissions().add(readPermission);
@@ -658,7 +658,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 		implToTest.setGroupPermissions(existingUserPermissionsMap);
 
 		// remove the permission that does not exist in the current collection
-		crudService.removeAndSaveGroupPermissions(implToTest, userGroup, writePermission);
+		crudService.removeAndSaveGroupPermissions(implToTest, userGroup, updatePermission);
 
 		// be sure that nothing has been updated
 		verify(permissionCollectionService, times(0)).saveOrUpdate(any(PermissionCollection.class));
@@ -674,12 +674,12 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 	public void removeAndSaveGroupPermissions_shouldRemoveExistingPermission() {
 
 		final Permission readPermission = Permission.READ;
-		final Permission writePermission = Permission.WRITE;
+		final Permission updatePermission = Permission.UPDATE;
 
 		PermissionCollection existingPermissionCollection = new PermissionCollection();
 
 		existingPermissionCollection.getPermissions().add(readPermission);
-		existingPermissionCollection.getPermissions().add(writePermission);
+		existingPermissionCollection.getPermissions().add(updatePermission);
 
 		UserGroup userGroup = new UserGroup();
 		userGroup.setName("test");
@@ -689,7 +689,7 @@ public abstract class AbstractSecuredPersistentObjectServiceTest<E extends Secur
 
 		implToTest.setGroupPermissions(existingGroupPermissionsMap);
 
-		crudService.removeAndSaveGroupPermissions(implToTest, userGroup, writePermission);
+		crudService.removeAndSaveGroupPermissions(implToTest, userGroup, updatePermission);
 
 		// be sure that the permission collection has been updated
 		verify(permissionCollectionService, times(1)).saveOrUpdate(any(PermissionCollection.class));

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/security/access/entity/ProjectApplicationPermissionEvaluator.java
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/security/access/entity/ProjectApplicationPermissionEvaluator.java
@@ -36,8 +36,7 @@ public class ProjectApplicationPermissionEvaluator<E extends ProjectApplication>
 	}
 
 	/**
-	 * Grants READ permission on the user object of the currently logged in
-	 * user. Uses default implementation otherwise.
+	 * Always grants right to CREATE this entity.
 	 */
 	@Override
 	public boolean hasPermission(User user, E entity, Permission permission) {

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/security/access/entity/ProjectApplicationPermissionEvaluator.java
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/security/access/entity/ProjectApplicationPermissionEvaluator.java
@@ -1,0 +1,56 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package}.security.access.entity;
+
+import ${package}.model.ProjectApplication;
+import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.security.Permission;
+import de.terrestris.shogun2.security.access.entity.PersistentObjectPermissionEvaluator;
+
+/**
+ * Demonstrates the implementation of a custom permission evaluator for
+ * {@link ProjectApplication}.
+ * 
+ * @author Nils Bühner
+ *
+ */
+public class ProjectApplicationPermissionEvaluator<E extends ProjectApplication> extends
+		PersistentObjectPermissionEvaluator<E> {
+
+	/**
+	 * Default constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public ProjectApplicationPermissionEvaluator() {
+		this((Class<E>) ProjectApplication.class);
+	}
+
+	/**
+	 * Constructor for subclasses
+	 *
+	 * @param entityClass
+	 */
+	protected ProjectApplicationPermissionEvaluator(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * Grants READ permission on the user object of the currently logged in
+	 * user. Uses default implementation otherwise.
+	 */
+	@Override
+	public boolean hasPermission(User user, E entity, Permission permission) {
+
+		// always grant CREATE right for this entity
+		// This is just a demo!
+		if (permission.equals(Permission.CREATE)) {
+			LOG.trace("Granting CREATE for project application.");
+			return true;
+		}
+
+		// call parent implementation from SHOGun2
+		return super.hasPermission(user, entity, permission);
+	}
+
+}

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/security/access/factory/ProjectEntityPermissionEvaluatorFactory.java
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/security/access/factory/ProjectEntityPermissionEvaluatorFactory.java
@@ -1,0 +1,40 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package}.security.access.factory;
+
+import ${package}.model.ProjectApplication;
+import ${package}.security.access.entity.ProjectApplicationPermissionEvaluator;
+import de.terrestris.shogun2.model.PersistentObject;
+import de.terrestris.shogun2.security.access.entity.PersistentObjectPermissionEvaluator;
+import de.terrestris.shogun2.security.access.factory.EntityPermissionEvaluatorFactory;
+
+
+/**
+ * This is just a demo to show how the {@link EntityPermissionEvaluatorFactory}
+ * from SHOGun2 can be extended to make use of it in a project specific
+ * implementation.
+ * 
+ * This class has to be configured to be used for the permissionEvaluator (of
+ * SHOGun2) in the security XML of this project.
+ * 
+ * @author Nils Bühner
+ *
+ */
+public class ProjectEntityPermissionEvaluatorFactory<E extends PersistentObject> extends EntityPermissionEvaluatorFactory<E> {
+
+	@Override
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public PersistentObjectPermissionEvaluator<E> getEntityPermissionEvaluator(
+			final Class<E> entityClass) {
+
+		if(ProjectApplication.class.isAssignableFrom(entityClass)) {
+			return new ProjectApplicationPermissionEvaluator();
+		}
+
+		// call SHOGun2 implementation otherwise
+		return super.getEntityPermissionEvaluator(entityClass);
+
+	}
+
+}

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/web/ProjectApplicationController.java
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/web/ProjectApplicationController.java
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import ${package}.model.ProjectApplication;
 import ${package}.dao.ProjectApplicationDao;
@@ -54,5 +56,26 @@ public class ProjectApplicationController<E extends ProjectApplication, D extend
 	@Qualifier("projectApplicationService")
 	public void setService(S service) {
 		super.setService(service);
+	}
+
+	/**
+	 * A demo interface for the creation of a new project application. Can be
+	 * used as a showcase that the project specific permission evaluators for
+	 * the CREATE permission are really working ;-) You should set the LOG level
+	 * to TRACE to see the logs of the permission evaluators (when logged in as
+	 * a NON-admin, e.g. "user").
+	 *
+	 * @param name
+	 * @return
+	 * @throws InstantiationException
+	 * @throws IllegalAccessException
+	 */
+	@RequestMapping(value = "create.action", method = RequestMethod.GET)
+	public @ResponseBody E create(String name)
+			throws InstantiationException, IllegalAccessException {
+		E app = getEntityClass().newInstance();
+		app.setName(name);
+		service.saveOrUpdate(app);
+		return app;
 	}
 }

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-security.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context-security.xml
@@ -76,7 +76,8 @@
 
     <beans:bean id="permissionEvaluator" class="de.terrestris.shogun2.security.access.Shogun2PermissionEvaluator">
         <beans:property name="permissionEvaluatorFactory">
-            <beans:bean class="de.terrestris.shogun2.security.access.factory.EntityPermissionEvaluatorFactory" />
+            <!-- This is how project specific permission evaluators can be used/configured -->
+            <beans:bean class="${package}.security.access.factory.ProjectEntityPermissionEvaluatorFactory" />
         </beans:property>
     </beans:bean>
 

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/log4j.properties
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/log4j.properties
@@ -6,7 +6,7 @@ ${symbol_pound} LOGGING PROPERTIES
 ${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}
 
 ${symbol_pound} Some example settings
-log4j.rootLogger=DEBUG, stdout
+log4j.rootLogger=TRACE, stdout
 ${symbol_pound}log4j.rootLogger=DEBUG, stdout
 ${symbol_pound}log4j.rootLogger=WARN, logfile
 ${symbol_pound}log4j.rootLogger=ERROR, logfile


### PR DESCRIPTION
This PR mainly protects the `saveOrUpdate` method of the `AbstractCrudService`, which was previously only secured with `isAuthenticated()`.

In this context, the `Permission` enum has changed:

* a new `CREATE` permission has been introduced
* the existing `WRITE` permission has been renamed to `UPDATE`

On top of that the archetype has been extended to demonstrate how custom permission evaluators can be used for project specific solutions.

Please review.