### PR TITLE
Removed transfer-encoding:chunked header in httputil

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
@@ -776,7 +776,14 @@ public class HttpUtil {
 			response.setStatusCode(httpStatus);
 
 			for (Header header : headers) {
-				headersMap.set(header.getName(), header.getValue());
+
+				if (header.getName().equalsIgnoreCase("Transfer-Encoding") &&
+					header.getValue().equalsIgnoreCase("chunked")) {
+					LOG.debug("Removed the header 'Transfer-Encoding:chunked'" +
+							" from a response, as its handled by the http-client");
+				} else {
+					headersMap.set(header.getName(), header.getValue());
+				}
 			}
 			response.setHeaders(headersMap);
 


### PR DESCRIPTION
The HttpClient automatically handles the chunked transfer-encoding when requesting resources, and returns non chunked content. But currently we copy all headers from the original response to the final response, which declarates the answer as chunked, which it is not at that moment. So we do not set the header for responses, if present in original response