### PR TITLE
Use applications as templates for new apps

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/ApplicationDao.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/ApplicationDao.java
@@ -36,7 +36,7 @@ public class ApplicationDao<E extends Application> extends
 	 */
 	@Override
 	public List<E> findAll() {
-		LOG.trace("Finding all (non-template) applications of ");
+		LOG.trace("Finding all (non-template) applications.");
 		SimpleExpression areNotTemplate =
 				Restrictions.ne("template", true); // everything but true (i.e. false or null)
 		return findByCriteria(areNotTemplate);
@@ -48,7 +48,7 @@ public class ApplicationDao<E extends Application> extends
 	 * @return All applications that are templates.
 	 */
 	public List<E> findAllTemplates() {
-		LOG.trace("Finding all template applications of ");
+		LOG.trace("Finding all template applications.");
 		SimpleExpression areTemplate =
 				Restrictions.eq("template", true);
 		return findByCriteria(areTemplate);

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/ApplicationDao.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/ApplicationDao.java
@@ -1,5 +1,9 @@
 package de.terrestris.shogun2.dao;
 
+import java.util.List;
+
+import org.hibernate.criterion.Restrictions;
+import org.hibernate.criterion.SimpleExpression;
 import org.springframework.stereotype.Repository;
 
 import de.terrestris.shogun2.model.Application;
@@ -18,11 +22,36 @@ public class ApplicationDao<E extends Application> extends
 
 	/**
 	 * Constructor that has to be called by subclasses.
-	 * 
+	 *
 	 * @param clazz
 	 */
 	protected ApplicationDao(Class<E> clazz) {
 		super(clazz);
+	}
+
+	/**
+	 * Returns all applications that are NOT templates!
+	 *
+	 * @return All appliocations that are NOT templates.
+	 */
+	@Override
+	public List<E> findAll() {
+		LOG.trace("Finding all (non-template) applications of ");
+		SimpleExpression areNotTemplate =
+				Restrictions.ne("template", true); // everything but true (i.e. false or null)
+		return findByCriteria(areNotTemplate);
+	}
+
+	/**
+	 * Returns all applications that are templates!
+	 *
+	 * @return All applications that are templates.
+	 */
+	public List<E> findAllTemplates() {
+		LOG.trace("Finding all template applications of ");
+		SimpleExpression areTemplate =
+				Restrictions.eq("template", true);
+		return findByCriteria(areTemplate);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/GenericHibernateDao.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/GenericHibernateDao.java
@@ -147,6 +147,17 @@ public class GenericHibernateDao<E extends PersistentObject, ID extends Serializ
 	}
 
 	/**
+	 * Evicts/detaches the entity from the hibernate session cache.
+	 *
+	 * @param e The entity to evict/detach
+	 */
+	public void evict(E e) {
+		LOG.trace("Removing/detaching " + entityClass.getSimpleName() + " with ID " + e.getId()
+				+ " from the hibernate session cache.");
+		getSession().evict(e);
+	}
+
+	/**
 	 * Gets the results, that match a variable number of passed criterions. Call
 	 * this method without arguments to find all entities.
 	 *

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Application.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Application.java
@@ -66,6 +66,17 @@ public class Application extends PersistentObject {
 	private Boolean active = true;
 
 	/**
+	 * Whether this application serves as a template for new applications or
+	 * not. A template application will not be returned when querying for all
+	 * applications via REST.
+	 *
+	 * An application is only considered to be a template if this value is true,
+	 * i.e. if this value is null, the app should not be treated as a template.
+	 */
+	@Column
+	private Boolean template = false;
+
+	/**
 	 * The URL under which the application is accessible.
 	 */
 	@Column
@@ -149,6 +160,14 @@ public class Application extends PersistentObject {
 		this.active = active;
 	}
 
+	public Boolean getTemplate() {
+		return template;
+	}
+
+	public void setTemplate(Boolean template) {
+		this.template = template;
+	}
+
 	public String getUrl() {
 		return url;
 	}
@@ -188,6 +207,7 @@ public class Application extends PersistentObject {
 				append(getLanguage()).
 				append(getOpen()).
 				append(getActive()).
+				append(getTemplate()).
 				append(getUrl()).
 				append(getViewport()).
 				toHashCode();
@@ -212,6 +232,7 @@ public class Application extends PersistentObject {
 				append(getLanguage(), other.getLanguage()).
 				append(getOpen(), other.getOpen()).
 				append(getActive(), other.getActive()).
+				append(getTemplate(), other.getTemplate()).
 				append(getUrl(), other.getUrl()).
 				append(getViewport(), other.getViewport()).
 				isEquals();

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/ApplicationRestController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/ApplicationRestController.java
@@ -1,8 +1,13 @@
 package de.terrestris.shogun2.rest;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import de.terrestris.shogun2.dao.ApplicationDao;
@@ -45,6 +50,23 @@ public class ApplicationRestController<E extends Application, D extends Applicat
 	@Qualifier("applicationService")
 	public void setService(S service) {
 		this.service = service;
+	}
+
+	/**
+	 * Find all template applications.
+	 *
+	 * @return
+	 */
+	@RequestMapping(value = "/templates", method = RequestMethod.GET)
+	public ResponseEntity<List<E>> findAllTemplates() {
+		final List<E> resultList = this.service.findAllTemplates();
+
+		if (resultList != null && !resultList.isEmpty()) {
+			LOG.trace("Found a total of " + resultList.size()
+					+ " template applications.");
+		}
+
+		return new ResponseEntity<List<E>>(resultList, HttpStatus.OK);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractCrudService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractCrudService.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.terrestris.shogun2.dao.GenericHibernateDao;
+import de.terrestris.shogun2.helper.IdHelper;
 import de.terrestris.shogun2.model.PersistentObject;
 
 /**
@@ -102,4 +103,26 @@ public abstract class AbstractCrudService<E extends PersistentObject, D extends 
 		dao.delete(e);
 	}
 
+	/**
+	 * Clones an entity by detaching it from the hibernate session and resetting the ID to null.
+	 * The clone will be persisted as a new entity if persist is true.
+	 *
+	 * @param e The entity to clone
+	 * @param persist whether or not the clone should be persisted as a new entity
+	 *
+	 * @throws IllegalAccessException
+	 * @throws NoSuchFieldException
+	 */
+	@PreAuthorize("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(#e, 'READ')")
+	public E cloneEntity(E e, boolean persist) throws NoSuchFieldException, IllegalAccessException {
+		dao.evict(e);
+
+		IdHelper.setIdOnPersistentObject(e, null);
+
+		if(persist) {
+			dao.saveOrUpdate(e);
+		}
+
+		return e;
+	}
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/ApplicationService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/ApplicationService.java
@@ -1,7 +1,10 @@
 package de.terrestris.shogun2.service;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.stereotype.Service;
 
 import de.terrestris.shogun2.dao.ApplicationDao;
@@ -44,5 +47,15 @@ public class ApplicationService<E extends Application, D extends ApplicationDao<
 	@Qualifier("applicationDao")
 	public void setDao(D dao) {
 		this.dao = dao;
+	}
+
+	/**
+	 * Returns all template applications
+	 *
+	 * @return
+	 */
+	@PostFilter("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(filterObject, 'READ')")
+	public List<E> findAllTemplates() {
+		return dao.findAllTemplates();
 	}
 }


### PR DESCRIPTION
This PR introduces a new property `template` (Boolean) for the Application model. Instances with `template=true` will not be treated as regular applications, e.g. they will not appear if all applications are requested via `rest/applications`.
(Instead, the templates could be queried via `rest/applications/templates` or by their ID `rest/applications/{id}`).

The target of this new "concept" is a simplification of the creation of new applications, e.g.  one now could do the following to create a new app:

1. Query an existing (preconfigured) template (!) application from DB (e.g. there may be different templates for different layouts)
1. Detach/evict the queried instance from the Hibernate Session (by calling the new `evict` method that is also introduced in this PR)
1. Set the ID of the detached object to `null`.
1. Set (or overwrite) all relevant information on the application (like name, modules, map, layers, etc.)
1. Persist the object as usual to create a new one.

Until now, the creation of new webapps was a bit cumbersome because a lot of other entities that are related to an application in its complex hierarchy (like the viewport or other (sub-)modules) had to be handled (i.e. fetched/created and/or persisted) separateley with custom logic before the new application could be persisted. When you did not code that carefully, hibernate quickly complained with exceptions like `org.hibernate.PersistentObjectException: detached entity passed to persist`