### PR TITLE
Remove unused auth provider

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/init/ContentInitializer.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/init/ContentInitializer.java
@@ -7,7 +7,6 @@ import javax.annotation.Resource;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.security.authentication.AuthenticationProvider;
 
 import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.model.User;
@@ -39,14 +38,6 @@ public class ContentInitializer {
 	 */
 	@Autowired
 	protected InitializationService initService;
-
-	/**
-	 * We use the authenticationProvider to login with the admin user, that will
-	 * be created in this initializer.
-	 */
-	@Autowired
-	@Qualifier("shogun2AuthenticationProvider")
-	protected AuthenticationProvider authenticationProvider;
 
 	/**
 	 * The list of objects that shall be persisted.


### PR DESCRIPTION
This removes a definition of the `AuthenticationProvider`, which is *never* used in the `ContentInitializer`, but may lead to problems when you do not have a bean of the SHOGun2 auth provider (but some other kind of authentication like pre-auth by http header info).

Please merge if you dont have any concerns!