### PR TITLE
Cleanup inside AbstractPermissionAwareCrudService

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractLayerService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractLayerService.java
@@ -20,12 +20,12 @@ import de.terrestris.shogun2.model.module.Map;
  * point.
  *
  * @author Nils Bühner
- * @see AbstractPermissionAwareCrudService
+ * @see PermissionAwareCrudService
  *
  */
 @Service("abstractLayerService")
 public class AbstractLayerService<E extends AbstractLayer, D extends AbstractLayerDao<E>>
-		extends AbstractPermissionAwareCrudService<E, D> {
+		extends PermissionAwareCrudService<E, D> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractPermissionAwareCrudService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractPermissionAwareCrudService.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
 
 import de.terrestris.shogun2.dao.GenericHibernateDao;
 import de.terrestris.shogun2.dao.PermissionCollectionDao;
@@ -23,7 +24,8 @@ import de.terrestris.shogun2.model.security.PermissionCollection;
  * @see AbstractCrudService
  *
  */
-public abstract class AbstractPermissionAwareCrudService<E extends PersistentObject, D extends GenericHibernateDao<E, Integer>>
+@Service("permissionAwareCrudService")
+public class AbstractPermissionAwareCrudService<E extends PersistentObject, D extends GenericHibernateDao<E, Integer>>
 		extends AbstractCrudService<E, D> {
 
 	/**
@@ -33,12 +35,28 @@ public abstract class AbstractPermissionAwareCrudService<E extends PersistentObj
 	@Qualifier("permissionCollectionService")
 	protected PermissionCollectionService<PermissionCollection, PermissionCollectionDao<PermissionCollection>> permissionCollectionService;
 
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public AbstractPermissionAwareCrudService() {
+		this((Class<E>) PersistentObject.class);
+	}
+
 	/**
 	 * Constructor that sets the concrete entity class for the service.
 	 * Subclasses MUST call this constructor.
 	 */
 	protected AbstractPermissionAwareCrudService(Class<E> entityClass) {
 		super(entityClass);
+	}
+
+	@Override
+	@Autowired
+	@Qualifier("genericDao")
+	public void setDao(D dao) {
+		this.dao = dao;
 	}
 
 	/**
@@ -155,6 +173,18 @@ public abstract class AbstractPermissionAwareCrudService<E extends PersistentObj
 		userPermissions.removeAll(permissionsSet);
 
 		int newNrOfPermissions = userPermissions.size();
+
+		if(newNrOfPermissions == 0) {
+			LOG.debug("The permission collection is empty and will thereby be deleted now.");
+
+			// remove
+			entity.getUserPermissions().remove(user);
+			this.saveOrUpdate(entity);
+
+			permissionCollectionService.delete(userPermissionCollection);
+
+			return;
+		}
 
 		// only persist if we have "really" removed something
 		if(newNrOfPermissions < originalNrOfPermissions) {
@@ -281,6 +311,17 @@ public abstract class AbstractPermissionAwareCrudService<E extends PersistentObj
 		groupPermissions.removeAll(permissionsSet);
 
 		int newNrOfPermissions = groupPermissions.size();
+
+		if(newNrOfPermissions == 0) {
+			// remove
+			entity.getGroupPermissions().remove(userGroup);
+			this.saveOrUpdate(entity);
+
+			LOG.debug("The permission collection is empty and will thereby be deleted now.");
+			permissionCollectionService.delete(groupPermissionCollection);
+
+			return;
+		}
 
 		// only persist if we have "really" removed something
 		if(newNrOfPermissions < originalNrOfPermissions) {

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractTokenService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractTokenService.java
@@ -14,7 +14,7 @@ import de.terrestris.shogun2.model.token.Token;
  *
  */
 public abstract class AbstractTokenService<E extends Token, D extends AbstractTokenDao<E>>
-		extends AbstractPermissionAwareCrudService<E, D> {
+		extends PermissionAwareCrudService<E, D> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/ApplicationService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/ApplicationService.java
@@ -16,7 +16,7 @@ import de.terrestris.shogun2.model.Application;
  */
 @Service("applicationService")
 public class ApplicationService<E extends Application, D extends ApplicationDao<E>>
-		extends AbstractPermissionAwareCrudService<E, D> {
+		extends PermissionAwareCrudService<E, D> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/ExtentService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/ExtentService.java
@@ -17,7 +17,7 @@ import de.terrestris.shogun2.model.module.Module;
  */
 @Service("extentService")
 public class ExtentService<E extends Extent, D extends ExtentDao<E>> extends
-		AbstractPermissionAwareCrudService<E, D> {
+		PermissionAwareCrudService<E, D> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/FileService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/FileService.java
@@ -21,7 +21,7 @@ import de.terrestris.shogun2.model.File;
  */
 @Service("fileService")
 public class FileService<E extends File, D extends FileDao<E>>
-		extends AbstractPermissionAwareCrudService<E, D> {
+		extends PermissionAwareCrudService<E, D> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/InterceptorRuleService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/InterceptorRuleService.java
@@ -20,7 +20,7 @@ import de.terrestris.shogun2.model.interceptor.InterceptorRule;
  */
 @Service("interceptorRuleService")
 public class InterceptorRuleService<E extends InterceptorRule, D extends InterceptorRuleDao<E>>
-		extends AbstractPermissionAwareCrudService<E, D> {
+		extends PermissionAwareCrudService<E, D> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/LayerAppearanceService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/LayerAppearanceService.java
@@ -17,7 +17,7 @@ import de.terrestris.shogun2.model.module.Module;
  */
 @Service("layerAppearanceService")
 public class LayerAppearanceService<E extends LayerAppearance, D extends LayerAppearanceDao<E>> extends
-		AbstractPermissionAwareCrudService<E, D> {
+		PermissionAwareCrudService<E, D> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/LayerDataSourceService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/LayerDataSourceService.java
@@ -17,7 +17,7 @@ import de.terrestris.shogun2.model.module.Module;
  */
 @Service("layerDataSourceService")
 public class LayerDataSourceService<E extends LayerDataSource, D extends LayerDataSourceDao<E>> extends
-		AbstractPermissionAwareCrudService<E, D> {
+		PermissionAwareCrudService<E, D> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/LayoutService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/LayoutService.java
@@ -16,7 +16,7 @@ import de.terrestris.shogun2.model.layout.Layout;
  */
 @Service("layoutService")
 public class LayoutService<E extends Layout, D extends LayoutDao<E>> extends
-		AbstractPermissionAwareCrudService<E, D> {
+		PermissionAwareCrudService<E, D> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/MapConfigService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/MapConfigService.java
@@ -17,7 +17,7 @@ import de.terrestris.shogun2.model.module.Module;
  */
 @Service("mapConfigService")
 public class MapConfigService<E extends MapConfig, D extends MapConfigDao<E>> extends
-		AbstractPermissionAwareCrudService<E, D> {
+		PermissionAwareCrudService<E, D> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/MapControlService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/MapControlService.java
@@ -17,7 +17,7 @@ import de.terrestris.shogun2.model.module.Module;
  */
 @Service("mapControlService")
 public class MapControlService<E extends MapControl, D extends MapControlDao<E>> extends
-		AbstractPermissionAwareCrudService<E, D> {
+		PermissionAwareCrudService<E, D> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/ModuleService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/ModuleService.java
@@ -16,7 +16,7 @@ import de.terrestris.shogun2.model.module.Module;
  */
 @Service("moduleService")
 public class ModuleService<E extends Module, D extends ModuleDao<E>> extends
-		AbstractPermissionAwareCrudService<E, D> {
+		PermissionAwareCrudService<E, D> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/PermissionAwareCrudService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/PermissionAwareCrudService.java
@@ -25,7 +25,7 @@ import de.terrestris.shogun2.model.security.PermissionCollection;
  *
  */
 @Service("permissionAwareCrudService")
-public class AbstractPermissionAwareCrudService<E extends PersistentObject, D extends GenericHibernateDao<E, Integer>>
+public class PermissionAwareCrudService<E extends PersistentObject, D extends GenericHibernateDao<E, Integer>>
 		extends AbstractCrudService<E, D> {
 
 	/**
@@ -40,7 +40,7 @@ public class AbstractPermissionAwareCrudService<E extends PersistentObject, D ex
 	 * Default constructor, which calls the type-constructor
 	 */
 	@SuppressWarnings("unchecked")
-	public AbstractPermissionAwareCrudService() {
+	public PermissionAwareCrudService() {
 		this((Class<E>) PersistentObject.class);
 	}
 
@@ -48,7 +48,7 @@ public class AbstractPermissionAwareCrudService<E extends PersistentObject, D ex
 	 * Constructor that sets the concrete entity class for the service.
 	 * Subclasses MUST call this constructor.
 	 */
-	protected AbstractPermissionAwareCrudService(Class<E> entityClass) {
+	protected PermissionAwareCrudService(Class<E> entityClass) {
 		super(entityClass);
 	}
 

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/PersonService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/PersonService.java
@@ -16,7 +16,7 @@ import de.terrestris.shogun2.model.Person;
  */
 @Service("personService")
 public class PersonService<E extends Person, D extends PersonDao<E>> extends
-		AbstractPermissionAwareCrudService<E, D> {
+		PermissionAwareCrudService<E, D> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/RoleService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/RoleService.java
@@ -17,7 +17,7 @@ import de.terrestris.shogun2.model.Role;
  */
 @Service("roleService")
 public class RoleService<E extends Role, D extends RoleDao<E>> extends
-		AbstractPermissionAwareCrudService<E, D> {
+		PermissionAwareCrudService<E, D> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/TileGridService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/TileGridService.java
@@ -17,7 +17,7 @@ import de.terrestris.shogun2.model.module.Module;
  */
 @Service("tileGridService")
 public class TileGridService<E extends TileGrid, D extends TileGridDao<E>> extends
-		AbstractPermissionAwareCrudService<E, D> {
+		PermissionAwareCrudService<E, D> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/UserGroupService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/UserGroupService.java
@@ -22,7 +22,7 @@ import de.terrestris.shogun2.model.UserGroup;
  */
 @Service("userGroupService")
 public class UserGroupService<E extends UserGroup, D extends UserGroupDao<E>>
-		extends AbstractPermissionAwareCrudService<E, D> {
+		extends PermissionAwareCrudService<E, D> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/AbstractUserTokenServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/AbstractUserTokenServiceTest.java
@@ -28,7 +28,7 @@ import de.terrestris.shogun2.model.token.UserToken;
  *
  */
 public abstract class AbstractUserTokenServiceTest<E extends UserToken, D extends AbstractUserTokenDao<E>, S extends AbstractUserTokenService<E, D>>
-		extends AbstractPermissionAwareCrudServiceTest<E, D, S> {
+		extends PermissionAwareCrudServiceTest<E, D, S> {
 
 	/**
 	 * Has to be implemented by subclasses and should return an expired token.

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/ApplicationServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/ApplicationServiceTest.java
@@ -4,7 +4,7 @@ import de.terrestris.shogun2.dao.ApplicationDao;
 import de.terrestris.shogun2.model.Application;
 
 public class ApplicationServiceTest extends
-		AbstractPermissionAwareCrudServiceTest<Application, ApplicationDao<Application>, ApplicationService<Application, ApplicationDao<Application>>> {
+		PermissionAwareCrudServiceTest<Application, ApplicationDao<Application>, ApplicationService<Application, ApplicationDao<Application>>> {
 
 	/**
 	 *

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/FileServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/FileServiceTest.java
@@ -13,7 +13,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import de.terrestris.shogun2.dao.FileDao;
 import de.terrestris.shogun2.model.File;
 
-public class FileServiceTest extends AbstractPermissionAwareCrudServiceTest<File, FileDao<File>, FileService<File, FileDao<File>>> {
+public class FileServiceTest extends PermissionAwareCrudServiceTest<File, FileDao<File>, FileService<File, FileDao<File>>> {
 
 	/**
 	 *

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/ImageFileServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/ImageFileServiceTest.java
@@ -22,7 +22,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import de.terrestris.shogun2.dao.ImageFileDao;
 import de.terrestris.shogun2.model.ImageFile;
 
-public class ImageFileServiceTest extends AbstractPermissionAwareCrudServiceTest<ImageFile, ImageFileDao<ImageFile>, ImageFileService<ImageFile, ImageFileDao<ImageFile>>> {
+public class ImageFileServiceTest extends PermissionAwareCrudServiceTest<ImageFile, ImageFileDao<ImageFile>, ImageFileService<ImageFile, ImageFileDao<ImageFile>>> {
 
 	/**
 	 *

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/PermissionAwareCrudServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/PermissionAwareCrudServiceTest.java
@@ -27,12 +27,12 @@ import de.terrestris.shogun2.model.security.PermissionCollection;
 
 /**
  * Abstract (parent) test for the
- * {@link AbstractPermissionAwareCrudServiceTest}.
+ * {@link PermissionAwareCrudServiceTest}.
  *
  * @author Nils Bühner
  *
  */
-public abstract class AbstractPermissionAwareCrudServiceTest<E extends PersistentObject, D extends GenericHibernateDao<E, Integer>, S extends AbstractPermissionAwareCrudService<E, D>>
+public abstract class PermissionAwareCrudServiceTest<E extends PersistentObject, D extends GenericHibernateDao<E, Integer>, S extends PermissionAwareCrudService<E, D>>
 	extends AbstractCrudServiceTest<E, D, S> {
 
 	/**

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/PersonServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/PersonServiceTest.java
@@ -4,7 +4,7 @@ import de.terrestris.shogun2.dao.PersonDao;
 import de.terrestris.shogun2.model.Person;
 
 public class PersonServiceTest extends
-		AbstractPermissionAwareCrudServiceTest<Person, PersonDao<Person>, PersonService<Person, PersonDao<Person>>> {
+		PermissionAwareCrudServiceTest<Person, PersonDao<Person>, PersonService<Person, PersonDao<Person>>> {
 
 	/**
 	 *

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/RoleServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/RoleServiceTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 import de.terrestris.shogun2.dao.RoleDao;
 import de.terrestris.shogun2.model.Role;
 
-public class RoleServiceTest extends AbstractPermissionAwareCrudServiceTest<Role, RoleDao<Role>, RoleService<Role, RoleDao<Role>>> {
+public class RoleServiceTest extends PermissionAwareCrudServiceTest<Role, RoleDao<Role>, RoleService<Role, RoleDao<Role>>> {
 
 	/**
 	 *

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/UserGroupServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/UserGroupServiceTest.java
@@ -4,7 +4,7 @@ import de.terrestris.shogun2.dao.UserGroupDao;
 import de.terrestris.shogun2.model.UserGroup;
 
 public class UserGroupServiceTest extends
-		AbstractPermissionAwareCrudServiceTest<UserGroup, UserGroupDao<UserGroup>, UserGroupService<UserGroup, UserGroupDao<UserGroup>>> {
+		PermissionAwareCrudServiceTest<UserGroup, UserGroupDao<UserGroup>, UserGroupService<UserGroup, UserGroupDao<UserGroup>>> {
 
 	/**
 	 *

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/UserServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/UserServiceTest.java
@@ -38,7 +38,7 @@ import de.terrestris.shogun2.model.token.RegistrationToken;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath*:META-INF/spring/test-encoder-bean.xml" })
-public class UserServiceTest extends AbstractPermissionAwareCrudServiceTest<User, UserDao<User>, UserService<User, UserDao<User>>> {
+public class UserServiceTest extends PermissionAwareCrudServiceTest<User, UserDao<User>, UserService<User, UserDao<User>>> {
 
 	@Mock
 	private RegistrationTokenService<RegistrationToken, RegistrationTokenDao<RegistrationToken>> registrationTokenService;


### PR DESCRIPTION
We now delete empty permission collections.
Besides, the abstract definition has been removed from the class.
@buehner : Should the classname change?