### PR TITLE
Send error message to client when PW reset failed

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/UserController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/UserController.java
@@ -128,8 +128,9 @@ public class UserController<E extends User, D extends UserDao<E>, S extends User
 			return ResultSet.success("Password reset has been requested. "
 					+ "Please check your mails!");
 		} catch (Exception e) {
-			LOG.error("Could not request a password reset: " + e.getMessage());
-			return ResultSet.error("An error has occurred during password reset request.");
+			final String message = e.getMessage();
+			LOG.error("Could not request a password reset: " + message);
+			return ResultSet.error(message);
 		}
 	}
 

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/web/UserControllerTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/web/UserControllerTest.java
@@ -170,7 +170,8 @@ public class UserControllerTest {
 		String email = "test@example.com";
 
 		// mock service
-		doThrow(new RuntimeException("errormsg"))
+		final String exceptionMsg = "errormsg";
+		doThrow(new RuntimeException(exceptionMsg))
 			.when(tokenService)
 				.sendResetPasswordMail(
 					any(HttpServletRequest.class),
@@ -183,7 +184,7 @@ public class UserControllerTest {
 			.andExpect(content().contentType("application/json;charset=UTF-8"))
 			.andExpect(jsonPath("$.*", hasSize(2)))
 			.andExpect(jsonPath("$.success", is(false)))
-			.andExpect(jsonPath("$.message", is("An error has occurred during password reset request.")));
+			.andExpect(jsonPath("$.message", is(exceptionMsg)));
 
 		verify(tokenService, times(1)).sendResetPasswordMail(any(HttpServletRequest.class), eq(email));
 		verifyNoMoreInteractions(tokenService);


### PR DESCRIPTION
Just a minor change to send a more meaningful error message to the client if a password reset did not work as expected.