### PR TITLE
HttpUtil - use Credentials interface of apache httpcomponents

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,8 @@
 
 ## 0.1.1 (xxxx-xx-xx)
 
+* Changes:
+  * `HttpUtil` methods can now be called with intances of [`Credentials` interface](https://hc.apache.org/httpcomponents-client-4.5.x/httpclient/apidocs/org/apache/http/auth/class-use/Credentials.html)
 * New features:
   * A new web interface for the easy creation of ExtJS locale JSON files (based on CSV files) has been added. See this PR for details: https://github.com/terrestris/shogun2/pull/213
 

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
@@ -22,6 +22,7 @@ import org.apache.http.HttpHost;
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
+import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.AuthCache;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.RequestConfig;
@@ -72,7 +73,7 @@ public class HttpUtil {
 	private static int httpTimeout;
 
 	/**
-	 * Performs an HTTP GET on the given URL.
+	 * Performs an HTTP GET on the given URL <i>without authentication</i>
 	 *
 	 * @param url The URL to connect to.
 	 *
@@ -89,7 +90,7 @@ public class HttpUtil {
 	 * Performs an HTTP GET on the given URL.
 	 *
 	 * @param url The URL to connect to.
-	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
+	 * @param credentials instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 *
@@ -102,7 +103,21 @@ public class HttpUtil {
 	}
 
 	/**
+	 * Performs an HTTP GET on the given URL
+	 *
+	 * @param url The URL to connect to.
+	 * @param username Credentials - username
+	 * @param password Credentials - password
+	 * @throws HttpException
+	 * @throws URISyntaxException
+	 */
+	public static Response get(String url, String username, String password) throws URISyntaxException, HttpException {
+		return send(new HttpGet(url), new UsernamePasswordCredentials(username, password));
+	}
+
+	/**
 	 * Performs an HTTP GET on the given URI.
+	 * No credentials needed.
 	 *
 	 * @param uri The URI to connect to.
 	 *
@@ -113,6 +128,24 @@ public class HttpUtil {
 	 */
 	public static Response get(URI uri) throws URISyntaxException, HttpException {
 		return send(new HttpGet(uri), null);
+	}
+
+	/**
+	 * Performs an HTTP GET on the given URI.
+	 * Basic auth is used if both username and password are not null.
+	 *
+	 * @param uri The URI to connect to.
+	 * @param username Credentials - username
+	 * @param password Credentials - password
+	 *
+	 * @return The HTTP response as Response object.
+	 *
+	 * @throws URISyntaxException
+	 * @throws HttpException
+	 */
+	public static Response get(URI uri, String username, String password)
+			throws URISyntaxException, HttpException {
+		return send(new HttpGet(uri), new UsernamePasswordCredentials(username, password));
 	}
 
 	/**
@@ -150,7 +183,26 @@ public class HttpUtil {
 
 	/**
 	 * Performs an HTTP POST on the given URL.
-	 * Basic auth is used if both username and pw are not null.
+	 * Basic auth is used if both and password are not null.
+	 *
+	 * @param uri The URI to connect to.
+	 * @param username Credentials - username
+	 * @param password Credentials - password
+	 *
+	 * @return The HTTP response as Response object.
+	 *
+	 * @throws URISyntaxException
+	 * @throws UnsupportedEncodingException
+	 * @throws HttpException
+	 */
+	public static Response post(String url, String password, String username)
+			throws URISyntaxException, UnsupportedEncodingException, HttpException {
+		return postParams(new HttpPost(url), new ArrayList<NameValuePair>(), new UsernamePasswordCredentials(username, password));
+	}
+
+	/**
+	 * Performs an HTTP POST on the given URL.
+	 * Basic auth is used if credentials object is not null
 	 *
 	 * @param url The URL to connect to.
 	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
@@ -184,7 +236,26 @@ public class HttpUtil {
 
 	/**
 	 * Performs an HTTP POST on the given URI.
-	 * Basic auth is used if both username and pw are not null.
+	 * Basic auth is used if both and password are not null.
+	 *
+	 * @param uri The URI to connect to.
+	 * @param username Credentials - username
+	 * @param password Credentials - password
+	 *
+	 * @return The HTTP response as Response object.
+	 *
+	 * @throws URISyntaxException
+	 * @throws UnsupportedEncodingException
+	 * @throws HttpException
+	 */
+	public static Response post(URI uri, String username, String password)
+			throws URISyntaxException, UnsupportedEncodingException, HttpException {
+		return postParams(new HttpPost(uri), new ArrayList<NameValuePair>(), new UsernamePasswordCredentials(username, password));
+	}
+
+	/**
+	 * Performs an HTTP POST on the given URI.
+	 * Basic auth is used if credentials object is not null
 	 *
 	 * @param uri The URI to connect to.
 	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
@@ -219,6 +290,26 @@ public class HttpUtil {
 
 	/**
 	 * Performs an HTTP POST on the given URL.
+	 * Basic auth is used if both and password are not null.
+	 *
+	 * @param url The URL to connect to.
+	 * @param queryParams The list of NameValuePairs.
+	 * @param username Credentials - username
+	 * @param password Credentials - password
+	 *
+	 * @return The HTTP response as Response object.
+	 *
+	 * @throws URISyntaxException
+	 * @throws UnsupportedEncodingException
+	 * @throws HttpException
+	 */
+	public static Response post(String url, List<NameValuePair> queryParams, String username, String password) throws URISyntaxException,
+			UnsupportedEncodingException, HttpException {
+		return postParams(new HttpPost(url), queryParams, new UsernamePasswordCredentials(username, password));
+	}
+
+	/**
+	 * Performs an HTTP POST on the given URL.
 	 *
 	 * @param url The URL to connect to.
 	 * @param queryParams The list of NameValuePairs.
@@ -230,8 +321,7 @@ public class HttpUtil {
 	 * @throws UnsupportedEncodingException
 	 * @throws HttpException
 	 */
-	public static Response post(String url, List<NameValuePair> queryParams,
-			Credentials credentials) throws URISyntaxException,
+	public static Response post(String url, List<NameValuePair> queryParams, Credentials credentials) throws URISyntaxException,
 			UnsupportedEncodingException, HttpException {
 		return postParams(new HttpPost(url), queryParams, credentials);
 	}
@@ -255,6 +345,26 @@ public class HttpUtil {
 
 	/**
 	 * Performs an HTTP POST on the given URI.
+	 * Basic auth is used if both and password are not null.
+	 *
+	 * @param uri The URI to connect to.
+	 * @param queryParams The list of NameValuePairs.
+	 * @param username Credentials - username
+	 * @param password Credentials - password
+	 *
+	 * @return The HTTP response as Response object.
+	 *
+	 * @throws URISyntaxException
+	 * @throws UnsupportedEncodingException
+	 * @throws HttpException
+	 */
+	public static Response post(URI uri, List<NameValuePair> queryParams, String username, String password) throws URISyntaxException,
+			UnsupportedEncodingException, HttpException {
+		return postParams(new HttpPost(uri), queryParams, new UsernamePasswordCredentials(username, password));
+	}
+
+	/**
+	 * Performs an HTTP POST on the given URI.
 	 *
 	 * @param uri The URI to connect to.
 	 * @param queryParams The list of NameValuePairs.
@@ -266,8 +376,7 @@ public class HttpUtil {
 	 * @throws UnsupportedEncodingException
 	 * @throws HttpException
 	 */
-	public static Response post(URI uri, List<NameValuePair> queryParams,
-			Credentials credentials) throws URISyntaxException,
+	public static Response post(URI uri, List<NameValuePair> queryParams, Credentials credentials) throws URISyntaxException,
 			UnsupportedEncodingException, HttpException {
 		return postParams(new HttpPost(uri), queryParams, credentials);
 	}
@@ -287,6 +396,25 @@ public class HttpUtil {
 	public static Response post(String url, String body, ContentType contentType)
 			throws URISyntaxException, HttpException {
 		return postBody(new HttpPost(url), body, contentType, null);
+	}
+
+	/**
+	 * Performs an HTTP POST on the given URL.
+	 * Basic auth is used is both username and password are not null
+	 *
+	 * @param url The URL to connect to.
+	 * @param body The POST body.
+	 * @param contentType The ContentType of the POST body
+	 * @param username Credentials - username
+	 * @param password Credentials - password
+	 *
+	 * @return The HTTP response as Response object.
+	 *
+	 * @throws URISyntaxException
+	 * @throws HttpException
+	 */
+	public static Response post(String url, String body, ContentType contentType, String username, String password) throws URISyntaxException, HttpException {
+		return postBody(new HttpPost(url), body, contentType, new UsernamePasswordCredentials(username, password));
 	}
 
 	/**
@@ -327,6 +455,26 @@ public class HttpUtil {
 
 	/**
 	 * Performs an HTTP POST on the given URL.
+	 * Basic auth is used if both username and password are not null
+	 *
+	 * @param uri The URI to connect to.
+	 * @param body The POST body.
+	 * @param contentType The ContentType of the POST body.
+	 * @param username Credentials - username
+	 * @param password Credentials - password
+	 *
+	 * @return The HTTP response as Response object.
+	 *
+	 * @throws URISyntaxException
+	 * @throws HttpException
+	 */
+	public static Response post(URI uri, String body, ContentType contentType,
+			String username, String password) throws URISyntaxException, HttpException {
+		return postBody(new HttpPost(uri), body, contentType, new UsernamePasswordCredentials(username, password));
+	}
+
+	/**
+	 * Performs an HTTP POST on the given URL.
 	 *
 	 * @param uri The URI to connect to.
 	 * @param body The POST body.
@@ -356,6 +504,25 @@ public class HttpUtil {
 	 */
 	public static Response post(String url, File file) throws URISyntaxException, HttpException {
 		return postMultiPart(new HttpPost(url), new FileBody(file), null);
+	}
+
+	/**
+	 *
+	 * Performs an HTTP POST on the given URL.
+	 * Basic auth is used if both username and password are not null
+	 *
+	 * @param url The URL to connect to.
+	 * @param file The file to send as MultiPartFile.
+	 * @param username username
+	 * @param password password
+	 *
+	 * @return The HTTP response as Response object.
+	 *
+	 * @throws URISyntaxException
+	 * @throws HttpException
+	 */
+	public static Response post(String url, File file, String username, String password) throws URISyntaxException, HttpException {
+		return postMultiPart(new HttpPost(url), new FileBody(file), new UsernamePasswordCredentials(username, password));
 	}
 
 	/**
@@ -393,6 +560,24 @@ public class HttpUtil {
 
 	/**
 	 * Performs an HTTP POST on the given URL.
+	 * Basic auth is used if both username and password are not null.
+	 *
+	 * @param uri The URI to connect to.
+	 * @param file The file to send as MultiPartFile.
+	 * @param username username
+	 * @param password password
+	 *
+	 * @return The HTTP response as Response object.
+	 *
+	 * @throws URISyntaxException
+	 * @throws HttpException
+	 */
+	public static Response post(URI uri, File file, String username, String password) throws URISyntaxException, HttpException {
+		return postMultiPart(new HttpPost(uri), new FileBody(file), new UsernamePasswordCredentials(username, password));
+	}
+
+	/**
+	 * Performs an HTTP POST on the given URL.
 	 * Basic auth is used if credentials object is not null.
 	 *
 	 * @param uri The URI to connect to.
@@ -419,8 +604,7 @@ public class HttpUtil {
 	 * @throws URISyntaxException
 	 * @throws HttpException
 	 */
-	private static Response postMultiPart(HttpPost httpRequest, FileBody file,
-			Credentials credentials) throws URISyntaxException, HttpException {
+	private static Response postMultiPart(HttpPost httpRequest, FileBody file, Credentials credentials) throws URISyntaxException, HttpException {
 
 		HttpEntity multiPartEntity = MultipartEntityBuilder.create()
 				.addPart("file", file)
@@ -442,8 +626,7 @@ public class HttpUtil {
 	 * @throws URISyntaxException
 	 * @throws HttpException
 	 */
-	private static Response postBody(HttpPost httpRequest, String body,
-			ContentType contentType, Credentials credentials)
+	private static Response postBody(HttpPost httpRequest, String body, ContentType contentType, Credentials credentials)
 			throws URISyntaxException, HttpException {
 
 		StringEntity stringEntity = new StringEntity(body, contentType);
@@ -465,8 +648,7 @@ public class HttpUtil {
 	 * @throws UnsupportedEncodingException
 	 * @throws HttpException
 	 */
-	private static Response postParams(HttpPost httpRequest,
-			List<NameValuePair> queryParams, Credentials credentials)
+	private static Response postParams(HttpPost httpRequest, List<NameValuePair> queryParams, Credentials credentials)
 			throws URISyntaxException, UnsupportedEncodingException, HttpException {
 
 		HttpEntity httpEntity = new UrlEncodedFormEntity(queryParams);
@@ -501,9 +683,26 @@ public class HttpUtil {
 
 	/**
 	 * Perform HTTP PUT with empty body
+	 * Basic auth will be used if both username and password are not null
 	 *
-	 * @param uri
+	 * @param uri URI to connect to
+	 * @param username username
+	 * @param password password
+	 *
+	 * @return
+	 * @throws URISyntaxException
+	 * @throws HttpException
+	 */
+	public static Response put(URI uri, String username, String password) throws URISyntaxException, HttpException {
+		return putBody(new HttpPut(uri), null, null, new UsernamePasswordCredentials(username, password));
+	}
+
+	/**
+	 * Perform HTTP PUT with empty body
+	 *
+	 * @param uri URI to connect to
 	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
+	 *
 	 * @return
 	 * @throws URISyntaxException
 	 * @throws HttpException
@@ -515,7 +714,22 @@ public class HttpUtil {
 	/**
 	 * Perform HTTP PUT with empty body
 	 *
-	 * @param uriString
+	 * @param uriString String representing the URI to connect to
+	 * @param username username
+	 * @param password password
+	 *
+	 * @return
+	 * @throws HttpException
+	 * @throws URISyntaxException
+	 */
+	public static Response put(String uriString, String username, String password) throws URISyntaxException, HttpException {
+		return putBody(new HttpPut(uriString), null, null, new UsernamePasswordCredentials(username, password));
+	}
+
+	/**
+	 * Perform HTTP PUT with empty body
+	 *
+	 * @param uriString String representing the URI to connect to
 	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return
@@ -530,15 +744,33 @@ public class HttpUtil {
 	 * Performs an HTTP PUT on the given URL.
 	 * (without BasicAuth)
 	 *
-	 * @param uriString
+	 * @param uriString String representing the URI to connect to
 	 * @param body
 	 * @param contentType
+	 *
 	 * @return
 	 * @throws URISyntaxException
 	 * @throws HttpException
 	 */
 	public static Response put(String uriString, String body, ContentType contentType) throws URISyntaxException, HttpException{
 		return putBody(new HttpPut(uriString), body, contentType, null);
+	}
+
+	/**
+	 * Performs an HTTP PUT on the given URL.
+	 *
+	 * @param uriString String representing the URI to connect to
+	 * @param body
+	 * @param contentType
+	 * @param username
+	 * @param password
+	 *
+	 * @return
+	 * @throws URISyntaxException
+	 * @throws HttpException
+	 */
+	public static Response put(String uriString, String body, ContentType contentType, String username, String password) throws URISyntaxException, HttpException{
+		return putBody(new HttpPut(uriString), body, contentType, new UsernamePasswordCredentials(username, password));
 	}
 
 	/**
@@ -578,6 +810,22 @@ public class HttpUtil {
 	 * @param uri
 	 * @param body
 	 * @param contentType
+	 * @param username
+	 * @param password
+	 * @return
+	 * @throws URISyntaxException
+	 * @throws HttpException
+	 */
+	public static Response put(URI uri, String body, ContentType contentType, String username, String password) throws URISyntaxException, HttpException{
+		return putBody(new HttpPut(uri), body, contentType, new UsernamePasswordCredentials(username, password));
+	}
+
+	/**
+	 * Performs an HTTP PUT on the given URL.
+	 *
+	 * @param uri
+	 * @param body
+	 * @param contentType
 	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
@@ -600,6 +848,23 @@ public class HttpUtil {
 	 */
 	public static Response delete(String url) throws URISyntaxException, HttpException {
 		return send(new HttpDelete(url), null);
+	}
+
+	/**
+	 * Performs an HTTP DELETE on the given URL.
+	 *
+	 * @param url The URL to connect to.
+	 * @param username username
+	 * @param password password
+	 *
+	 * @return The HTTP response as Response object.
+	 *
+	 * @throws URISyntaxException
+	 * @throws HttpException
+	 */
+	public static Response delete(String url, String username, String password)
+			throws URISyntaxException, HttpException {
+		return send(new HttpDelete(url), new UsernamePasswordCredentials(username, password));
 	}
 
 	/**
@@ -630,6 +895,23 @@ public class HttpUtil {
 	 */
 	public static Response delete(URI uri) throws URISyntaxException, HttpException {
 		return send(new HttpDelete(uri), null);
+	}
+
+	/**
+	 * Performs an HTTP DELETE on the given URI.
+	 * Basic auth is used if both username and pw are not null.
+	 *
+	 * @param uri The URI to connect to.
+	 * @param username username
+	 * @param password password
+	 *
+	 * @return The HTTP response as Response object.
+	 *
+	 * @throws URISyntaxException
+	 * @throws HttpException
+	 */
+	public static Response delete(URI uri, String username, String password) throws URISyntaxException, HttpException {
+		return send(new HttpDelete(uri), new UsernamePasswordCredentials(username, password));
 	}
 
 	/**

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
@@ -21,7 +21,7 @@ import org.apache.http.HttpException;
 import org.apache.http.HttpHost;
 import org.apache.http.NameValuePair;
 import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.auth.Credentials;
 import org.apache.http.client.AuthCache;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.RequestConfig;
@@ -54,6 +54,7 @@ import de.terrestris.shogun2.util.model.Response;
 /**
  *
  * @author Daniel Koch
+ * @author Andre Henn
  * @author terrestris GmbH & Co. KG
  *
  */
@@ -81,24 +82,23 @@ public class HttpUtil {
 	 * @throws HttpException
 	 */
 	public static Response get(String url) throws URISyntaxException, HttpException {
-		return send(new HttpGet(url), null, null);
+		return send(new HttpGet(url), null);
 	}
 
 	/**
 	 * Performs an HTTP GET on the given URL.
 	 *
 	 * @param url The URL to connect to.
-	 * @param username The Basic authentication username.
-	 * @param password The Basic authentication password.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 *
 	 * @throws URISyntaxException
 	 * @throws HttpException
 	 */
-	public static Response get(String url, String username, String password)
+	public static Response get(String url, Credentials credentials)
 			throws URISyntaxException, HttpException {
-		return send(new HttpGet(url), username, password);
+		return send(new HttpGet(url), credentials);
 	}
 
 	/**
@@ -112,7 +112,7 @@ public class HttpUtil {
 	 * @throws HttpException
 	 */
 	public static Response get(URI uri) throws URISyntaxException, HttpException {
-		return send(new HttpGet(uri), null, null);
+		return send(new HttpGet(uri), null);
 	}
 
 	/**
@@ -120,17 +120,16 @@ public class HttpUtil {
 	 * Basic auth is used if both username and pw are not null.
 	 *
 	 * @param uri The URI to connect to.
-	 * @param username The Basic authentication username.
-	 * @param password The Basic authentication password.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 *
 	 * @throws URISyntaxException
 	 * @throws HttpException
 	 */
-	public static Response get(URI uri, String username, String password)
+	public static Response get(URI uri, Credentials credentials)
 			throws URISyntaxException, HttpException {
-		return send(new HttpGet(uri), username, password);
+		return send(new HttpGet(uri), credentials);
 	}
 
 	/**
@@ -146,8 +145,7 @@ public class HttpUtil {
 	 */
 	public static Response post(String url)
 			throws URISyntaxException, UnsupportedEncodingException, HttpException {
-		return postParams(new HttpPost(url), new ArrayList<NameValuePair>(),
-				null, null);
+		return postParams(new HttpPost(url), new ArrayList<NameValuePair>(), null);
 	}
 
 	/**
@@ -155,8 +153,7 @@ public class HttpUtil {
 	 * Basic auth is used if both username and pw are not null.
 	 *
 	 * @param url The URL to connect to.
-	 * @param username The Basic authentication username.
-	 * @param password The Basic authentication password.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 *
@@ -164,10 +161,9 @@ public class HttpUtil {
 	 * @throws UnsupportedEncodingException
 	 * @throws HttpException
 	 */
-	public static Response post(String url, String username, String password)
+	public static Response post(String url, Credentials credentials)
 			throws URISyntaxException, UnsupportedEncodingException, HttpException {
-		return postParams(new HttpPost(url), new ArrayList<NameValuePair>(),
-				username, password);
+		return postParams(new HttpPost(url), new ArrayList<NameValuePair>(), credentials);
 	}
 
 	/**
@@ -183,8 +179,7 @@ public class HttpUtil {
 	 */
 	public static Response post(URI uri)
 			throws URISyntaxException, UnsupportedEncodingException, HttpException {
-		return postParams(new HttpPost(uri), new ArrayList<NameValuePair>(),
-				null, null);
+		return postParams(new HttpPost(uri), new ArrayList<NameValuePair>(), null);
 	}
 
 	/**
@@ -192,8 +187,7 @@ public class HttpUtil {
 	 * Basic auth is used if both username and pw are not null.
 	 *
 	 * @param uri The URI to connect to.
-	 * @param username The Basic authentication username.
-	 * @param password The Basic authentication password.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 *
@@ -201,10 +195,9 @@ public class HttpUtil {
 	 * @throws UnsupportedEncodingException
 	 * @throws HttpException
 	 */
-	public static Response post(URI uri, String username, String password)
+	public static Response post(URI uri, Credentials credentials)
 			throws URISyntaxException, UnsupportedEncodingException, HttpException {
-		return postParams(new HttpPost(uri), new ArrayList<NameValuePair>(),
-				username, password);
+		return postParams(new HttpPost(uri), new ArrayList<NameValuePair>(), credentials);
 	}
 
 	/**
@@ -221,7 +214,7 @@ public class HttpUtil {
 	 */
 	public static Response post(String url, List<NameValuePair> queryParams)
 			throws URISyntaxException, UnsupportedEncodingException, HttpException {
-		return postParams(new HttpPost(url), queryParams, null, null);
+		return postParams(new HttpPost(url), queryParams, null);
 	}
 
 	/**
@@ -229,8 +222,7 @@ public class HttpUtil {
 	 *
 	 * @param url The URL to connect to.
 	 * @param queryParams The list of NameValuePairs.
-	 * @param username The Basic authentication username.
-	 * @param password The Basic authentication password.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 *
@@ -239,9 +231,9 @@ public class HttpUtil {
 	 * @throws HttpException
 	 */
 	public static Response post(String url, List<NameValuePair> queryParams,
-			String username, String password) throws URISyntaxException,
+			Credentials credentials) throws URISyntaxException,
 			UnsupportedEncodingException, HttpException {
-		return postParams(new HttpPost(url), queryParams, username, password);
+		return postParams(new HttpPost(url), queryParams, credentials);
 	}
 
 	/**
@@ -258,7 +250,7 @@ public class HttpUtil {
 	 */
 	public static Response post(URI uri, List<NameValuePair> queryParams)
 			throws URISyntaxException, UnsupportedEncodingException, HttpException {
-		return postParams(new HttpPost(uri), queryParams, null, null);
+		return postParams(new HttpPost(uri), queryParams, null);
 	}
 
 	/**
@@ -266,8 +258,7 @@ public class HttpUtil {
 	 *
 	 * @param uri The URI to connect to.
 	 * @param queryParams The list of NameValuePairs.
-	 * @param username The Basic authentication username.
-	 * @param password The Basic authentication password.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 *
@@ -276,9 +267,9 @@ public class HttpUtil {
 	 * @throws HttpException
 	 */
 	public static Response post(URI uri, List<NameValuePair> queryParams,
-			String username, String password) throws URISyntaxException,
+			Credentials credentials) throws URISyntaxException,
 			UnsupportedEncodingException, HttpException {
-		return postParams(new HttpPost(uri), queryParams, username, password);
+		return postParams(new HttpPost(uri), queryParams, credentials);
 	}
 
 	/**
@@ -295,7 +286,7 @@ public class HttpUtil {
 	 */
 	public static Response post(String url, String body, ContentType contentType)
 			throws URISyntaxException, HttpException {
-		return postBody(new HttpPost(url), body, contentType, null, null);
+		return postBody(new HttpPost(url), body, contentType, null);
 	}
 
 	/**
@@ -304,8 +295,7 @@ public class HttpUtil {
 	 * @param url The URL to connect to.
 	 * @param body The POST body.
 	 * @param contentType The ContentType of the POST body.
-	 * @param username The Basic authentication username.
-	 * @param password The Basic authentication password.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 *
@@ -313,8 +303,8 @@ public class HttpUtil {
 	 * @throws HttpException
 	 */
 	public static Response post(String url, String body, ContentType contentType,
-			String username, String password) throws URISyntaxException, HttpException {
-		return postBody(new HttpPost(url), body, contentType, username, password);
+			Credentials credentials) throws URISyntaxException, HttpException {
+		return postBody(new HttpPost(url), body, contentType, credentials);
 	}
 
 	/**
@@ -332,7 +322,7 @@ public class HttpUtil {
 	 */
 	public static Response post(URI uri, String body, ContentType contentType)
 			throws URISyntaxException, HttpException {
-		return postBody(new HttpPost(uri), body, contentType, null, null);
+		return postBody(new HttpPost(uri), body, contentType, null);
 	}
 
 	/**
@@ -341,8 +331,7 @@ public class HttpUtil {
 	 * @param uri The URI to connect to.
 	 * @param body The POST body.
 	 * @param contentType The ContentType of the POST body.
-	 * @param username The Basic authentication username.
-	 * @param password The Basic authentication password.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 *
@@ -350,8 +339,8 @@ public class HttpUtil {
 	 * @throws HttpException
 	 */
 	public static Response post(URI uri, String body, ContentType contentType,
-			String username, String password) throws URISyntaxException, HttpException {
-		return postBody(new HttpPost(uri), body, contentType, username, password);
+			Credentials credentials) throws URISyntaxException, HttpException {
+		return postBody(new HttpPost(uri), body, contentType, credentials);
 	}
 
 	/**
@@ -366,27 +355,25 @@ public class HttpUtil {
 	 * @throws HttpException
 	 */
 	public static Response post(String url, File file) throws URISyntaxException, HttpException {
-		return postMultiPart(new HttpPost(url), new FileBody(file), null, null);
+		return postMultiPart(new HttpPost(url), new FileBody(file), null);
 	}
 
 	/**
 	 *
 	 * Performs an HTTP POST on the given URL.
-	 * Basic auth is used if both username and password are not null.
+	 * Basic auth is used if credentials object is not null.
 	 *
 	 * @param url The URL to connect to.
 	 * @param file The file to send as MultiPartFile.
-	 * @param username The Basic authentication username.
-	 * @param password The Basic authentication password.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 *
 	 * @throws URISyntaxException
 	 * @throws HttpException
 	 */
-	public static Response post(String url, File file, String username,
-			String password) throws URISyntaxException, HttpException {
-		return postMultiPart(new HttpPost(url), new FileBody(file), username, password);
+	public static Response post(String url, File file, Credentials credentials) throws URISyntaxException, HttpException {
+		return postMultiPart(new HttpPost(url), new FileBody(file), credentials);
 	}
 
 	/**
@@ -401,34 +388,31 @@ public class HttpUtil {
 	 * @throws HttpException
 	 */
 	public static Response post(URI uri, File file) throws URISyntaxException, HttpException {
-		return postMultiPart(new HttpPost(uri), new FileBody(file), null, null);
+		return postMultiPart(new HttpPost(uri), new FileBody(file), null);
 	}
 
 	/**
 	 * Performs an HTTP POST on the given URL.
-	 * Basic auth is used if both username and password are not null.
+	 * Basic auth is used if credentials object is not null.
 	 *
 	 * @param uri The URI to connect to.
 	 * @param file The file to send as MultiPartFile.
-	 * @param username The Basic authentication username.
-	 * @param password The Basic authentication password.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 *
 	 * @throws URISyntaxException
 	 * @throws HttpException
 	 */
-	public static Response post(URI uri, File file, String username,
-			String password) throws URISyntaxException, HttpException {
-		return postMultiPart(new HttpPost(uri), new FileBody(file), username, password);
+	public static Response post(URI uri, File file, Credentials credentials) throws URISyntaxException, HttpException {
+		return postMultiPart(new HttpPost(uri), new FileBody(file), credentials);
 	}
 
 	/**
 	 *
 	 * @param httpRequest
 	 * @param file
-	 * @param username The Basic authentication username.
-	 * @param password The Basic authentication password.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 *
@@ -436,14 +420,14 @@ public class HttpUtil {
 	 * @throws HttpException
 	 */
 	private static Response postMultiPart(HttpPost httpRequest, FileBody file,
-			String username, String password) throws URISyntaxException, HttpException {
+			Credentials credentials) throws URISyntaxException, HttpException {
 
 		HttpEntity multiPartEntity = MultipartEntityBuilder.create()
 				.addPart("file", file)
 				.build();
 		httpRequest.setEntity(multiPartEntity);
 
-		return send(httpRequest, username, password);
+		return send(httpRequest, credentials);
 	}
 
 	/**
@@ -451,8 +435,7 @@ public class HttpUtil {
 	 * @param httpRequest
 	 * @param body
 	 * @param contentType
-	 * @param username The Basic authentication username. No basic auth if null.
-	 * @param password The Basic authentication password. No basic auth if null.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 *
@@ -460,22 +443,21 @@ public class HttpUtil {
 	 * @throws HttpException
 	 */
 	private static Response postBody(HttpPost httpRequest, String body,
-			ContentType contentType, String username, String password)
+			ContentType contentType, Credentials credentials)
 			throws URISyntaxException, HttpException {
 
 		StringEntity stringEntity = new StringEntity(body, contentType);
 		stringEntity.setChunked(true);
 		httpRequest.setEntity(stringEntity);
 
-		return send(httpRequest, username, password);
+		return send(httpRequest, credentials);
 	}
 
 	/**
 	 *
 	 * @param httpRequest
 	 * @param queryParams
-	 * @param username The Basic authentication username. No basic auth if null.
-	 * @param password The Basic authentication password. No basic auth if null.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 *
@@ -484,13 +466,13 @@ public class HttpUtil {
 	 * @throws HttpException
 	 */
 	private static Response postParams(HttpPost httpRequest,
-			List<NameValuePair> queryParams, String username, String password)
+			List<NameValuePair> queryParams, Credentials credentials)
 			throws URISyntaxException, UnsupportedEncodingException, HttpException {
 
 		HttpEntity httpEntity = new UrlEncodedFormEntity(queryParams);
 		httpRequest.setEntity(httpEntity);
 
-		return send(httpRequest, username, password);
+		return send(httpRequest, credentials);
 	}
 
 	/**
@@ -502,7 +484,7 @@ public class HttpUtil {
 	 * @throws URISyntaxException
 	 */
 	public static Response put(URI uri) throws URISyntaxException, HttpException {
-		return putBody(new HttpPut(uri), null, null, null, null);
+		return putBody(new HttpPut(uri), null, null, null);
 	}
 
 	/**
@@ -514,36 +496,34 @@ public class HttpUtil {
 	 * @throws URISyntaxException
 	 */
 	public static Response put(String uriString) throws URISyntaxException, HttpException {
-		return putBody(new HttpPut(uriString), null, null, null, null);
+		return putBody(new HttpPut(uriString), null, null, null);
 	}
 
 	/**
 	 * Perform HTTP PUT with empty body
 	 *
 	 * @param uri
-	 * @param username The Basic authentication username.
-	 * @param password The Basic authentication password.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 * @return
 	 * @throws URISyntaxException
 	 * @throws HttpException
 	 */
-	public static Response put(URI uri, String username, String password) throws URISyntaxException, HttpException {
-		return putBody(new HttpPut(uri), null, null, username, password);
+	public static Response put(URI uri, Credentials credentials) throws URISyntaxException, HttpException {
+		return putBody(new HttpPut(uri), null, null, credentials);
 	}
 
 	/**
 	 * Perform HTTP PUT with empty body
 	 *
 	 * @param uriString
-	 * @param username The Basic authentication username.
-	 * @param password The Basic authentication password.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return
 	 * @throws HttpException
 	 * @throws URISyntaxException
 	 */
-	public static Response put(String uriString, String username, String password) throws URISyntaxException, HttpException {
-		return putBody(new HttpPut(uriString), null, null, username, password);
+	public static Response put(String uriString, Credentials credentials) throws URISyntaxException, HttpException {
+		return putBody(new HttpPut(uriString), null, null, credentials);
 	}
 
 	/**
@@ -558,7 +538,7 @@ public class HttpUtil {
 	 * @throws HttpException
 	 */
 	public static Response put(String uriString, String body, ContentType contentType) throws URISyntaxException, HttpException{
-		return putBody(new HttpPut(uriString), body, contentType, null, null);
+		return putBody(new HttpPut(uriString), body, contentType, null);
 	}
 
 	/**
@@ -567,15 +547,14 @@ public class HttpUtil {
 	 * @param uriString
 	 * @param body
 	 * @param contentType
-	 * @param username The Basic authentication username. No basic auth if null.
-	 * @param password The Basic authentication password. No basic auth if null.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 * @throws URISyntaxException
 	 * @throws HttpException
 	 */
-	public static Response put(String uriString, String body, ContentType contentType, String username, String password) throws URISyntaxException, HttpException{
-		return putBody(new HttpPut(uriString), body, contentType, username, password);
+	public static Response put(String uriString, String body, ContentType contentType, Credentials credentials) throws URISyntaxException, HttpException{
+		return putBody(new HttpPut(uriString), body, contentType, credentials);
 	}
 
 	/**
@@ -590,7 +569,7 @@ public class HttpUtil {
 	 * @throws HttpException
 	 */
 	public static Response put(URI uri, String body, ContentType contentType) throws URISyntaxException, HttpException{
-		return putBody(new HttpPut(uri), body, contentType, null, null);
+		return putBody(new HttpPut(uri), body, contentType, null);
 	}
 
 	/**
@@ -599,15 +578,14 @@ public class HttpUtil {
 	 * @param uri
 	 * @param body
 	 * @param contentType
-	 * @param username The Basic authentication username. No basic auth if null.
-	 * @param password The Basic authentication password. No basic auth if null.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 * @throws URISyntaxException
 	 * @throws HttpException
 	 */
-	public static Response put(URI uri, String body, ContentType contentType, String username, String password) throws URISyntaxException, HttpException{
-		return putBody(new HttpPut(uri), body, contentType, username, password);
+	public static Response put(URI uri, String body, ContentType contentType, Credentials credentials) throws URISyntaxException, HttpException{
+		return putBody(new HttpPut(uri), body, contentType, credentials);
 	}
 
 	/**
@@ -621,24 +599,23 @@ public class HttpUtil {
 	 * @throws HttpException
 	 */
 	public static Response delete(String url) throws URISyntaxException, HttpException {
-		return send(new HttpDelete(url), null, null);
+		return send(new HttpDelete(url), null);
 	}
 
 	/**
 	 * Performs an HTTP DELETE on the given URL.
 	 *
 	 * @param url The URL to connect to.
-	 * @param username The Basic authentication username.
-	 * @param password The Basic authentication password.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 *
 	 * @throws URISyntaxException
 	 * @throws HttpException
 	 */
-	public static Response delete(String url, String username, String password)
+	public static Response delete(String url, Credentials credentials)
 			throws URISyntaxException, HttpException {
-		return send(new HttpDelete(url), username, password);
+		return send(new HttpDelete(url), credentials);
 	}
 
 	/**
@@ -652,7 +629,7 @@ public class HttpUtil {
 	 * @throws HttpException
 	 */
 	public static Response delete(URI uri) throws URISyntaxException, HttpException {
-		return send(new HttpDelete(uri), null, null);
+		return send(new HttpDelete(uri), null);
 	}
 
 	/**
@@ -660,17 +637,16 @@ public class HttpUtil {
 	 * Basic auth is used if both username and pw are not null.
 	 *
 	 * @param uri The URI to connect to.
-	 * @param username The Basic authentication username.
-	 * @param password The Basic authentication password.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 *
 	 * @throws URISyntaxException
 	 * @throws HttpException
 	 */
-	public static Response delete(URI uri, String username, String password)
+	public static Response delete(URI uri, Credentials credentials)
 			throws URISyntaxException, HttpException {
-		return send(new HttpDelete(uri), username, password);
+		return send(new HttpDelete(uri), credentials);
 	}
 
 	/**
@@ -678,13 +654,13 @@ public class HttpUtil {
 	 * @param httpRequest
 	 * @param body
 	 * @param contentType
-	 * @param username The Basic authentication username.
-	 * @param password The Basic authentication password.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
+	 *
 	 * @return The HTTP response as Response object.
 	 * @throws URISyntaxException
 	 * @throws HttpException
 	 */
-	private static Response putBody(HttpPut httpRequest, String body, ContentType contentType, String username, String password) throws URISyntaxException, HttpException {
+	private static Response putBody(HttpPut httpRequest, String body, ContentType contentType, Credentials credentials) throws URISyntaxException, HttpException {
 
 		if (contentType != null && !StringUtils.isEmpty(body)) {
 			StringEntity stringEntity = new StringEntity(body, contentType);
@@ -692,7 +668,7 @@ public class HttpUtil {
 			httpRequest.setEntity(stringEntity);
 		}
 
-		return send(httpRequest, username, password);
+		return send(httpRequest, credentials);
 	}
 
 	/**
@@ -700,16 +676,14 @@ public class HttpUtil {
 	 * Basic auth is used if both username and pw are not null.
 	 *
 	 * @param httpRequest The HttpRequest to connect to.
-	 * @param username The Basic authentication username. No basic auth if null.
-	 * @param password The Basic authentication password. No basic auth if null.
+	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 *
 	 * @return The HTTP response as Response object.
 	 *
 	 * @throws URISyntaxException
 	 * @throws HttpException
 	 */
-	private static Response send(HttpRequestBase httpRequest, String username,
-			String password) throws URISyntaxException, HttpException {
+	private static Response send(HttpRequestBase httpRequest, Credentials credentials) throws URISyntaxException, HttpException {
 
 		CloseableHttpClient httpClient = null;
 		CloseableHttpResponse httpResponse = null;
@@ -733,12 +707,12 @@ public class HttpUtil {
 				.build();
 
 		// set (preemptive) authentication if credentials are given
-		if (username != null && password != null) {
+		if (credentials != null) {
 
 			CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
 			credentialsProvider.setCredentials(
 					AuthScope.ANY,
-					new UsernamePasswordCredentials(username, password)
+					credentials
 			);
 
 			HttpHost targetHost = new HttpHost(uri.getHost(), uri.getPort(),

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/http/HttpUtilTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/http/HttpUtilTest.java
@@ -17,6 +17,8 @@ import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
@@ -62,12 +64,7 @@ public class HttpUtilTest {
 	/**
 	 *
 	 */
-	private static final String USERNAME = "Shinji";
-
-	/**
-	 *
-	 */
-	private static final String PASSWORD = "Kagawa";
+	private static final Credentials CREDENTIALS = new UsernamePasswordCredentials("Shinji", "Kagawa");
 
 	/**
 	 *
@@ -178,13 +175,13 @@ public class HttpUtilTest {
 
 	@Test
 	public void get_url_auth() throws URISyntaxException, HttpException {
-		Response response = HttpUtil.get(URL, USERNAME, PASSWORD);
+		Response response = HttpUtil.get(URL, CREDENTIALS);
 		assertNotNull(response);
 	}
 
 	@Test
 	public void get_uri_auth() throws URISyntaxException, HttpException {
-		Response response = HttpUtil.get(URI, USERNAME, PASSWORD);
+		Response response = HttpUtil.get(URI, CREDENTIALS);
 		assertNotNull(response);
 	}
 
@@ -202,13 +199,13 @@ public class HttpUtilTest {
 
 	@Test
 	public void post_url_empty_auth() throws URISyntaxException, UnsupportedEncodingException, HttpException {
-		Response response = HttpUtil.post(URL, USERNAME, PASSWORD);
+		Response response = HttpUtil.post(URL, CREDENTIALS);
 		assertNotNull(response);
 	}
 
 	@Test
 	public void post_uri_empty_auth() throws URISyntaxException, UnsupportedEncodingException, HttpException {
-		Response response = HttpUtil.post(URI, USERNAME, PASSWORD);
+		Response response = HttpUtil.post(URI, CREDENTIALS);
 		assertNotNull(response);
 	}
 
@@ -220,7 +217,7 @@ public class HttpUtilTest {
 
 	@Test
 	public void post_url_kvp_auth() throws URISyntaxException, UnsupportedEncodingException, HttpException {
-		Response response = HttpUtil.post(URL, POST_KEY_VALUE_PAIRS, USERNAME, PASSWORD);
+		Response response = HttpUtil.post(URL, POST_KEY_VALUE_PAIRS, CREDENTIALS);
 		assertNotNull(response);
 	}
 
@@ -232,7 +229,7 @@ public class HttpUtilTest {
 
 	@Test
 	public void post_uri_kvp_auth() throws URISyntaxException, UnsupportedEncodingException, HttpException {
-		Response response = HttpUtil.post(URI, POST_KEY_VALUE_PAIRS, USERNAME, PASSWORD);
+		Response response = HttpUtil.post(URI, POST_KEY_VALUE_PAIRS, CREDENTIALS);
 		assertNotNull(response);
 	}
 
@@ -244,7 +241,7 @@ public class HttpUtilTest {
 
 	@Test
 	public void post_url_body_auth() throws URISyntaxException, UnsupportedEncodingException, HttpException {
-		Response response = HttpUtil.post(URL, POST_XML_BODY, POST_XML_BODY_CONTENT_TYPE, USERNAME, PASSWORD);
+		Response response = HttpUtil.post(URL, POST_XML_BODY, POST_XML_BODY_CONTENT_TYPE, CREDENTIALS);
 		assertNotNull(response);
 	}
 
@@ -256,7 +253,7 @@ public class HttpUtilTest {
 
 	@Test
 	public void post_uri_body_auth() throws URISyntaxException, UnsupportedEncodingException, HttpException {
-		Response response = HttpUtil.post(URI, POST_XML_BODY, POST_XML_BODY_CONTENT_TYPE, USERNAME, PASSWORD);
+		Response response = HttpUtil.post(URI, POST_XML_BODY, POST_XML_BODY_CONTENT_TYPE, CREDENTIALS);
 		assertNotNull(response);
 	}
 
@@ -268,7 +265,7 @@ public class HttpUtilTest {
 
 	@Test
 	public void post_url_multipart_auth() throws URISyntaxException, HttpException {
-		Response response = HttpUtil.post(URL, getTestFile(), USERNAME, PASSWORD);
+		Response response = HttpUtil.post(URL, getTestFile(), CREDENTIALS);
 		assertNotNull(response);
 	}
 
@@ -280,7 +277,7 @@ public class HttpUtilTest {
 
 	@Test
 	public void post_uri_multipart_auth() throws URISyntaxException, HttpException {
-		Response response = HttpUtil.post(URI, getTestFile(), USERNAME, PASSWORD);
+		Response response = HttpUtil.post(URI, getTestFile(), CREDENTIALS);
 		assertNotNull(response);
 	}
 
@@ -298,13 +295,13 @@ public class HttpUtilTest {
 
 	@Test
 	public void put_uri_empty_auth() throws URISyntaxException, HttpException{
-		Response response = HttpUtil.put(URI, USERNAME, PASSWORD);
+		Response response = HttpUtil.put(URI, CREDENTIALS);
 		assertNotNull(response);
 	}
 
 	@Test
 	public void put_url_empty_auth() throws URISyntaxException, HttpException{
-		Response response = HttpUtil.put(URL, USERNAME, PASSWORD);
+		Response response = HttpUtil.put(URL, CREDENTIALS);
 		assertNotNull(response);
 	}
 
@@ -316,7 +313,7 @@ public class HttpUtilTest {
 
 	@Test
 	public void put_uri_body_auth() throws URISyntaxException, HttpException{
-		Response response = HttpUtil.put(URI, POST_XML_BODY, POST_XML_BODY_CONTENT_TYPE, USERNAME, PASSWORD);
+		Response response = HttpUtil.put(URI, POST_XML_BODY, POST_XML_BODY_CONTENT_TYPE, CREDENTIALS);
 		assertNotNull(response);
 	}
 
@@ -328,7 +325,7 @@ public class HttpUtilTest {
 
 	@Test
 	public void put_url_body_auth() throws URISyntaxException, HttpException{
-		Response response = HttpUtil.put(URL, POST_XML_BODY, POST_XML_BODY_CONTENT_TYPE, USERNAME, PASSWORD);
+		Response response = HttpUtil.put(URL, POST_XML_BODY, POST_XML_BODY_CONTENT_TYPE, CREDENTIALS);
 		assertNotNull(response);
 	}
 

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/http/HttpUtilTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/http/HttpUtilTest.java
@@ -36,6 +36,7 @@ import de.terrestris.shogun2.util.model.Response;
 /**
  *
  * @author danielkoch
+ * @author ahennr
  *
  */
 @SuppressWarnings("static-method")
@@ -64,7 +65,17 @@ public class HttpUtilTest {
 	/**
 	 *
 	 */
-	private static final Credentials CREDENTIALS = new UsernamePasswordCredentials("Shinji", "Kagawa");
+	private static final String USERNAME = "Shinji";
+
+	/**
+	 *
+	 */
+	private static final String PASSWORD = "Kagawa";
+
+	/**
+	 *
+	 */
+	private static final Credentials CREDENTIALS = new UsernamePasswordCredentials(USERNAME, PASSWORD);
 
 	/**
 	 *
@@ -143,7 +154,6 @@ public class HttpUtilTest {
 
 		HttpUtilTest.URI = builder.build();
 		HttpUtilTest.URL = HttpUtilTest.URI.toString();
-
 	}
 
 	/**
@@ -174,13 +184,25 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	public void get_url_auth() throws URISyntaxException, HttpException {
+	public void get_url_auth_pw() throws URISyntaxException, HttpException {
+		Response response = HttpUtil.get(URL, USERNAME, PASSWORD);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void get_uri_auth_pw() throws URISyntaxException, HttpException {
+		Response response = HttpUtil.get(URI, USERNAME, PASSWORD);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void get_url_auth_cred() throws URISyntaxException, HttpException {
 		Response response = HttpUtil.get(URL, CREDENTIALS);
 		assertNotNull(response);
 	}
 
 	@Test
-	public void get_uri_auth() throws URISyntaxException, HttpException {
+	public void get_uri_auth_cred() throws URISyntaxException, HttpException {
 		Response response = HttpUtil.get(URI, CREDENTIALS);
 		assertNotNull(response);
 	}
@@ -198,13 +220,25 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	public void post_url_empty_auth() throws URISyntaxException, UnsupportedEncodingException, HttpException {
+	public void post_url_empty_auth_pw() throws URISyntaxException, UnsupportedEncodingException, HttpException {
+		Response response = HttpUtil.post(URL, USERNAME, PASSWORD);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void post_uri_empty_auth_pw() throws URISyntaxException, UnsupportedEncodingException, HttpException {
+		Response response = HttpUtil.post(URI,  USERNAME, PASSWORD);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void post_url_empty_auth_cred() throws URISyntaxException, UnsupportedEncodingException, HttpException {
 		Response response = HttpUtil.post(URL, CREDENTIALS);
 		assertNotNull(response);
 	}
 
 	@Test
-	public void post_uri_empty_auth() throws URISyntaxException, UnsupportedEncodingException, HttpException {
+	public void post_uri_empty_auth_cred() throws URISyntaxException, UnsupportedEncodingException, HttpException {
 		Response response = HttpUtil.post(URI, CREDENTIALS);
 		assertNotNull(response);
 	}
@@ -216,7 +250,13 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	public void post_url_kvp_auth() throws URISyntaxException, UnsupportedEncodingException, HttpException {
+	public void post_url_kvp_auth_pw() throws URISyntaxException, UnsupportedEncodingException, HttpException {
+		Response response = HttpUtil.post(URL, POST_KEY_VALUE_PAIRS, USERNAME, PASSWORD);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void post_url_kvp_auth_cred() throws URISyntaxException, UnsupportedEncodingException, HttpException {
 		Response response = HttpUtil.post(URL, POST_KEY_VALUE_PAIRS, CREDENTIALS);
 		assertNotNull(response);
 	}
@@ -228,7 +268,13 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	public void post_uri_kvp_auth() throws URISyntaxException, UnsupportedEncodingException, HttpException {
+	public void post_uri_kvp_auth_pw() throws URISyntaxException, UnsupportedEncodingException, HttpException {
+		Response response = HttpUtil.post(URI, POST_KEY_VALUE_PAIRS, USERNAME, PASSWORD);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void post_uri_kvp_auth_cred() throws URISyntaxException, UnsupportedEncodingException, HttpException {
 		Response response = HttpUtil.post(URI, POST_KEY_VALUE_PAIRS, CREDENTIALS);
 		assertNotNull(response);
 	}
@@ -240,7 +286,13 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	public void post_url_body_auth() throws URISyntaxException, UnsupportedEncodingException, HttpException {
+	public void post_url_body_auth_pw() throws URISyntaxException, UnsupportedEncodingException, HttpException {
+		Response response = HttpUtil.post(URL, POST_XML_BODY, POST_XML_BODY_CONTENT_TYPE, USERNAME, PASSWORD);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void post_url_body_auth_cred() throws URISyntaxException, UnsupportedEncodingException, HttpException {
 		Response response = HttpUtil.post(URL, POST_XML_BODY, POST_XML_BODY_CONTENT_TYPE, CREDENTIALS);
 		assertNotNull(response);
 	}
@@ -252,7 +304,13 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	public void post_uri_body_auth() throws URISyntaxException, UnsupportedEncodingException, HttpException {
+	public void post_uri_body_auth_pw() throws URISyntaxException, UnsupportedEncodingException, HttpException {
+		Response response = HttpUtil.post(URI, POST_XML_BODY, POST_XML_BODY_CONTENT_TYPE, USERNAME, PASSWORD);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void post_uri_body_auth_cred() throws URISyntaxException, UnsupportedEncodingException, HttpException {
 		Response response = HttpUtil.post(URI, POST_XML_BODY, POST_XML_BODY_CONTENT_TYPE, CREDENTIALS);
 		assertNotNull(response);
 	}
@@ -264,7 +322,13 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	public void post_url_multipart_auth() throws URISyntaxException, HttpException {
+	public void post_url_multipart_auth_pw() throws URISyntaxException, HttpException {
+		Response response = HttpUtil.post(URL, getTestFile(), USERNAME, PASSWORD);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void post_url_multipart_auth_cred() throws URISyntaxException, HttpException {
 		Response response = HttpUtil.post(URL, getTestFile(), CREDENTIALS);
 		assertNotNull(response);
 	}
@@ -276,7 +340,13 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	public void post_uri_multipart_auth() throws URISyntaxException, HttpException {
+	public void post_uri_multipart_auth_pw() throws URISyntaxException, HttpException {
+		Response response = HttpUtil.post(URI, getTestFile(), USERNAME, PASSWORD);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void post_uri_multipart_auth_cred() throws URISyntaxException, HttpException {
 		Response response = HttpUtil.post(URI, getTestFile(), CREDENTIALS);
 		assertNotNull(response);
 	}
@@ -294,13 +364,25 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	public void put_uri_empty_auth() throws URISyntaxException, HttpException{
+	public void put_uri_empty_auth_pw() throws URISyntaxException, HttpException{
+		Response response = HttpUtil.put(URI, USERNAME, PASSWORD);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void put_url_empty_auth_pw() throws URISyntaxException, HttpException{
+		Response response = HttpUtil.put(URL,  USERNAME, PASSWORD);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void put_uri_empty_auth_cred() throws URISyntaxException, HttpException{
 		Response response = HttpUtil.put(URI, CREDENTIALS);
 		assertNotNull(response);
 	}
 
 	@Test
-	public void put_url_empty_auth() throws URISyntaxException, HttpException{
+	public void put_url_empty_auth_cred() throws URISyntaxException, HttpException{
 		Response response = HttpUtil.put(URL, CREDENTIALS);
 		assertNotNull(response);
 	}
@@ -312,7 +394,13 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	public void put_uri_body_auth() throws URISyntaxException, HttpException{
+	public void put_uri_body_auth_pw() throws URISyntaxException, HttpException{
+		Response response = HttpUtil.put(URI, POST_XML_BODY, POST_XML_BODY_CONTENT_TYPE, USERNAME, PASSWORD);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void put_uri_body_auth_cred() throws URISyntaxException, HttpException{
 		Response response = HttpUtil.put(URI, POST_XML_BODY, POST_XML_BODY_CONTENT_TYPE, CREDENTIALS);
 		assertNotNull(response);
 	}
@@ -324,8 +412,70 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	public void put_url_body_auth() throws URISyntaxException, HttpException{
+	public void put_url_body_auth_pw() throws URISyntaxException, HttpException{
+		Response response = HttpUtil.put(URL, POST_XML_BODY, POST_XML_BODY_CONTENT_TYPE, USERNAME, PASSWORD);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void put_url_body_auth_cred() throws URISyntaxException, HttpException{
 		Response response = HttpUtil.put(URL, POST_XML_BODY, POST_XML_BODY_CONTENT_TYPE, CREDENTIALS);
+		assertNotNull(response);
+	}
+
+	/**
+	 * username and password may not be null
+	 * @throws URISyntaxException
+	 * @throws HttpException
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void checkIllegalArgumentException_all() throws URISyntaxException, HttpException{
+		HttpUtil.get(URL, null, null);
+	}
+
+	/**
+	 * username may not be null
+	 * @throws URISyntaxException
+	 * @throws HttpException
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void checkIllegalArgumentException_user() throws URISyntaxException, HttpException{
+		HttpUtil.get(URL, null, PASSWORD);
+	}
+
+	@Test
+	public void delete_url() throws URISyntaxException, HttpException{
+		Response response = HttpUtil.delete(URL);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void delete_uri() throws URISyntaxException, HttpException{
+		Response response = HttpUtil.delete(URI);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void delete_url_auth_pw() throws URISyntaxException, HttpException{
+		Response response = HttpUtil.delete(URL, USERNAME, PASSWORD);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void delete_uri_auth_pw() throws URISyntaxException, HttpException{
+		Response response = HttpUtil.delete(URI, USERNAME, PASSWORD);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void delete_url_auth_cred() throws URISyntaxException, HttpException{
+		Response response = HttpUtil.delete(URL, CREDENTIALS);
+		assertNotNull(response);
+	}
+
+	@Test
+	public void delete_uri_auth_cred() throws URISyntaxException, HttpException{
+		Response response = HttpUtil.delete(URI, CREDENTIALS);
 		assertNotNull(response);
 	}
 


### PR DESCRIPTION
This PR replaces the `String` parameters for username and password passed to the `BasicCredentialsProvider` in `send(...)` method by the [`Credentials`](https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/auth/Credentials.html)  interface.

For example, for simple username and password credentials, the implementing class `UsernamePasswordCredentials` can be used.

