### PR TITLE
Introduce a territory class

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -184,6 +184,12 @@
         <!-- Powermock -->
         <powermock.version>1.6.4</powermock.version>
 
+        <!-- Java Topology Suite -->
+        <jts.version>1.14.0</jts.version>
+
+        <!-- JTS Jackson Datatype -->
+        <jackson-datatype-jts.version>2.3</jackson-datatype-jts.version>
+
         <downloadSources>true</downloadSources>
         <downloadJavadocs>true</downloadJavadocs>
     </properties>
@@ -613,6 +619,12 @@
                 <version>${jackson.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>com.bedatadriven</groupId>
+                <artifactId>jackson-datatype-jts</artifactId>
+                <version>${jackson-datatype-jts.version}</version>
+            </dependency>
+
             <!-- ehcache -->
             <dependency>
                 <groupId>net.sf.ehcache</groupId>
@@ -741,6 +753,12 @@
                 <groupId>org.imgscalr</groupId>
                 <artifactId>imgscalr-lib</artifactId>
                 <version>${imgscalr.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.vividsolutions</groupId>
+                <artifactId>jts-core</artifactId>
+                <version>${jts.version}</version>
             </dependency>
 
         </dependencies>

--- a/src/shogun2-core/pom.xml
+++ b/src/shogun2-core/pom.xml
@@ -187,6 +187,10 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.bedatadriven</groupId>
+            <artifactId>jackson-datatype-jts</artifactId>
+        </dependency>
 
         <!-- Mailing -->
         <dependency>
@@ -233,6 +237,11 @@
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-servlet-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.vividsolutions</groupId>
+            <artifactId>jts-core</artifactId>
+    	</dependency>
 
     </dependencies>
 

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/TerritoryDao.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/TerritoryDao.java
@@ -1,0 +1,28 @@
+package de.terrestris.shogun2.dao;
+
+import org.springframework.stereotype.Repository;
+
+import de.terrestris.shogun2.model.Territory;
+
+@Repository("territoryDao")
+public class TerritoryDao<E extends Territory> extends
+		GenericHibernateDao<E, Integer> {
+
+	/**
+	 * Public default constructor for this DAO.
+	 */
+	@SuppressWarnings("unchecked")
+	public TerritoryDao() {
+		super((Class<E>) Territory.class);
+	}
+
+	/**
+	 * Constructor that has to be called by subclasses.
+	 *
+	 * @param clazz
+	 */
+	protected TerritoryDao(Class<E> clazz) {
+		super(clazz);
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Territory.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Territory.java
@@ -1,0 +1,140 @@
+package de.terrestris.shogun2.model;
+
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import com.vividsolutions.jts.geom.MultiPolygon;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+import de.terrestris.shogun2.model.PersistentObject;
+
+/**
+ *
+ * @author Nils Bühner
+ * @author Kai Volland
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+@Entity
+@Table
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+public class Territory extends PersistentObject {
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 *
+	 */
+	private String name;
+
+	/**
+	 *
+	 */
+	@Column(length = Integer.MAX_VALUE)
+	private MultiPolygon geometry;
+
+	/**
+	 * default constructor
+	 */
+	public Territory(){
+		super();
+	}
+
+	/**
+	 * @param name
+	 * @param type
+	 * @param url
+	 */
+	public Territory(String name, MultiPolygon geometry) {
+		super();
+		this.name = name;
+		this.geometry = geometry;
+	}
+
+	/**
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @param name the name to set
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public MultiPolygon getGeometry() {
+		return geometry;
+	}
+
+	/**
+	 *
+	 * @param geometry
+	 */
+	public void setGeometry(MultiPolygon geometry) {
+		this.geometry = geometry;
+	}
+
+	/**
+	 * @see java.lang.Object#hashCode()
+	 *
+	 *      According to
+	 *      http://stackoverflow.com/questions/27581/overriding-equals
+	 *      -and-hashcode-in-java it is recommended only to use getter-methods
+	 *      when using ORM like Hibernate
+	 */
+	public int hashCode() {
+		// two randomly chosen prime numbers
+		return new HashCodeBuilder(13, 37).
+				appendSuper(super.hashCode()).
+				append(getName()).
+				append(getGeometry()).
+				toHashCode();
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 *
+	 *      According to
+	 *      http://stackoverflow.com/questions/27581/overriding-equals
+	 *      -and-hashcode-in-java it is recommended only to use getter-methods
+	 *      when using ORM like Hibernate
+	 */
+	public boolean equals(Object obj) {
+		if (!(obj instanceof Territory))
+			return false;
+		Territory other = (Territory) obj;
+
+		return new EqualsBuilder().
+				appendSuper(super.equals(other)).
+				append(getName(), other.getName()).
+				append(getGeometry(), other.getGeometry()).
+				isEquals();
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/security/PermissionCollection.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/security/PermissionCollection.java
@@ -7,6 +7,8 @@ import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
 import javax.persistence.Table;
 
 import de.terrestris.shogun2.model.PersistentObject;
@@ -17,6 +19,7 @@ import de.terrestris.shogun2.model.PersistentObject;
  */
 @Entity
 @Table
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
 public class PermissionCollection extends PersistentObject {
 
 	private static final long serialVersionUID = 1L;

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/json/Shogun2JsonObjectMapper.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/json/Shogun2JsonObjectMapper.java
@@ -2,6 +2,7 @@ package de.terrestris.shogun2.util.json;
 
 import java.util.TimeZone;
 
+import com.bedatadriven.jackson.datatype.jts.JtsModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
@@ -9,18 +10,18 @@ import com.fasterxml.jackson.datatype.joda.JodaModule;
 
 /**
  * Customized JSON/Jackson ObjectMapper attending the needs of SHOGun2.
- * 
+ *
  * This class will load the JodaModule for Jackson to support joda time types
  * and sets the date format to ISO8601, i.e. dates will be serialized in
  * ISO8601.
- * 
+ *
  * @author Nils Bühner
- * 
+ *
  */
 public class Shogun2JsonObjectMapper extends ObjectMapper {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 1L;
 
@@ -33,6 +34,9 @@ public class Shogun2JsonObjectMapper extends ObjectMapper {
 		// register the joda module to support the joda time types, which are
 		// used in shogun
 		this.registerModule(new JodaModule());
+
+		// register JTS geometry types
+		this.registerModule(new JtsModule());
 
 		// serialize dates in ISO8601 with time zone of the host
 		configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/json/Shogun2JsonObjectMapperTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/json/Shogun2JsonObjectMapperTest.java
@@ -11,6 +11,7 @@ import java.util.TimeZone;
 
 import org.junit.Test;
 
+import com.bedatadriven.jackson.datatype.jts.JtsModule;
 import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,8 +39,9 @@ public class Shogun2JsonObjectMapperTest {
 
 		List<Module> modules = Shogun2JsonObjectMapper.findModules();
 
-		assertEquals(1, modules.size());
+		assertEquals(2, modules.size());
 		assertThat(modules.get(0), instanceOf(JodaModule.class));
+		assertThat(modules.get(1), instanceOf(JtsModule.class));
 	}
 
 	/**


### PR DESCRIPTION
This PR introduces a new model class `Territory` that contains a geometry property of type `MultiPolygon` (JTS). This new class may be very helpful in project solutions, for example if you want to store information about spatial restrictions for a certain user or user group.

Currently, the geometry property will be saved as binary data in the database (Java serialized representation), which is not a very smart, but working solution. For the future, we could think about using Hibernate Spatial to persist the geometry, but this would require that the underlying SHOGun2 database is always a spatial database.

As we are using the Java Topology Suite, this PR also introduces a new dependency on `jackson-datatype-jts`, which provides a `JtsModule` that is now registered in the `Shogun2JsonObjectMapper`. By doing this, JTS-geometries will always be serialized as GeoJSON (and vice versa).