### PR TITLE
Extend button model and add dao/service/controller

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/ButtonDao.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/ButtonDao.java
@@ -1,0 +1,28 @@
+package de.terrestris.shogun2.dao;
+
+import org.springframework.stereotype.Repository;
+
+import de.terrestris.shogun2.model.module.Button;
+
+@Repository("buttonDao")
+public class ButtonDao<E extends Button> extends
+		GenericHibernateDao<E, Integer> {
+
+	/**
+	 * Public default constructor for this DAO.
+	 */
+	@SuppressWarnings("unchecked")
+	public ButtonDao() {
+		super((Class<E>) Button.class);
+	}
+
+	/**
+	 * Constructor that has to be called by subclasses.
+	 *
+	 * @param clazz
+	 */
+	protected ButtonDao(Class<E> clazz) {
+		super(clazz);
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Button.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Button.java
@@ -11,6 +11,8 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import de.terrestris.shogun2.model.Application;
+
 /**
  * The Image Module is the Ext JS representation of an HTML img element.
  *
@@ -30,23 +32,23 @@ public class Button extends Module {
 	 * A text to display on the button.
 	 */
 	private String text;
-	
+
 	/**
 	 * The text showing up when hovering the button.
 	 */
 	private String tooltip;
-	
+
 	/**
 	 * A glyph String to display an iconFont sign. e.g. 'xf059@FontAwesome'
 	 */
 	private String glyph;
-	
+
 	/**
 	 * The module which is connected to the button, if action OPENMODULEWINDOW
-	 * set. 
+	 * set.
 	 */
 	private Module connectedModule;
-	
+
 	/**
 	 * If action TOGGLEINTERACTION is set: This string represents the ol3
 	 * interaction class. e.g. 'ol.interaction.DragZoom'
@@ -55,29 +57,35 @@ public class Button extends Module {
 
 	/**
 	 * The buttonAction describes the action/handler of the button.
-	 * 
+	 *
 	 * The String can be any of the ButtonClasses available in the
 	 * BasiGX Package (https://github.com/terrestris/BasiGX).
 	 * e.g. "ToggleLegend"
 	 * Use "Measurearea" or "Measureline" to specify the type of the
 	 * BasiGX.view.button.Measure.
-	 * 
+	 *
 	 * Additional there are two ActionTypes to be more flexible:
-	 * 
+	 *
 	 * OPENMODULEWINDOW (this.connectedModule required)
 	 *    Opens any module in an Ext.window.Window.
 	 * TOGGLEINTERACTION (this.interaction required)
 	 *    Toggles the functionality of an OpenLayers 3 interaction.
 	 */
 	private String buttonAction;
-	
+
+	/**
+	 * Whether or not this button is a default tool in an {@link Application}.
+	 *
+	 */
+	private Boolean defaultButton;
+
 	/**
 	 * Explicitly adding the default constructor as this is important, e.g. for
 	 * Hibernate: http://goo.gl/3Cr1pw
 	 */
 	public Button() {
 	}
-	
+
 	/**
 	 * @return the text
 	 */
@@ -163,6 +171,20 @@ public class Button extends Module {
 	}
 
 	/**
+	 * @return the defaultButton
+	 */
+	public Boolean getDefaultButton() {
+		return defaultButton;
+	}
+
+	/**
+	 * @param defaultButton the defaultButton to set
+	 */
+	public void setDefaultButton(Boolean defaultButton) {
+		this.defaultButton = defaultButton;
+	}
+
+	/**
 	 * @see java.lang.Object#hashCode()
 	 *
 	 *      According to
@@ -180,6 +202,7 @@ public class Button extends Module {
 				append(getConnectedModule()).
 				append(getInteraction()).
 				append(getButtonAction()).
+				append(getDefaultButton()).
 				toHashCode();
 	}
 
@@ -204,6 +227,7 @@ public class Button extends Module {
 				append(getConnectedModule(), other.getConnectedModule()).
 				append(getInteraction(), other.getInteraction()).
 				append(getButtonAction(), other.getButtonAction()).
+				append(getDefaultButton(), other.getDefaultButton()).
 				isEquals();
 	}
 

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/ButtonRestController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/ButtonRestController.java
@@ -1,0 +1,48 @@
+package de.terrestris.shogun2.rest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import de.terrestris.shogun2.dao.ButtonDao;
+import de.terrestris.shogun2.model.module.Button;
+import de.terrestris.shogun2.service.ButtonService;
+
+/**
+ * @author Nils Bühner
+ *
+ */
+@RestController
+@RequestMapping("/buttons")
+public class ButtonRestController<E extends Button, D extends ButtonDao<E>, S extends ButtonService<E, D>>
+		extends AbstractRestController<E, D, S> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public ButtonRestController() {
+		this((Class<E>) Button.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected ButtonRestController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct service here.
+	 * Otherwise, spring can not decide which service has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("buttonService")
+	public void setService(S service) {
+		this.service = service;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/ButtonService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/ButtonService.java
@@ -1,0 +1,48 @@
+package de.terrestris.shogun2.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import de.terrestris.shogun2.dao.ButtonDao;
+import de.terrestris.shogun2.model.module.Button;
+
+/**
+ * Service class for the {@link Button} model.
+ *
+ * @author Nils Bühner
+ * @see AbstractCrudService
+ *
+ */
+@Service("buttonService")
+public class ButtonService<E extends Button, D extends ButtonDao<E>> extends
+		PermissionAwareCrudService<E, D> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public ButtonService() {
+		this((Class<E>) Button.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the service.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected ButtonService(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct dao here.
+	 * Otherwise, spring can not decide which dao has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("buttonDao")
+	public void setDao(D dao) {
+		this.dao = dao;
+	}
+}


### PR DESCRIPTION
This commit adds a new Boolean property to the button model: `defaultButton`
The value of this property defines whether a button is a default button in an Application or not (i.e. an optional/configurable one).

Within this PR the missing DAO/Service/Controller are also added.