### PR TITLE
Fixed the password reset workflow

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/PasswordResetTokenService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/PasswordResetTokenService.java
@@ -59,6 +59,12 @@ public class PasswordResetTokenService<E extends PasswordResetToken, D extends P
 	 *
 	 */
 	@Autowired
+	private UserDao<User> userDao;
+
+	/**
+	 *
+	 */
+	@Autowired
 	private MailPublisher mailPublisher;
 
 	/**
@@ -123,7 +129,7 @@ public class PasswordResetTokenService<E extends PasswordResetToken, D extends P
 			URISyntaxException, UnsupportedEncodingException {
 
 		// get the user by the provided email address
-		User user = userService.findByEmail(email);
+		User user = userDao.findByEmail(email);
 
 		if (user == null) {
 			throw new UsernameNotFoundException(

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/UserService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/UserService.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PostFilter;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -215,7 +214,6 @@ public class UserService<E extends User, D extends UserDao<E>> extends
 	 * @param rawPassword
 	 * @throws Exception
 	 */
-	@PreAuthorize("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(#user, 'UPDATE')")
 	public void updatePassword(E user, String rawPassword) throws Exception {
 
 		if(user.getId() == null) {

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/UserController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/UserController.java
@@ -129,7 +129,7 @@ public class UserController<E extends User, D extends UserDao<E>, S extends User
 					+ "Please check your mails!");
 		} catch (Exception e) {
 			LOG.error("Could not request a password reset: " + e.getMessage());
-			return ResultSet.error("An error has occured during passwort reset request.");
+			return ResultSet.error("An error has occurred during password reset request.");
 		}
 	}
 

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/web/UserControllerTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/web/UserControllerTest.java
@@ -183,7 +183,7 @@ public class UserControllerTest {
 			.andExpect(content().contentType("application/json;charset=UTF-8"))
 			.andExpect(jsonPath("$.*", hasSize(2)))
 			.andExpect(jsonPath("$.success", is(false)))
-			.andExpect(jsonPath("$.message", is("An error has occured during passwort reset request.")));
+			.andExpect(jsonPath("$.message", is("An error has occurred during password reset request.")));
 
 		verify(tokenService, times(1)).sendResetPasswordMail(any(HttpServletRequest.class), eq(email));
 		verifyNoMoreInteractions(tokenService);


### PR DESCRIPTION
This PR fixes the currently broken password reset workflow.

1.) The `PasswordResetTokenService` now uses the `userDao` in method `sendResetPasswordMail` as the user who triggers this request cannot login because of his lost password and therefore has no authentication, which would be needed when using the service methods.

2.) The `@PreAuthorize` annotation in method `updatePassword` of `UserService` has been removed completely, as this method is also triggered by a non-logged-in user with no authentication.

Finally, minor typos have been fixed.

I am open to discussion if this is the way to go, but some projects are currenlty broken by the current state