### PR TITLE
Detect the coverage identifier in a WCS POST request

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequest.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequest.java
@@ -140,7 +140,7 @@ public class MutableHttpServletRequest extends HttpServletRequestWrapper {
 
 				} else if (Arrays.asList(OgcEnum.EndPoint.getAllValues()).contains(parameter)) {
 					value = OgcXmlUtil.getPathInDocument(document,
-							"//TypeName/text() | //TypeNames/text()");
+							"//TypeName/text() | //TypeNames/text() | //GetCoverage/Identifier/text()");
 					if (StringUtils.isEmpty(value)) {
 						value = OgcXmlUtil.getPathInDocument(document,
 								"//@typeName | //@typeNames");


### PR DESCRIPTION
Enables detection of the `Identifier` attribute value in a WCS POST request in the interceptor. This is needed to get the mandatory request endpoint to require the namespace from. Otherwise the interceptor isn't capable to forward the request to the correct GeoServer base URL.

A minimal WCS GetCoverage request could look like this:
```xml
<wcs:GetCoverage service="WCS" version="1.1.1">            
  <ows:Identifier>myWorkspace:myLayer</ows:Identifier>            
  <wcs:DomainSubset>            
  </wcs:DomainSubset>            
  <wcs:Output format="image/tiff"/>          
</wcs:GetCoverage>
```