### PR TITLE
Fix interceptor bugs

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
@@ -327,7 +327,7 @@ public class GeoServerInterceptorService {
 
 		for (Entry<String, String[]> param : params.entrySet()) {
 			queryParams.add(new BasicNameValuePair(param.getKey(),
-					StringUtils.join(param.getValue())));
+					StringUtils.join(param.getValue(), ",")));
 		}
 
 		return queryParams;

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequest.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequest.java
@@ -244,7 +244,7 @@ public class MutableHttpServletRequest extends HttpServletRequestWrapper {
 	 */
 	@Override
 	public String getParameter(String key) {
-		if (customParameters.get(key) != null) {
+		if (customParameters.containsKey(key)) {
 			return StringUtils.join(customParameters.get(key), ",");
 		} else {
 			HttpServletRequest request = (HttpServletRequest) super.getRequest();


### PR DESCRIPTION
This is an enhancement for the interceptor:

* There was a bug when a HTTP (GET) request had multiple, comma-separated values in one parameter, e.g. `LAYERS=A,B`, which resulted in `LAYERS=AB`. de3c922 fixes this.
* 6e27bda is a more solid way to check for the existance of a key. the previous version is not save as a map could also contain `null` as a value...

Please review