### PR TITLE
Make method public to access it easily

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
@@ -359,7 +359,7 @@ public class GeoServerInterceptorService {
 	 * @throws URISyntaxException
 	 * @throws InterceptorException
 	 */
-	private URI getGeoServerBaseURIFromNameSpace(String geoServerNamespace)
+	public URI getGeoServerBaseURIFromNameSpace(String geoServerNamespace)
 			throws URISyntaxException, InterceptorException {
 
 		URI uri = null;


### PR DESCRIPTION
Make this method public to have an easier access to the namespace <-> baseURI mapping.