### PR TITLE
Make the presence of role information optional

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/UserService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/UserService.java
@@ -74,7 +74,7 @@ public class UserService<E extends User, D extends UserDao<E>> extends
 	 *
 	 * TODO: We should only autowire a string with the role name...
 	 */
-	@Autowired
+	@Autowired(required = false)
 	@Qualifier("userRole")
 	private Role defaultUserRole;
 
@@ -162,13 +162,16 @@ public class UserService<E extends User, D extends UserDao<E>> extends
 		E user = (E) token.getUser();
 		user.setActive(true);
 
-		// get the persisted default user role
-		final String defaultRoleName = getDefaultUserRole().getName();
-		Role persistedDefaultUserRole = roleService
-				.findByRoleName(defaultRoleName);
+		// set the persisted default user role if available
+		if(defaultUserRole != null) {
+			final String defaultRoleName = defaultUserRole.getName();
+			Role persistedDefaultUserRole = roleService.findByRoleName(defaultRoleName);
 
-		// assign the default user role
-		user.getRoles().add(persistedDefaultUserRole);
+			if (persistedDefaultUserRole != null) {
+				// assign the default user role
+				user.getRoles().add(persistedDefaultUserRole);
+			}
+		}
 
 		// update the user
 		dao.saveOrUpdate((E) user);

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/config/ConfigHolder.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/config/ConfigHolder.java
@@ -13,10 +13,20 @@ import org.springframework.stereotype.Component;
 @Component("configHolder")
 public class ConfigHolder {
 
-	@Value("${role.superAdminRoleName}")
+	/**
+	 * The name of the (super) admin role. If the property configured in the
+	 * {@link Value} annotation is not present, the empty string "" will be used
+	 * as a fallback.
+	 */
+	@Value("${role.superAdminRoleName:}")
 	private String superAdminRoleName;
 
-	@Value("${role.defaultUserRoleName}")
+	/**
+	 * The name of the default user role. If the property configured in the
+	 * {@link Value} annotation is not present, the empty string "" will be used
+	 * as a fallback.
+	 */
+	@Value("${role.defaultUserRoleName:}")
 	private String defaultUserRoleName;
 
 	/**


### PR DESCRIPTION
The framework was very rigid regarding the presence of role information coming from the configuration. But as soon as role information is coming dynamically from external sources, this makes it hard to get rid of this (in those cases unnecessary/useless) configuration.

This PR simplifies this by making the presence of configurable role information optional.