### PR TITLE
Introduce a simple rest filter

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
@@ -10,10 +10,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,6 +57,27 @@ public abstract class AbstractRestController<E extends PersistentObject, D exten
 	@RequestMapping(method = RequestMethod.GET)
 	public ResponseEntity<List<E>> findAll() {
 		final List<E> resultList = this.service.findAll();
+
+		if (resultList != null && !resultList.isEmpty()) {
+			LOG.trace("Found a total of " + resultList.size()
+					+ " entities of type "
+					+ resultList.get(0).getClass().getSimpleName());
+		}
+
+		return new ResponseEntity<List<E>>(resultList, HttpStatus.OK);
+	}
+
+	/**
+	 * Find all entities that match the conditions from the query string.
+	 * 
+	 * The requestParams MultiValueMap contains all information from the query String @see {@link RequestParam}
+	 * 
+	 * @return
+	 */
+	@RequestMapping(value = "/filter", method = RequestMethod.GET)
+	public ResponseEntity<List<E>> findBySimpleFilter(@RequestParam MultiValueMap<String,String> requestParams) {
+
+		final List<E> resultList = this.service.findBySimpleFilter(requestParams);
 
 		if (resultList != null && !resultList.isEmpty()) {
 			LOG.trace("Found a total of " + resultList.size()

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractCrudService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractCrudService.java
@@ -1,11 +1,18 @@
 package de.terrestris.shogun2.service;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.criterion.Conjunction;
+import org.hibernate.criterion.Criterion;
+import org.hibernate.criterion.Disjunction;
+import org.hibernate.criterion.Restrictions;
+import org.hibernate.criterion.SimpleExpression;
 import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.util.MultiValueMap;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -13,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.terrestris.shogun2.dao.GenericHibernateDao;
 import de.terrestris.shogun2.model.PersistentObject;
+import de.terrestris.shogun2.util.entity.EntityUtil;
 
 /**
  * This abstract service class provides basic CRUD functionality.
@@ -91,6 +99,75 @@ public abstract class AbstractCrudService<E extends PersistentObject, D extends 
 	@PostFilter("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(filterObject, 'READ')")
 	public List<E> findAll() {
 		return dao.findAll();
+	}
+
+	/**
+	 * Finds all entities that match the given filter (multi value map).
+	 *
+	 * Each key in the multi value map is the name of a field/property of the
+	 * entity. These values may be case insensitive! Each field name is mapped
+	 * to a list of values (passed as Strings).
+	 *
+	 * Fields that do not exist in the entity will be ignored.
+	 *
+	 * Example:
+	 *
+	 * int=['1','2']
+	 * string=['foo']
+	 * bool1=['0']
+	 * bool2=['true']
+	 *
+	 * would be translated to a filter like (values are casted to the target type of the field)
+	 *
+	 * (int == 1 || int == 2) && (string == 'foo') && (bool1 == false) && (bool2 == true)
+	 *
+	 * and return all entities that match this condition.
+	 *
+	 * This will only work on simple properties of an entity.
+	 *
+	 * @param requestedFilter
+	 * @return
+	 */
+	@PostFilter("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(filterObject, 'READ')")
+	public List<E> findBySimpleFilter(MultiValueMap<String,String> requestedFilter) {
+
+		MultiValueMap<String, Object> origFieldNamesToCastedValues = EntityUtil
+				.validFieldNamesWithCastedValues(requestedFilter, getEntityClass());
+
+		// start with an empty list
+		List<E> results = new ArrayList<>();
+
+		List<Criterion> orPredicates = new ArrayList<>();
+
+		if(origFieldNamesToCastedValues != null && !origFieldNamesToCastedValues.isEmpty()) {
+
+			for (String fieldName : origFieldNamesToCastedValues.keySet()) {
+				List<Object> fieldValues = origFieldNamesToCastedValues.get(fieldName);
+
+				// if there are multiple values for a field name, we'll check
+				// for equality and connect them with OR
+				List<Criterion> eqExpressions = new ArrayList<>();
+
+				for (Object fieldValue : fieldValues) {
+					final SimpleExpression eq = Restrictions.eq(fieldName, fieldValue);
+					eqExpressions.add(eq);
+				}
+
+				if(!eqExpressions.isEmpty()) {
+					final Criterion[] eqArray = eqExpressions.toArray(new Criterion[0]);
+					final Disjunction or = Restrictions.or(eqArray);
+					orPredicates.add(or);
+				}
+			}
+
+			if(!orPredicates.isEmpty()) {
+				final Criterion[] orArray = orPredicates.toArray(new Criterion[0]);
+				final Conjunction and = Restrictions.and(orArray);
+				results = dao.findByCriteria(and);
+			}
+		}
+
+		return results;
 	}
 
 	/**

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/entity/EntityUtil.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/entity/EntityUtil.java
@@ -1,0 +1,100 @@
+package de.terrestris.shogun2.util.entity;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.beanutils.ConvertUtils;
+import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+/**
+ *
+ * @author Nils Bühner
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class EntityUtil {
+
+	/**
+	 * This method returns a multi value map, where the keys are the
+	 * intersection of (non-static private) field names of the given entity
+	 * class and the given set of requested/input field names (which are the
+	 * keys of the passed multi value map), i.e. fields in the input that are
+	 * not present in the entity model definition will be removed/ignored in
+	 * this method.
+	 *
+	 * Regarding case sensitivity, the field names that are building the keys of
+	 * the result map are used in their original representation/definition from
+	 * the entity model, but the keys/fieldnames in the input may be
+	 * case-insensitive.
+	 *
+	 * The value for each key is a list of casted (!) values of the string
+	 * values of the given input map. The type of the field in the entity is
+	 * used to determine the correct casting.
+	 *
+	 *
+	 * @param requestedFilter
+	 * @param entityClass
+	 * @return
+	 */
+	public static MultiValueMap<String, Object> validFieldNamesWithCastedValues(MultiValueMap<String, String> requestedFilter, Class<?> entityClass) {
+
+		Set<String> inputFieldNames = requestedFilter.keySet();
+
+		List<Field> allFields = FieldUtils.getAllFieldsList(entityClass);
+
+		// Regarding case insensitivity: build a map that maps from the input field name to its original field name,
+		// but add only those fields to the map that exist in the entity
+		Map<String, String> validInputFieldNameToOrigFieldName = new HashMap<>();
+
+		for (Field field : allFields) {
+			final Class<?> fieldType = field.getType();
+			final String fieldName = field.getName();
+			final int fieldModifiers = field.getModifiers();
+
+			final boolean isPrimitiveOrWrapper = ClassUtils.isPrimitiveOrWrapper(fieldType);
+			final boolean isString = fieldType.equals(String.class);
+			final boolean isStatic = Modifier.isStatic(fieldModifiers);
+			final boolean isPrivate = Modifier.isPrivate(fieldModifiers);
+
+			// extract only non-static private fields that are primitive or
+			// primitive wrapper types or String
+			if((isPrimitiveOrWrapper || isString) && isPrivate && !isStatic) {
+
+				// find the corresponding field in the input
+				for(String inputFieldName : inputFieldNames) {
+					if(fieldName.toLowerCase().equals(inputFieldName.toLowerCase())) {
+						validInputFieldNameToOrigFieldName.put(inputFieldName, fieldName);
+						break;
+					}
+				}
+			}
+		}
+
+		MultiValueMap<String, Object> result = new LinkedMultiValueMap<>();
+
+		Set<String> validInputFieldNames = validInputFieldNameToOrigFieldName.keySet();
+
+		for (String validInputFieldName : validInputFieldNames) {
+			String origInputFieldName = validInputFieldNameToOrigFieldName.get(validInputFieldName);
+
+			List<String> stringValues = requestedFilter.get(validInputFieldName);
+
+			// cast to the correct type to avoid hibernate exceptions when querying db or similar
+			for (String fieldStringValue : stringValues) {
+					Field f = FieldUtils.getField(entityClass, origInputFieldName, true);
+					Class<?> fieldType = f.getType();
+					Object castedValue = ConvertUtils.convert(fieldStringValue, fieldType);
+					result.add(origInputFieldName, castedValue);
+			}
+		}
+
+		return result ;
+	}
+}


### PR DESCRIPTION
This PR introduces a new rest GET interface `/rest/{myEntity}/filter` which allows basic/simple filtering based on primitve fields of (arbitrary) entities.

Examples:
- `/rest/modules/filter?name=test`
  - would return all modules with module.name = 'test'
- `/rest/modules/filter?id=17&name=mymodule`
  - would be translated to a filter `id == 17 AND name =='mymodule'`
- `/rest/modules/filter?name=n1&name=n2&xTYpe=foo`
  - would be translated to a filter `(name == 'n1' OR name == 'n2') AND (xtype == 'foo')'`

This will only provide basic filtering possibilities as this currently only works on simple properties of entities.

In case of boolean fields, the values in the query string may be `true` or `1` (or `false`/`0`).

If you try to filter on attribute names that dont exist in the target entity, they will be ignored!

Attribute names in the query string may be case insensitive (currently with one known exception: if you use a fieldname multiple times in the query string, the field name should always be exactly the same within the query string. so the following query string would not lead to an expected result currently: `filter?NAme=n1&naME=n2&xtype=foo`)

Tests for this PR may follow in the next week :wink: 
