### PR TITLE
Allow creation and updating of permissions

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/security/access/entity/PermissionCollectionPermissionEvaluator.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/security/access/entity/PermissionCollectionPermissionEvaluator.java
@@ -1,0 +1,42 @@
+package de.terrestris.shogun2.security.access.entity;
+
+import de.terrestris.shogun2.model.User;
+import de.terrestris.shogun2.model.security.Permission;
+import de.terrestris.shogun2.model.security.PermissionCollection;
+
+/**
+ * @author Nils Bühner
+ *
+ */
+public class PermissionCollectionPermissionEvaluator<E extends PermissionCollection> extends
+		PersistentObjectPermissionEvaluator<E> {
+
+	/**
+	 * Default constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public PermissionCollectionPermissionEvaluator() {
+		this((Class<E>) PermissionCollection.class);
+	}
+
+	/**
+	 * Constructor for subclasses
+	 *
+	 * @param entityClass
+	 */
+	protected PermissionCollectionPermissionEvaluator(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * Always grants every permission on permission collections.
+	 */
+	@Override
+	public boolean hasPermission(User user, E permissionCollection, Permission permission) {
+
+		// it is necessary to grant every permission.
+		// otherwise permission collections could not be created or updated.
+		return true;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/security/access/factory/EntityPermissionEvaluatorFactory.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/security/access/factory/EntityPermissionEvaluatorFactory.java
@@ -3,6 +3,8 @@ package de.terrestris.shogun2.security.access.factory;
 import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.model.User;
 import de.terrestris.shogun2.model.UserGroup;
+import de.terrestris.shogun2.model.security.PermissionCollection;
+import de.terrestris.shogun2.security.access.entity.PermissionCollectionPermissionEvaluator;
 import de.terrestris.shogun2.security.access.entity.PersistentObjectPermissionEvaluator;
 import de.terrestris.shogun2.security.access.entity.UserGroupPermissionEvaluator;
 import de.terrestris.shogun2.security.access.entity.UserPermissionEvaluator;
@@ -17,6 +19,10 @@ public class EntityPermissionEvaluatorFactory<E extends PersistentObject> {
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public PersistentObjectPermissionEvaluator<E> getEntityPermissionEvaluator(
 			final Class<E> entityClass) {
+
+		if(PermissionCollection.class.isAssignableFrom(entityClass)) {
+			return new PermissionCollectionPermissionEvaluator();
+		}
 
 		if(User.class.isAssignableFrom(entityClass)) {
 			return new UserPermissionEvaluator();


### PR DESCRIPTION
The `PermissionCollection` type is unsecured, but the `PersistentObjectPermissionEvaluator` only grants `READ` access on unsecured objects by default. (Otherwise one could misuse some REST-interfaces to create unsecured objects, which is not desired).

In case of `PermissionCollection` it is necessary to allow that they can be created and updated. For that reason the new class `PermissionCollectionPermissionEvaluator` has been introduced (where `hasPermission` always returns true).

Whether or not a `PermissionCollection` may be created or updated depends on the entity for which the permission collection is used. For this, i suggest to secure the methods of `AbstractSecuredPersistentObjectService` in a follow up-PR