### PR TITLE
Making the REST update method transactional

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
@@ -157,9 +157,17 @@ public abstract class AbstractRestController<E extends PersistentObject, D exten
 			E entity = service.findById(id);
 
 			if(entity != null){
-				// update "partially". credits go to http://stackoverflow.com/a/15145480
-				entity = objectMapper.readerForUpdating(entity).readValue(jsonObject);
-				service.saveOrUpdate(entity);
+				// we call this transactional method (instead of save or update)
+				// to make sure that the possibly modified entity does not
+				// get persisted / synced unexpectedly by hibernate
+				// (due to FlushMode.AUTO) when another database-related
+				// interaction is triggered in the meantime (which could happen
+				// for example in a permission evaluation).
+				// In other words: Do not get an entity, modify it and save it
+				// in a non-transactional way (e.g. controller method), as
+				// a possible permission evaluation could trigger an unwanted
+				// persist action before the permission was evaluated.
+				entity = service.updatePartialWithJsonNode(jsonObject, entity, objectMapper);
 				return new ResponseEntity<E>(entity, HttpStatus.OK);
 			}
 			return new ResponseEntity<E>(HttpStatus.NOT_FOUND);

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
@@ -167,7 +167,7 @@ public abstract class AbstractRestController<E extends PersistentObject, D exten
 				// in a non-transactional way (e.g. controller method), as
 				// a possible permission evaluation could trigger an unwanted
 				// persist action before the permission was evaluated.
-				entity = service.updatePartialWithJsonNode(jsonObject, entity, objectMapper);
+				entity = service.updatePartialWithJsonNode(entity, jsonObject, objectMapper);
 				return new ResponseEntity<E>(entity, HttpStatus.OK);
 			}
 			return new ResponseEntity<E>(HttpStatus.NOT_FOUND);

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractCrudService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractCrudService.java
@@ -51,8 +51,8 @@ public abstract class AbstractCrudService<E extends PersistentObject, D extends 
 	 * @throws IOException
 	 * @throws JsonProcessingException
 	 */
-	@PreAuthorize("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(#e, 'UPDATE')")
-	public E updatePartialWithJsonNode(JsonNode jsonObject, E entity, ObjectMapper objectMapper) throws IOException, JsonProcessingException {
+	@PreAuthorize("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(#entity, 'UPDATE')")
+	public E updatePartialWithJsonNode(E entity, JsonNode jsonObject, ObjectMapper objectMapper) throws IOException, JsonProcessingException {
 		// update "partially". credits go to http://stackoverflow.com/a/15145480
 		entity = objectMapper.readerForUpdating(entity).readValue(jsonObject);
 		this.saveOrUpdate(entity);

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/rest/AbstractRestControllerTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/rest/AbstractRestControllerTest.java
@@ -3,6 +3,7 @@ package de.terrestris.shogun2.rest;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
@@ -34,6 +35,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.terrestris.shogun2.dao.GenericHibernateDao;
@@ -322,14 +324,11 @@ public class AbstractRestControllerTest {
 
 		when(serviceMock.findById(id)).thenReturn(originalObject);
 
-		doAnswer(new Answer<Void>() {
-			@Override
-			public Void answer(InvocationOnMock invocation) throws Throwable {
-				TestModel entity = (TestModel) invocation.getArguments()[0];
-				entity.setTestValue(updatedValue);
-				return null;
-			}
-		}).when(serviceMock).saveOrUpdate(any(TestModel.class));;
+		when(serviceMock.updatePartialWithJsonNode(
+				any(JsonNode.class),
+				same(originalObject),
+				any(ObjectMapper.class)))
+		.thenReturn(updatedObject);
 
 		// Test PUT method with JSON payload
 		mockMvc.perform(
@@ -342,7 +341,8 @@ public class AbstractRestControllerTest {
 				.andExpect(jsonPath("$.testValue", is(updatedValue)));
 
 		verify(serviceMock, times(1)).findById(id);
-		verify(serviceMock, times(1)).saveOrUpdate(any(TestModel.class));
+		verify(serviceMock, times(1)).updatePartialWithJsonNode(
+				any(JsonNode.class), same(originalObject), any(ObjectMapper.class));
 		verifyNoMoreInteractions(serviceMock);
 	}
 
@@ -396,7 +396,10 @@ public class AbstractRestControllerTest {
 
 		when(serviceMock.findById(id)).thenReturn(originalObject);
 
-		doThrow(new RuntimeException()).when(serviceMock).saveOrUpdate(any(TestModel.class));
+		doThrow(new RuntimeException()).when(serviceMock).updatePartialWithJsonNode(
+				any(JsonNode.class),
+				same(originalObject),
+				any(ObjectMapper.class));
 
 		// Test PUT method with JSON payload
 		mockMvc.perform(
@@ -405,7 +408,10 @@ public class AbstractRestControllerTest {
 				status().isNotFound());
 
 		verify(serviceMock, times(1)).findById(id);
-		verify(serviceMock, times(1)).saveOrUpdate(any(TestModel.class));
+		verify(serviceMock, times(1)).updatePartialWithJsonNode(
+				any(JsonNode.class),
+				same(originalObject),
+				any(ObjectMapper.class));
 		verifyNoMoreInteractions(serviceMock);
 	}
 

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/rest/AbstractRestControllerTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/rest/AbstractRestControllerTest.java
@@ -325,8 +325,8 @@ public class AbstractRestControllerTest {
 		when(serviceMock.findById(id)).thenReturn(originalObject);
 
 		when(serviceMock.updatePartialWithJsonNode(
-				any(JsonNode.class),
 				same(originalObject),
+				any(JsonNode.class),
 				any(ObjectMapper.class)))
 		.thenReturn(updatedObject);
 
@@ -342,7 +342,7 @@ public class AbstractRestControllerTest {
 
 		verify(serviceMock, times(1)).findById(id);
 		verify(serviceMock, times(1)).updatePartialWithJsonNode(
-				any(JsonNode.class), same(originalObject), any(ObjectMapper.class));
+				same(originalObject), any(JsonNode.class), any(ObjectMapper.class));
 		verifyNoMoreInteractions(serviceMock);
 	}
 
@@ -397,8 +397,8 @@ public class AbstractRestControllerTest {
 		when(serviceMock.findById(id)).thenReturn(originalObject);
 
 		doThrow(new RuntimeException()).when(serviceMock).updatePartialWithJsonNode(
-				any(JsonNode.class),
 				same(originalObject),
+				any(JsonNode.class),
 				any(ObjectMapper.class));
 
 		// Test PUT method with JSON payload
@@ -409,8 +409,8 @@ public class AbstractRestControllerTest {
 
 		verify(serviceMock, times(1)).findById(id);
 		verify(serviceMock, times(1)).updatePartialWithJsonNode(
-				any(JsonNode.class),
 				same(originalObject),
+				any(JsonNode.class),
 				any(ObjectMapper.class));
 		verifyNoMoreInteractions(serviceMock);
 	}


### PR DESCRIPTION
See the comment in the diff, which explains what and why we do this.
It makes sure that entities do not get persisted by mistake due to `FlushMode.AUTO` in hibernate.