### PR TITLE
Add support for WFS2 typeNames attribute

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/enumeration/OgcEnum.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/enumeration/OgcEnum.java
@@ -126,6 +126,7 @@ public class OgcEnum {
 		LAYERS("LAYERS"),
 		LAYER("LAYER"),
 		TYPENAME("TYPENAME"),
+		TYPENAMES("TYPENAMES"),
 		NAMESPACE("NAMESPACE");
 
 		private final String value;

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequest.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequest.java
@@ -139,11 +139,11 @@ public class MutableHttpServletRequest extends HttpServletRequestWrapper {
 					}
 
 				} else if (Arrays.asList(OgcEnum.EndPoint.getAllValues()).contains(parameter)) {
-					value = OgcXmlUtil.getPathInDocument(
-							document, "//TypeName/text()");
+					value = OgcXmlUtil.getPathInDocument(document,
+							"//TypeName/text() | //TypeNames/text()");
 					if (StringUtils.isEmpty(value)) {
 						value = OgcXmlUtil.getPathInDocument(document,
-								"//@typeName");
+								"//@typeName | //@typeNames");
 					}
 				}
 


### PR DESCRIPTION
With this adaption the request payload interceptor will be able to detect the WFS 2.0 attribute/node named `typeNames`.