### PR TITLE
Make use of plain principal object in permission evaluation configurable

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/security/access/Shogun2PermissionEvaluator.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/security/access/Shogun2PermissionEvaluator.java
@@ -77,8 +77,10 @@ public class Shogun2PermissionEvaluator implements PermissionEvaluator {
 
 			User user = null;
 
-			if(authentication.getPrincipal() instanceof User) {
-				final User principal = (User) authentication.getPrincipal();
+			final Object principalObject = authentication.getPrincipal();
+
+			if(principalObject instanceof User) {
+				final User principal = (User) principalObject;
 
 				if(usePlainPrincipal == true) {
 					user = principal;

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/security/access/Shogun2PermissionEvaluator.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/security/access/Shogun2PermissionEvaluator.java
@@ -42,6 +42,19 @@ public class Shogun2PermissionEvaluator implements PermissionEvaluator {
 	private UserDao<User> userDao;
 
 	/**
+	 * If set to true, the plain principal object from the spring security
+	 * context will be used as "user". Otherwise the "full" user object will be
+	 * loaded from the SHOGun2 database.
+	 *
+	 * It may be helpful to set this to true, if the user/principal object from
+	 * the security context contains information that is not persisted in the
+	 * database.
+	 *
+	 * Setting this to the null value is the same as using "false".
+	 */
+	private Boolean usePlainPrincipal = false;
+
+	/**
 	 *
 	 */
 	@SuppressWarnings("rawtypes")
@@ -65,8 +78,14 @@ public class Shogun2PermissionEvaluator implements PermissionEvaluator {
 			User user = null;
 
 			if(authentication.getPrincipal() instanceof User) {
-				// get the "full" user from the database
-				user = userDao.findById(((User) authentication.getPrincipal()).getId());
+				final User principal = (User) authentication.getPrincipal();
+
+				if(usePlainPrincipal == true) {
+					user = principal;
+				} else {
+					// get the "full" user from the database
+					user = userDao.findById(principal.getId());
+				}
 			}
 
 			final PersistentObject persistentObject = (PersistentObject) targetDomainObject;
@@ -177,6 +196,20 @@ public class Shogun2PermissionEvaluator implements PermissionEvaluator {
 	 */
 	public void setUserDao(UserDao<User> userDao) {
 		this.userDao = userDao;
+	}
+
+	/**
+	 * @return the usePlainPrincipal
+	 */
+	public Boolean getUsePlainPrincipal() {
+		return usePlainPrincipal;
+	}
+
+	/**
+	 * @param usePlainPrincipal the usePlainPrincipal to set
+	 */
+	public void setUsePlainPrincipal(Boolean usePlainPrincipal) {
+		this.usePlainPrincipal = usePlainPrincipal;
 	}
 
 	/**


### PR DESCRIPTION
The `Shogun2PermissionEvaluator` always fetched the full user object from the database. But in cases where your `Principal` from the spring security context (which usually is a SHOGun2 user instance) holds temporary information that is not persisted in the database but required for the permission evaluation, you may want to use the plain principal object from the security context instead of retrieving the full user from the database.

This PR makes this configurable (i.e. you now can set the `usePlainPrincipal` property to `true` in your security XML).

Existing projects should not be affected by this change as the default for this value is `false`, which leads to the same behavior as before.