### PR TITLE
Adapt the permission evaluation to be less restrictive

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/security/access/Shogun2PermissionEvaluator.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/security/access/Shogun2PermissionEvaluator.java
@@ -58,23 +58,25 @@ public class Shogun2PermissionEvaluator implements PermissionEvaluator {
 		boolean hasPermission = false;
 
 		if (authentication != null
-				&& authentication.getPrincipal() instanceof User
 				&& targetDomainObject != null
 				&& targetDomainObject instanceof PersistentObject
 				&& permissionObject instanceof String) {
 
-			// get the user state when the user logged in
-			User user = (User) authentication.getPrincipal();
+			User user = null;
 
-			// get the "full" user from the database
-			user = userDao.findById(user.getId());
+			if(authentication.getPrincipal() instanceof User) {
+				// get the "full" user from the database
+				user = userDao.findById(((User) authentication.getPrincipal()).getId());
+			}
 
 			final PersistentObject persistentObject = (PersistentObject) targetDomainObject;
 			final Integer objectId = persistentObject.getId();
 			final String simpleClassName = targetDomainObject.getClass().getSimpleName();
 			final Permission permission = Permission.fromString((String) permissionObject);
 
-			LOG.trace("Evaluating whether user '" + user.getAccountName()
+			String accountName = (user == null) ? "ANONYMOUS" : user.getAccountName();
+
+			LOG.trace("Evaluating whether user '" + accountName
 					+ "' has permission '" + permission + "' on '"
 					+ simpleClassName + "' with ID " + objectId);
 

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/UserService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/UserService.java
@@ -233,9 +233,15 @@ public class UserService<E extends User, D extends UserDao<E>> extends
 	 */
 	public E getUserBySession() {
 
-		@SuppressWarnings("unchecked")
-		E loggedInUser = (E) SecurityContextHolder.getContext()
+		final Object principal = SecurityContextHolder.getContext()
 				.getAuthentication().getPrincipal();
+
+		if(!(principal instanceof User)) {
+			return null;
+		}
+
+		@SuppressWarnings("unchecked")
+		E loggedInUser = (E) principal;
 
 		// The SecurityContextHolder holds a static copy of the user from
 		// the moment he logged in. So we need to get the current instance from

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/security/access/Shogun2PermissionEvaluatorTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/security/access/Shogun2PermissionEvaluatorTest.java
@@ -65,14 +65,21 @@ public class Shogun2PermissionEvaluatorTest {
 	/**
 	 *
 	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void hasPermission_ShouldRestrictAccessIfPrinicipalIsNotAUser() {
 		// mock auth object
 		Authentication authentication = mock(Authentication.class);
 		when(authentication.getPrincipal()).thenReturn("Not a User object");
 
-		Object targetDomainObject = new Application("Test", "Test");
-		Object permissionObject = "READ";
+		PersistentObject targetDomainObject = new Application("Test", "Test");
+		String permissionObject = "READ";
+
+		PersistentObjectPermissionEvaluator persistentObjectEvaluatorMock = mock(PersistentObjectPermissionEvaluator.class);
+		when(persistentObjectEvaluatorMock.hasPermission(null, targetDomainObject, Permission.fromString(permissionObject))).thenReturn(false);
+
+		// mock factory (with previously mocked evaluator)
+		when(permissionEvaluatorFactoryMock.getEntityPermissionEvaluator(targetDomainObject.getClass())).thenReturn(persistentObjectEvaluatorMock);
 
 		// execute method that is tested here
 		boolean permissionResult = permissionEvaluator.hasPermission(authentication, targetDomainObject, permissionObject);
@@ -101,7 +108,7 @@ public class Shogun2PermissionEvaluatorTest {
 
 		// verify
 		assertFalse(permissionResult);
-		verify(authentication, times(1)).getPrincipal();
+		verify(authentication, times(0)).getPrincipal();
 		verifyNoMoreInteractions(authentication);
 	}
 
@@ -123,7 +130,7 @@ public class Shogun2PermissionEvaluatorTest {
 
 		// verify
 		assertFalse(permissionResult);
-		verify(authentication, times(1)).getPrincipal();
+		verify(authentication, times(0)).getPrincipal();
 		verifyNoMoreInteractions(authentication);
 	}
 
@@ -145,7 +152,7 @@ public class Shogun2PermissionEvaluatorTest {
 
 		// verify
 		assertFalse(permissionResult);
-		verify(authentication, times(1)).getPrincipal();
+		verify(authentication, times(0)).getPrincipal();
 		verifyNoMoreInteractions(authentication);
 	}
 


### PR DESCRIPTION
This PR adapts the permission evaluation to be less restrictive. This is necessary in scenarios where NO user is logged in (ROLE_ANONYMOUS), but we still want the permission evaluators to run.