### PR TITLE
WPS plugins

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/converter/PluginIdResolver.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/converter/PluginIdResolver.java
@@ -1,0 +1,25 @@
+package de.terrestris.shogun2.converter;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import de.terrestris.shogun2.dao.PluginDao;
+import de.terrestris.shogun2.model.Plugin;
+import de.terrestris.shogun2.service.PluginService;
+
+/**
+ *
+ * @author Nils Buehner
+ *
+ */
+public class PluginIdResolver<E extends Plugin, D extends PluginDao<E>, S extends PluginService<E, D>> extends
+		PersistentObjectIdResolver<E, D, S> {
+
+	@Override
+	@Autowired
+	@Qualifier("pluginService")
+	public void setService(S service) {
+		this.service = service;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/PluginDao.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/PluginDao.java
@@ -1,0 +1,33 @@
+package de.terrestris.shogun2.dao;
+
+import org.springframework.stereotype.Repository;
+
+import de.terrestris.shogun2.model.Plugin;
+
+
+/**
+ *
+ * @author Nils Bühner
+ *
+ */
+@Repository("pluginDao")
+public class PluginDao<E extends Plugin>
+		extends GenericHibernateDao<E, Integer> {
+
+	/**
+	 * Public default constructor for this DAO.
+	 */
+	@SuppressWarnings("unchecked")
+	public PluginDao() {
+		super((Class<E>) Plugin.class);
+	}
+
+	/**
+	 * Constructor that has to be called by subclasses.
+	 *
+	 * @param clazz
+	 */
+	protected PluginDao(Class<E> clazz) {
+		super(clazz);
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/WpsParameterDao.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/WpsParameterDao.java
@@ -1,0 +1,33 @@
+package de.terrestris.shogun2.dao;
+
+import org.springframework.stereotype.Repository;
+
+import de.terrestris.shogun2.model.wps.WpsParameter;
+
+
+/**
+ *
+ * @author Nils Bühner
+ *
+ */
+@Repository("wpsParameterDao")
+public class WpsParameterDao<E extends WpsParameter>
+		extends GenericHibernateDao<E, Integer> {
+
+	/**
+	 * Public default constructor for this DAO.
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsParameterDao() {
+		super((Class<E>) WpsParameter.class);
+	}
+
+	/**
+	 * Constructor that has to be called by subclasses.
+	 *
+	 * @param clazz
+	 */
+	protected WpsParameterDao(Class<E> clazz) {
+		super(clazz);
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/WpsPluginDao.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/WpsPluginDao.java
@@ -1,0 +1,32 @@
+package de.terrestris.shogun2.dao;
+
+import org.springframework.stereotype.Repository;
+
+import de.terrestris.shogun2.model.wps.WpsPlugin;
+
+
+/**
+ *
+ * @author Nils Bühner
+ *
+ */
+@Repository("wpsPluginDao")
+public class WpsPluginDao<E extends WpsPlugin> extends PluginDao<E> {
+
+	/**
+	 * Public default constructor for this DAO.
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsPluginDao() {
+		super((Class<E>) WpsPlugin.class);
+	}
+
+	/**
+	 * Constructor that has to be called by subclasses.
+	 *
+	 * @param clazz
+	 */
+	protected WpsPluginDao(Class<E> clazz) {
+		super(clazz);
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/WpsPrimitiveDao.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/WpsPrimitiveDao.java
@@ -1,0 +1,32 @@
+package de.terrestris.shogun2.dao;
+
+import org.springframework.stereotype.Repository;
+
+import de.terrestris.shogun2.model.wps.WpsPrimitive;
+
+
+/**
+ *
+ * @author Nils Bühner
+ *
+ */
+@Repository("wpsPrimitiveDao")
+public class WpsPrimitiveDao<E extends WpsPrimitive> extends WpsParameterDao<E> {
+
+	/**
+	 * Public default constructor for this DAO.
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsPrimitiveDao() {
+		super((Class<E>) WpsPrimitive.class);
+	}
+
+	/**
+	 * Constructor that has to be called by subclasses.
+	 *
+	 * @param clazz
+	 */
+	protected WpsPrimitiveDao(Class<E> clazz) {
+		super(clazz);
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/WpsProcessExecuteDao.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/WpsProcessExecuteDao.java
@@ -1,0 +1,32 @@
+package de.terrestris.shogun2.dao;
+
+import org.springframework.stereotype.Repository;
+
+import de.terrestris.shogun2.model.wps.WpsProcessExecute;
+
+
+/**
+ *
+ * @author Nils Bühner
+ *
+ */
+@Repository("wpsProcessExecuteDao")
+public class WpsProcessExecuteDao<E extends WpsProcessExecute> extends WpsReferenceDao<E> {
+
+	/**
+	 * Public default constructor for this DAO.
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsProcessExecuteDao() {
+		super((Class<E>) WpsProcessExecute.class);
+	}
+
+	/**
+	 * Constructor that has to be called by subclasses.
+	 *
+	 * @param clazz
+	 */
+	protected WpsProcessExecuteDao(Class<E> clazz) {
+		super(clazz);
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/WpsReferenceDao.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/WpsReferenceDao.java
@@ -1,0 +1,32 @@
+package de.terrestris.shogun2.dao;
+
+import org.springframework.stereotype.Repository;
+
+import de.terrestris.shogun2.model.wps.WpsReference;
+
+
+/**
+ *
+ * @author Nils Bühner
+ *
+ */
+@Repository("wpsReferenceDao")
+public class WpsReferenceDao<E extends WpsReference> extends WpsParameterDao<E> {
+
+	/**
+	 * Public default constructor for this DAO.
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsReferenceDao() {
+		super((Class<E>) WpsReference.class);
+	}
+
+	/**
+	 * Constructor that has to be called by subclasses.
+	 *
+	 * @param clazz
+	 */
+	protected WpsReferenceDao(Class<E> clazz) {
+		super(clazz);
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Application.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Application.java
@@ -1,12 +1,18 @@
 package de.terrestris.shogun2.model;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
+import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -15,8 +21,12 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.joda.time.ReadableDateTime;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 
+import de.terrestris.shogun2.converter.PluginIdResolver;
 import de.terrestris.shogun2.model.module.CompositeModule;
 
 /**
@@ -76,6 +86,24 @@ public class Application extends PersistentObject {
 	 */
 	@ManyToOne
 	private CompositeModule viewport;
+
+	/**
+	 * The plugins available in this application
+	 */
+	@ManyToMany
+	@JoinTable(
+		joinColumns = { @JoinColumn(name = "APPLICATION_ID") },
+		inverseJoinColumns = { @JoinColumn(name = "PLUGIN_ID") }
+	)
+	@OrderColumn(name = "IDX")
+	// The List of layers will be serialized (JSON) as an array of ID values
+	@JsonIdentityInfo(
+		generator = ObjectIdGenerators.PropertyGenerator.class,
+		property = "id",
+		resolver = PluginIdResolver.class
+	)
+	@JsonIdentityReference(alwaysAsId = true)
+	private List<Plugin> plugins = new ArrayList<>();
 
 	/**
 	 * Explicitly adding the default constructor as this is important, e.g. for
@@ -170,6 +198,20 @@ public class Application extends PersistentObject {
 	 */
 	public void setViewport(CompositeModule viewport) {
 		this.viewport = viewport;
+	}
+
+	/**
+	 * @return the plugins
+	 */
+	public List<Plugin> getPlugins() {
+		return plugins;
+	}
+
+	/**
+	 * @param plugins the plugins to set
+	 */
+	public void setPlugins(List<Plugin> plugins) {
+		this.plugins = plugins;
 	}
 
 	/**

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Plugin.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Plugin.java
@@ -166,6 +166,8 @@ public class Plugin extends PersistentObject {
 			.append(getName())
 			.append(getClassName())
 			.append(getXtype())
+			.append(getSourceCode())
+			.append(getStyleSheet())
 			.toHashCode();
 	}
 
@@ -187,6 +189,8 @@ public class Plugin extends PersistentObject {
 			.append(getName(), other.getName())
 			.append(getClassName(), other.getClassName())
 			.append(getXtype(), other.getXtype())
+			.append(getSourceCode(), other.getSourceCode())
+			.append(getStyleSheet(), other.getStyleSheet())
 			.isEquals();
 	}
 
@@ -200,6 +204,8 @@ public class Plugin extends PersistentObject {
 			.append("name", name)
 			.append("className", className)
 			.append("xtype", xtype)
+			.append("sourcecode", sourceCode)
+			.append("stylesheet", styleSheet)
 			.toString();
 	}
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Plugin.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Plugin.java
@@ -20,7 +20,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 /**
- * 
+ *
  */
 @Entity
 @Table
@@ -28,9 +28,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 public class Plugin extends PersistentObject {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 1L;
+
+	/** A name (or display name) */
+	private String name;
 
 	/** the class name of the plugin **/
 	private String className;
@@ -59,6 +62,20 @@ public class Plugin extends PersistentObject {
 	 * Constructor
 	 */
 	public Plugin() {
+	}
+
+	/**
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @param name the name to set
+	 */
+	public void setName(String name) {
+		this.name = name;
 	}
 
 	/**
@@ -144,6 +161,7 @@ public class Plugin extends PersistentObject {
 	public int hashCode() {
 		return new HashCodeBuilder(47, 19) // two randomly chosen prime numbers
 			.appendSuper(super.hashCode())
+			.append(getName())
 			.append(getClassName())
 			.append(getXtype())
 			.toHashCode();
@@ -164,6 +182,7 @@ public class Plugin extends PersistentObject {
 
 		return new EqualsBuilder()
 			.appendSuper(super.equals(other))
+			.append(getName(), other.getName())
 			.append(getClassName(), other.getClassName())
 			.append(getXtype(), other.getXtype())
 			.isEquals();
@@ -176,6 +195,7 @@ public class Plugin extends PersistentObject {
 	public String toString(){
 		return new ToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE)
 			.appendSuper(super.toString())
+			.append("name", name)
 			.append("className", className)
 			.append("xtype", xtype)
 			.toString();

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Plugin.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Plugin.java
@@ -1,0 +1,183 @@
+package de.terrestris.shogun2.model;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * 
+ */
+@Entity
+@Table
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+public class Plugin extends PersistentObject {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	/** the class name of the plugin **/
+	private String className;
+
+	/** the xtype of the plugin **/
+	private String xtype;
+
+	/** the JavaScript (JS) code of the plugin **/
+	@Column(length = Integer.MAX_VALUE)
+	private String sourceCode;
+
+	/** the Cascading Style Sheets (CSS) of the plugin **/
+	@Column(length = Integer.MAX_VALUE)
+	private String styleSheet;
+
+	/** A list of assigned {@link PluginUploadFile}s. */
+	@ManyToMany
+	@JoinTable(
+		joinColumns = { @JoinColumn(name = "PLUGIN_ID") },
+		inverseJoinColumns = { @JoinColumn(name = "FILE_ID") }
+	)
+	@JsonIgnore
+	private Set<File> fileUploads = new HashSet<File>();
+
+	/**
+	 * Constructor
+	 */
+	public Plugin() {
+	}
+
+	/**
+	 * @return the className
+	 */
+	@Column(unique = true, nullable = false)
+	public String getClassName() {
+		return className;
+	}
+
+	/**
+	 * @param className the className to set
+	 */
+	public void setClassName(String className) {
+		this.className = className;
+	}
+
+	/**
+	 * @return the xtype
+	 */
+	@Column(unique = true, nullable = false)
+	public String getXtype() {
+		return xtype;
+	}
+
+	/**
+	 * @param xtype the xtype to set
+	 */
+	public void setXtype(String xtype) {
+		this.xtype = xtype;
+	}
+
+	/**
+	 * @return the sourceCode
+	 */
+	public String getSourceCode() {
+		return sourceCode;
+	}
+
+	/**
+	 * @param sourceCode the sourceCode to set
+	 */
+	public void setSourceCode(String sourceCode) {
+		this.sourceCode = sourceCode;
+	}
+
+	/**
+	 * @return the styleSheet
+	 */
+	public String getStyleSheet() {
+		return styleSheet;
+	}
+
+	/**
+	 * @param styleSheet the styleSheet to set
+	 */
+	public void setStyleSheet(String styleSheet) {
+		this.styleSheet = styleSheet;
+	}
+
+	/**
+	 * @return the fileUploads
+	 */
+	public Set<File> getFileUploads() {
+		return fileUploads;
+	}
+
+	/**
+	 * @param fileUploads the fileUploads to set
+	 */
+	public void setFileUploads(Set<File> fileUploads) {
+		this.fileUploads = fileUploads;
+	}
+
+	/**
+	 * @see java.lang.Object#hashCode()
+	 *
+	 * According to
+	 * http://stackoverflow.com/questions/27581/overriding-equals-and-hashcode-in-java
+	 * it is recommended only to use getter-methods when using ORM like Hibernate
+	 */
+	@Override
+	public int hashCode() {
+		return new HashCodeBuilder(47, 19) // two randomly chosen prime numbers
+			.appendSuper(super.hashCode())
+			.append(getClassName())
+			.append(getXtype())
+			.toHashCode();
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 *
+	 * According to
+	 * http://stackoverflow.com/questions/27581/overriding-equals-and-hashcode-in-java
+	 * it is recommended only to use getter-methods when using ORM like Hibernate
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof Plugin))
+			return false;
+		Plugin other = (Plugin) obj;
+
+		return new EqualsBuilder()
+			.appendSuper(super.equals(other))
+			.append(getClassName(), other.getClassName())
+			.append(getXtype(), other.getXtype())
+			.isEquals();
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public String toString(){
+		return new ToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE)
+			.appendSuper(super.toString())
+			.append("className", className)
+			.append("xtype", xtype)
+			.toString();
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Plugin.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Plugin.java
@@ -36,9 +36,11 @@ public class Plugin extends PersistentObject {
 	private String name;
 
 	/** the class name of the plugin **/
+	@Column(unique = true)
 	private String className;
 
 	/** the xtype of the plugin **/
+	@Column(unique = true)
 	private String xtype;
 
 	/** the JavaScript (JS) code of the plugin **/

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsParameter.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsParameter.java
@@ -1,0 +1,110 @@
+package de.terrestris.shogun2.model.wps;
+
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import de.terrestris.shogun2.model.PersistentObject;
+
+/**
+ * 
+ */
+@Entity
+@JsonTypeInfo(
+	use = JsonTypeInfo.Id.MINIMAL_CLASS,
+	include = JsonTypeInfo.As.PROPERTY,
+	property = "classType",
+	visible = true
+)
+//@JsonSubTypes({
+//		@Type(value = PointGeometry.class, name = "Point"),
+//		@Type(value = LineGeometry.class, name = "LineString"),
+//		@Type(value = PolygonGeometry.class, name = "Polygon")
+//})
+@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+public abstract class WpsParameter extends PersistentObject {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 *
+	 */
+	private String valueType;
+
+	/**
+	 * Constructor
+	 */
+	public WpsParameter() {
+	}
+
+
+	/**
+	 * @return the valueType
+	 */
+	public String getValueType() {
+		return valueType;
+	}
+
+
+	/**
+	 * @param valueType the valueType to set
+	 */
+	public void setValueType(String valueType) {
+		this.valueType = valueType;
+	}
+
+	/**
+	 * @see java.lang.Object#hashCode()
+	 *
+	 * According to
+	 * http://stackoverflow.com/questions/27581/overriding-equals-and-hashcode-in-java
+	 * it is recommended only to use getter-methods when using ORM like Hibernate
+	 */
+	@Override
+	public int hashCode() {
+		return new HashCodeBuilder(19, 47) // two randomly chosen prime numbers
+			.appendSuper(super.hashCode())
+			.append(getValueType())
+			.toHashCode();
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 *
+	 * According to
+	 * http://stackoverflow.com/questions/27581/overriding-equals-and-hashcode-in-java
+	 * it is recommended only to use getter-methods when using ORM like Hibernate
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof WpsParameter))
+			return false;
+		WpsParameter other = (WpsParameter) obj;
+
+		return new EqualsBuilder()
+			.appendSuper(super.equals(other))
+			.append(getValueType(), other.getValueType())
+			.isEquals();
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public String toString(){
+		return new ToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE)
+			.appendSuper(super.toString())
+			.append("valueType", valueType)
+			.toString();
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsParameter.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsParameter.java
@@ -9,27 +9,24 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
 import de.terrestris.shogun2.model.PersistentObject;
 
 /**
- * 
+ *
  */
 @Entity
-@JsonTypeInfo(
-	use = JsonTypeInfo.Id.MINIMAL_CLASS,
-	include = JsonTypeInfo.As.PROPERTY,
-	property = "classType",
-	visible = true
-)
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
 public abstract class WpsParameter extends PersistentObject {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 1L;
+
+	/**
+	 *
+	 */
+	private final String classType;
 
 	/**
 	 *
@@ -40,6 +37,15 @@ public abstract class WpsParameter extends PersistentObject {
 	 * Constructor
 	 */
 	public WpsParameter() {
+		this.classType = getClass().getSimpleName();
+	}
+
+
+	/**
+	 * @return the classType
+	 */
+	public String getClassType() {
+		return classType;
 	}
 
 

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsParameter.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsParameter.java
@@ -9,6 +9,10 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import de.terrestris.shogun2.model.PersistentObject;
 
 /**
@@ -16,6 +20,15 @@ import de.terrestris.shogun2.model.PersistentObject;
  */
 @Entity
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@JsonTypeInfo(
+		use = JsonTypeInfo.Id.NAME,
+		property = "classType"
+)
+@JsonSubTypes({
+		@Type(value = WpsPrimitive.class, name = "WpsPrimitive"),
+		@Type(value = WpsReference.class, name = "WpsReference"),
+		@Type(value = WpsProcessExecute.class, name = "WpsProcessExecute")
+})
 public abstract class WpsParameter extends PersistentObject {
 
 	/**

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsParameter.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsParameter.java
@@ -23,11 +23,6 @@ import de.terrestris.shogun2.model.PersistentObject;
 	property = "classType",
 	visible = true
 )
-//@JsonSubTypes({
-//		@Type(value = PointGeometry.class, name = "Point"),
-//		@Type(value = LineGeometry.class, name = "LineString"),
-//		@Type(value = PolygonGeometry.class, name = "Polygon")
-//})
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
 public abstract class WpsParameter extends PersistentObject {
 

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsPlugin.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsPlugin.java
@@ -1,0 +1,118 @@
+package de.terrestris.shogun2.model.wps;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import de.terrestris.shogun2.model.Plugin;
+
+/**
+ * 
+ */
+@Entity
+@Table
+public class WpsPlugin extends Plugin {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * 
+	 */
+	private String name;
+
+	/**
+	 * 
+	 */
+	private WpsProcessExecute process;
+
+	/**
+	 * Constructor
+	 */
+	public WpsPlugin() {
+	}
+
+
+	/**
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+
+
+	/**
+	 * @param name the name to set
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+
+	/**
+	 * @return the process
+	 */
+	public WpsProcessExecute getProcess() {
+		return process;
+	}
+
+
+	/**
+	 * @param process the process to set
+	 */
+	public void setProcess(WpsProcessExecute process) {
+		this.process = process;
+	}
+
+
+	/**
+	 * @see java.lang.Object#hashCode()
+	 *
+	 * According to
+	 * http://stackoverflow.com/questions/27581/overriding-equals-and-hashcode-in-java
+	 * it is recommended only to use getter-methods when using ORM like Hibernate
+	 */
+	@Override
+	public int hashCode() {
+		return new HashCodeBuilder(19, 59) // two randomly chosen prime numbers
+			.appendSuper(super.hashCode())
+			.append(getName())
+			.toHashCode();
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 *
+	 * According to
+	 * http://stackoverflow.com/questions/27581/overriding-equals-and-hashcode-in-java
+	 * it is recommended only to use getter-methods when using ORM like Hibernate
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof WpsPlugin))
+			return false;
+		WpsPlugin other = (WpsPlugin) obj;
+
+		return new EqualsBuilder()
+			.appendSuper(super.equals(other))
+			.append(getName(), other.getName())
+			.isEquals();
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public String toString(){
+		return new ToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE)
+			.appendSuper(super.toString())
+			.append("name", name)
+			.toString();
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsPlugin.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsPlugin.java
@@ -26,11 +26,6 @@ public class WpsPlugin extends Plugin {
 	/**
 	 * 
 	 */
-	private String name;
-
-	/**
-	 * 
-	 */
 	@ManyToOne
 	private WpsProcessExecute process;
 
@@ -39,23 +34,6 @@ public class WpsPlugin extends Plugin {
 	 */
 	public WpsPlugin() {
 	}
-
-
-	/**
-	 * @return the name
-	 */
-	public String getName() {
-		return name;
-	}
-
-
-	/**
-	 * @param name the name to set
-	 */
-	public void setName(String name) {
-		this.name = name;
-	}
-
 
 	/**
 	 * @return the process
@@ -84,7 +62,7 @@ public class WpsPlugin extends Plugin {
 	public int hashCode() {
 		return new HashCodeBuilder(19, 59) // two randomly chosen prime numbers
 			.appendSuper(super.hashCode())
-			.append(getName())
+			.append(getProcess())
 			.toHashCode();
 	}
 
@@ -103,7 +81,7 @@ public class WpsPlugin extends Plugin {
 
 		return new EqualsBuilder()
 			.appendSuper(super.equals(other))
-			.append(getName(), other.getName())
+			.append(getProcess(), other.getProcess())
 			.isEquals();
 	}
 
@@ -114,7 +92,7 @@ public class WpsPlugin extends Plugin {
 	public String toString(){
 		return new ToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE)
 			.appendSuper(super.toString())
-			.append("name", name)
+			.append("process", process)
 			.toString();
 	}
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsPlugin.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsPlugin.java
@@ -1,6 +1,7 @@
 package de.terrestris.shogun2.model.wps;
 
 import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -30,6 +31,7 @@ public class WpsPlugin extends Plugin {
 	/**
 	 * 
 	 */
+	@ManyToOne
 	private WpsProcessExecute process;
 
 	/**

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsPrimitive.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsPrimitive.java
@@ -1,0 +1,118 @@
+package de.terrestris.shogun2.model.wps;
+
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import de.terrestris.shogun2.model.Plugin;
+
+/**
+ *
+ */
+@Entity
+@Table
+public class WpsPrimitive extends WpsParameter {
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 *
+	 */
+	private String defaultTextValue;
+
+	/**
+	 *
+	 */
+	@ManyToOne
+	private Plugin inputPlugin;
+
+	/**
+	 * Constructor
+	 */
+	public WpsPrimitive() {
+	}
+
+	/**
+	 * @return the defaultTextValue
+	 */
+	public String getDefaultTextValue() {
+		return defaultTextValue;
+	}
+
+	/**
+	 * @param defaultTextValue the defaultTextValue to set
+	 */
+	public void setDefaultTextValue(String defaultTextValue) {
+		this.defaultTextValue = defaultTextValue;
+	}
+
+	/**
+	 * @return the inputPlugin
+	 */
+	public Plugin getInputPlugin() {
+		return inputPlugin;
+	}
+
+	/**
+	 * @param inputPlugin the inputPlugin to set
+	 */
+	public void setInputPlugin(Plugin inputPlugin) {
+		this.inputPlugin = inputPlugin;
+	}
+
+	/**
+	 * @see java.lang.Object#hashCode()
+	 *
+	 * According to
+	 * http://stackoverflow.com/questions/27581/overriding-equals-and-hashcode-in-java
+	 * it is recommended only to use getter-methods when using ORM like Hibernate
+	 */
+	@Override
+	public int hashCode() {
+		return new HashCodeBuilder(13, 47) // two randomly chosen prime numbers
+			.appendSuper(super.hashCode())
+			.append(getDefaultTextValue())
+			.append(getInputPlugin())
+			.toHashCode();
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 *
+	 * According to
+	 * http://stackoverflow.com/questions/27581/overriding-equals-and-hashcode-in-java
+	 * it is recommended only to use getter-methods when using ORM like Hibernate
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof WpsPrimitive))
+			return false;
+		WpsPrimitive other = (WpsPrimitive) obj;
+
+		return new EqualsBuilder()
+			.appendSuper(super.equals(other))
+			.append(getDefaultTextValue(), other.getDefaultTextValue())
+			.append(getInputPlugin(), other.getInputPlugin())
+			.isEquals();
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public String toString(){
+		return new ToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE)
+			.appendSuper(super.toString())
+			.append("defaultTextValue", defaultTextValue)
+			.append("inputPlugin", inputPlugin)
+			.toString();
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsProcessExecute.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsProcessExecute.java
@@ -14,6 +14,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
 
 /**
  *
@@ -47,6 +49,7 @@ public class WpsProcessExecute extends WpsReference {
 			inverseJoinColumns = { @JoinColumn(name = "WPSPARAMETER_ID") }
 		)
 	@MapKeyColumn(name="IDENTIFIER")
+	@Cascade(CascadeType.SAVE_UPDATE)
 	private Map<String, WpsParameter> input = new HashMap<>();
 
 	/**

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsProcessExecute.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsProcessExecute.java
@@ -3,10 +3,10 @@ package de.terrestris.shogun2.model.wps;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.persistence.CollectionTable;
-import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
 import javax.persistence.MapKeyColumn;
 import javax.persistence.Table;
 
@@ -40,12 +40,13 @@ public class WpsProcessExecute extends WpsReference {
 	/**
 	 *
 	 */
-	@ElementCollection
-	@MapKeyColumn(name = "INPUT_IDENTIFIER")
-	@CollectionTable(
-		name = "WPSPROCESSEXECUTE_INPUTS",
-		joinColumns = @JoinColumn(name = "WPSPROCESSEXECUTE_ID")
-	)
+	@ManyToMany
+	@JoinTable(
+			name = "WPSPROCESSEXECUTES_INPUTS",
+			joinColumns = { @JoinColumn(name = "WPSEXECUTEPROCESS_ID") },
+			inverseJoinColumns = { @JoinColumn(name = "WPSPARAMETER_ID") }
+		)
+	@MapKeyColumn(name="IDENTIFIER")
 	private Map<String, WpsParameter> input = new HashMap<>();
 
 	/**

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsProcessExecute.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsProcessExecute.java
@@ -1,0 +1,153 @@
+package de.terrestris.shogun2.model.wps;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.persistence.CollectionTable;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.MapKeyColumn;
+import javax.persistence.Table;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+/**
+ *
+ */
+@Entity
+@Table
+public class WpsProcessExecute extends WpsReference {
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 *
+	 */
+	private String identifier;
+
+	/**
+	 *
+	 */
+	private String displayName;
+
+	/**
+	 *
+	 */
+	@ElementCollection
+	@MapKeyColumn(name = "INPUT_IDENTIFIER")
+	@CollectionTable(
+		name = "WPSPROCESSEXECUTE_INPUTS",
+		joinColumns = @JoinColumn(name = "WPSPROCESSEXECUTE_ID")
+	)
+	private Map<String, WpsParameter> input = new HashMap<>();
+
+	/**
+	 * Constructor
+	 */
+	public WpsProcessExecute() {
+	}
+
+
+	/**
+	 * @return the identifier
+	 */
+	public String getIdentifier() {
+		return identifier;
+	}
+
+
+	/**
+	 * @param identifier the identifier to set
+	 */
+	public void setIdentifier(String identifier) {
+		this.identifier = identifier;
+	}
+
+
+	/**
+	 * @return the displayName
+	 */
+	public String getDisplayName() {
+		return displayName;
+	}
+
+
+	/**
+	 * @param displayName the displayName to set
+	 */
+	public void setDisplayName(String displayName) {
+		this.displayName = displayName;
+	}
+
+
+	/**
+	 * @return the input
+	 */
+	public Map<String, WpsParameter> getInput() {
+		return input;
+	}
+
+
+	/**
+	 * @param input the input to set
+	 */
+	public void setInput(Map<String, WpsParameter> input) {
+		this.input = input;
+	}
+
+
+	/**
+	 * @see java.lang.Object#hashCode()
+	 *
+	 * According to
+	 * http://stackoverflow.com/questions/27581/overriding-equals-and-hashcode-in-java
+	 * it is recommended only to use getter-methods when using ORM like Hibernate
+	 */
+	@Override
+	public int hashCode() {
+		return new HashCodeBuilder(47, 23) // two randomly chosen prime numbers
+			.appendSuper(super.hashCode())
+			.append(getIdentifier())
+			.append(getDisplayName())
+			.toHashCode();
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 *
+	 * According to
+	 * http://stackoverflow.com/questions/27581/overriding-equals-and-hashcode-in-java
+	 * it is recommended only to use getter-methods when using ORM like Hibernate
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof WpsProcessExecute))
+			return false;
+		WpsProcessExecute other = (WpsProcessExecute) obj;
+
+		return new EqualsBuilder()
+			.appendSuper(super.equals(other))
+			.append(getIdentifier(), other.getIdentifier())
+			.append(getDisplayName(), other.getDisplayName())
+			.isEquals();
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public String toString(){
+		return new ToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE)
+			.appendSuper(super.toString())
+			.append("identifier", identifier)
+			.append("displayName", displayName)
+			.toString();
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsReference.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsReference.java
@@ -1,0 +1,166 @@
+package de.terrestris.shogun2.model.wps;
+
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+/**
+ *
+ */
+@Entity
+@Table
+public class WpsReference extends WpsParameter {
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
+	
+	/**
+	 * 
+	 */
+	private String url;
+	
+	/**
+	 * 
+	 */
+	private String mimeType;
+	
+	/**
+	 * 
+	 */
+	private String method;
+
+	/**
+	 *
+	 */
+	@ManyToOne
+	private WpsParameter body;
+
+	/**
+	 * Constructor
+	 */
+	public WpsReference() {
+	}
+
+
+	/**
+	 * @return the url
+	 */
+	public String getUrl() {
+		return url;
+	}
+
+
+	/**
+	 * @param url the url to set
+	 */
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
+
+	/**
+	 * @return the mimeType
+	 */
+	public String getMimeType() {
+		return mimeType;
+	}
+
+
+	/**
+	 * @param mimeType the mimeType to set
+	 */
+	public void setMimeType(String mimeType) {
+		this.mimeType = mimeType;
+	}
+
+
+	/**
+	 * @return the method
+	 */
+	public String getMethod() {
+		return method;
+	}
+
+
+	/**
+	 * @param method the method to set
+	 */
+	public void setMethod(String method) {
+		this.method = method;
+	}
+
+
+	/**
+	 * @return the body
+	 */
+	public WpsParameter getBody() {
+		return body;
+	}
+
+
+	/**
+	 * @param body the body to set
+	 */
+	public void setBody(WpsParameter body) {
+		this.body = body;
+	}
+
+
+	/**
+	 * @see java.lang.Object#hashCode()
+	 *
+	 * According to
+	 * http://stackoverflow.com/questions/27581/overriding-equals-and-hashcode-in-java
+	 * it is recommended only to use getter-methods when using ORM like Hibernate
+	 */
+	@Override
+	public int hashCode() {
+		return new HashCodeBuilder(11, 47) // two randomly chosen prime numbers
+			.appendSuper(super.hashCode())
+			.append(getUrl())
+			.append(getMimeType())
+			.append(getMethod())
+			.toHashCode();
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 *
+	 * According to
+	 * http://stackoverflow.com/questions/27581/overriding-equals-and-hashcode-in-java
+	 * it is recommended only to use getter-methods when using ORM like Hibernate
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof WpsReference))
+			return false;
+		WpsReference other = (WpsReference) obj;
+
+		return new EqualsBuilder()
+			.appendSuper(super.equals(other))
+			.append(getUrl(), other.getUrl())
+			.append(getMimeType(), other.getMimeType())
+			.append(getMethod(), other.getMethod())
+			.isEquals();
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public String toString(){
+		return new ToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE)
+			.appendSuper(super.toString())
+			.append("url", url)
+			.append("mimeType", mimeType)
+			.append("method", method)
+			.toString();
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/PluginRestController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/PluginRestController.java
@@ -1,0 +1,48 @@
+package de.terrestris.shogun2.rest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import de.terrestris.shogun2.dao.PluginDao;
+import de.terrestris.shogun2.model.Plugin;
+import de.terrestris.shogun2.service.PluginService;
+
+/**
+ * @author Nils Bühner
+ *
+ */
+@RestController
+@RequestMapping("/plugins")
+public class PluginRestController<E extends Plugin, D extends PluginDao<E>, S extends PluginService<E, D>>
+		extends AbstractRestController<E, D, S> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public PluginRestController() {
+		this((Class<E>) Plugin.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected PluginRestController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct service here.
+	 * Otherwise, spring can not decide which service has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("pluginService")
+	public void setService(S service) {
+		this.service = service;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/PluginRestController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/PluginRestController.java
@@ -2,7 +2,13 @@ package de.terrestris.shogun2.rest;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import de.terrestris.shogun2.dao.PluginDao;
@@ -32,6 +38,48 @@ public class PluginRestController<E extends Plugin, D extends PluginDao<E>, S ex
 	 */
 	protected PluginRestController(Class<E> entityClass) {
 		super(entityClass);
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	@RequestMapping(value="/{simpleClassName}.js", method=RequestMethod.GET)
+	public @ResponseBody ResponseEntity<String> getExternalPluginSource(
+			@PathVariable String simpleClassName) {
+
+		LOG.debug("Requested to return the sourcecode for plugin " + simpleClassName);
+
+		ResponseEntity<String> responseEntity = null;
+		HttpHeaders responseHeaders = new HttpHeaders();
+
+		try {
+			responseHeaders.add("Content-Type", "text/javascript; charset=utf-8");
+
+			String classCode = service.getPluginSource(simpleClassName);
+
+			responseEntity = new ResponseEntity<String>(
+					classCode,
+					responseHeaders,
+					HttpStatus.OK
+			);
+
+		} catch(Exception e) {
+			responseHeaders.add("Content-Type", "text/*");
+
+			String errMsg = "Error while returning the class code for "
+					+ "external plugin: " + e.getMessage();
+
+			LOG.error(errMsg);
+
+			responseEntity = new ResponseEntity<String>(
+					errMsg,
+					responseHeaders,
+					HttpStatus.INTERNAL_SERVER_ERROR
+			);
+		}
+
+		return responseEntity;
 	}
 
 	/**

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/WpsParameterRestController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/WpsParameterRestController.java
@@ -1,0 +1,48 @@
+package de.terrestris.shogun2.rest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import de.terrestris.shogun2.dao.WpsParameterDao;
+import de.terrestris.shogun2.model.wps.WpsParameter;
+import de.terrestris.shogun2.service.WpsParameterService;
+
+/**
+ * @author Nils Bühner
+ *
+ */
+@RestController
+@RequestMapping("/wpsparameters")
+public class WpsParameterRestController<E extends WpsParameter, D extends WpsParameterDao<E>, S extends WpsParameterService<E, D>>
+		extends AbstractRestController<E, D, S> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsParameterRestController() {
+		this((Class<E>) WpsParameter.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected WpsParameterRestController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct service here.
+	 * Otherwise, spring can not decide which service has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("wpsParameterService")
+	public void setService(S service) {
+		this.service = service;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/WpsPluginRestController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/WpsPluginRestController.java
@@ -1,0 +1,48 @@
+package de.terrestris.shogun2.rest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import de.terrestris.shogun2.dao.WpsPluginDao;
+import de.terrestris.shogun2.model.wps.WpsPlugin;
+import de.terrestris.shogun2.service.WpsPluginService;
+
+/**
+ * @author Nils Bühner
+ *
+ */
+@RestController
+@RequestMapping("/wpsplugins")
+public class WpsPluginRestController<E extends WpsPlugin, D extends WpsPluginDao<E>, S extends WpsPluginService<E, D>>
+		extends PluginRestController<E, D, S> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsPluginRestController() {
+		this((Class<E>) WpsPlugin.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected WpsPluginRestController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct service here.
+	 * Otherwise, spring can not decide which service has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("wpsPluginService")
+	public void setService(S service) {
+		this.service = service;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/WpsPrimitiveRestController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/WpsPrimitiveRestController.java
@@ -1,0 +1,48 @@
+package de.terrestris.shogun2.rest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import de.terrestris.shogun2.dao.WpsPrimitiveDao;
+import de.terrestris.shogun2.model.wps.WpsPrimitive;
+import de.terrestris.shogun2.service.WpsPrimitiveService;
+
+/**
+ * @author Nils Bühner
+ *
+ */
+@RestController
+@RequestMapping("/wpsprimitives")
+public class WpsPrimitiveRestController<E extends WpsPrimitive, D extends WpsPrimitiveDao<E>, S extends WpsPrimitiveService<E, D>>
+		extends AbstractRestController<E, D, S> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsPrimitiveRestController() {
+		this((Class<E>) WpsPrimitive.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected WpsPrimitiveRestController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct service here.
+	 * Otherwise, spring can not decide which service has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("wpsPrimitiveService")
+	public void setService(S service) {
+		this.service = service;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/WpsPrimitiveRestController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/WpsPrimitiveRestController.java
@@ -16,7 +16,7 @@ import de.terrestris.shogun2.service.WpsPrimitiveService;
 @RestController
 @RequestMapping("/wpsprimitives")
 public class WpsPrimitiveRestController<E extends WpsPrimitive, D extends WpsPrimitiveDao<E>, S extends WpsPrimitiveService<E, D>>
-		extends AbstractRestController<E, D, S> {
+		extends WpsParameterRestController<E, D, S> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/WpsProcessExecuteRestController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/WpsProcessExecuteRestController.java
@@ -1,0 +1,48 @@
+package de.terrestris.shogun2.rest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import de.terrestris.shogun2.dao.WpsProcessExecuteDao;
+import de.terrestris.shogun2.model.wps.WpsProcessExecute;
+import de.terrestris.shogun2.service.WpsProcessExecuteService;
+
+/**
+ * @author Nils Bühner
+ *
+ */
+@RestController
+@RequestMapping("/wpsprocessexecutes")
+public class WpsProcessExecuteRestController<E extends WpsProcessExecute, D extends WpsProcessExecuteDao<E>, S extends WpsProcessExecuteService<E, D>>
+		extends AbstractRestController<E, D, S> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsProcessExecuteRestController() {
+		this((Class<E>) WpsProcessExecute.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected WpsProcessExecuteRestController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct service here.
+	 * Otherwise, spring can not decide which service has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("wpsProcessExecuteService")
+	public void setService(S service) {
+		this.service = service;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/WpsReferenceRestController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/WpsReferenceRestController.java
@@ -1,0 +1,48 @@
+package de.terrestris.shogun2.rest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import de.terrestris.shogun2.dao.WpsReferenceDao;
+import de.terrestris.shogun2.model.wps.WpsReference;
+import de.terrestris.shogun2.service.WpsReferenceService;
+
+/**
+ * @author Nils Bühner
+ *
+ */
+@RestController
+@RequestMapping("/wpsreferences")
+public class WpsReferenceRestController<E extends WpsReference, D extends WpsReferenceDao<E>, S extends WpsReferenceService<E, D>>
+		extends AbstractRestController<E, D, S> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsReferenceRestController() {
+		this((Class<E>) WpsReference.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected WpsReferenceRestController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct service here.
+	 * Otherwise, spring can not decide which service has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("wpsReferenceService")
+	public void setService(S service) {
+		this.service = service;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/WpsReferenceRestController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/WpsReferenceRestController.java
@@ -16,7 +16,7 @@ import de.terrestris.shogun2.service.WpsReferenceService;
 @RestController
 @RequestMapping("/wpsreferences")
 public class WpsReferenceRestController<E extends WpsReference, D extends WpsReferenceDao<E>, S extends WpsReferenceService<E, D>>
-		extends AbstractRestController<E, D, S> {
+		extends WpsParameterRestController<E, D, S> {
 
 	/**
 	 * Default constructor, which calls the type-constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/PluginService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/PluginService.java
@@ -1,7 +1,11 @@
 package de.terrestris.shogun2.service;
 
+import org.h2.util.StringUtils;
+import org.hibernate.criterion.Criterion;
+import org.hibernate.criterion.Restrictions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import de.terrestris.shogun2.dao.PluginDao;
@@ -19,6 +23,12 @@ public class PluginService<E extends Plugin, D extends PluginDao<E>> extends
 		PermissionAwareCrudService<E, D> {
 
 	/**
+	 * The name of the plugin namespace.
+	 */
+	@Value("${plugin.namespace:Plugin}")
+	private String pluginNamespace;
+
+	/**
 	 * Default constructor, which calls the type-constructor
 	 */
 	@SuppressWarnings("unchecked")
@@ -32,6 +42,46 @@ public class PluginService<E extends Plugin, D extends PluginDao<E>> extends
 	 */
 	protected PluginService(Class<E> entityClass) {
 		super(entityClass);
+	}
+
+	/**
+	 * @return the pluginNamespace
+	 */
+	public String getPluginNamespace() {
+		return pluginNamespace;
+	}
+
+	/**
+	 * @param pluginNamespace the pluginNamespace to set
+	 */
+	public void setPluginNamespace(String pluginNamespace) {
+		this.pluginNamespace = pluginNamespace;
+	}
+
+	/**
+	 *
+	 * @param simpleClassName
+	 * @return
+	 * @throws Exception
+	 */
+	public String getPluginSource(String simpleClassName) throws Exception {
+
+		// qualify className
+		String className = pluginNamespace + "." + simpleClassName;
+
+		Criterion criterion = Restrictions.eq("className", className);
+		final E plugin = dao.findByUniqueCriteria(criterion);
+
+		String code = null;
+		if(plugin != null) {
+			code = plugin.getSourceCode();
+		}
+
+		if(StringUtils.isNullOrEmpty(code)) {
+			throw new Exception("Could not retrieve code for '" + className + "'");
+		}
+
+		return code;
 	}
 
 	/**

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/PluginService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/PluginService.java
@@ -1,0 +1,48 @@
+package de.terrestris.shogun2.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import de.terrestris.shogun2.dao.PluginDao;
+import de.terrestris.shogun2.model.Plugin;
+
+/**
+ * Service class for the {@link Plugin} model.
+ *
+ * @author Nils Bühner
+ * @see AbstractCrudService
+ *
+ */
+@Service("pluginService")
+public class PluginService<E extends Plugin, D extends PluginDao<E>> extends
+		PermissionAwareCrudService<E, D> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public PluginService() {
+		this((Class<E>) Plugin.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the service.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected PluginService(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct dao here.
+	 * Otherwise, spring can not decide which dao has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("pluginDao")
+	public void setDao(D dao) {
+		this.dao = dao;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/WpsParameterService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/WpsParameterService.java
@@ -1,0 +1,48 @@
+package de.terrestris.shogun2.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import de.terrestris.shogun2.dao.WpsParameterDao;
+import de.terrestris.shogun2.model.wps.WpsParameter;
+
+/**
+ * Service class for the {@link WpsParameter} model.
+ *
+ * @author Nils Bühner
+ * @see AbstractCrudService
+ *
+ */
+@Service("wpsParameterService")
+public class WpsParameterService<E extends WpsParameter, D extends WpsParameterDao<E>> extends
+		PermissionAwareCrudService<E, D> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsParameterService() {
+		this((Class<E>) WpsParameter.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the service.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected WpsParameterService(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct dao here.
+	 * Otherwise, spring can not decide which dao has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("wpsParameterDao")
+	public void setDao(D dao) {
+		this.dao = dao;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/WpsPluginService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/WpsPluginService.java
@@ -1,0 +1,48 @@
+package de.terrestris.shogun2.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import de.terrestris.shogun2.dao.WpsPluginDao;
+import de.terrestris.shogun2.model.wps.WpsPlugin;
+
+/**
+ * Service class for the {@link WpsPlugin} model.
+ *
+ * @author Nils Bühner
+ * @see AbstractCrudService
+ *
+ */
+@Service("wpsPluginService")
+public class WpsPluginService<E extends WpsPlugin, D extends WpsPluginDao<E>> extends
+		PluginService<E, D> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsPluginService() {
+		this((Class<E>) WpsPlugin.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the service.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected WpsPluginService(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct dao here.
+	 * Otherwise, spring can not decide which dao has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("wpsPluginDao")
+	public void setDao(D dao) {
+		this.dao = dao;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/WpsPrimitiveService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/WpsPrimitiveService.java
@@ -1,0 +1,48 @@
+package de.terrestris.shogun2.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import de.terrestris.shogun2.dao.WpsPrimitiveDao;
+import de.terrestris.shogun2.model.wps.WpsPrimitive;
+
+/**
+ * Service class for the {@link WpsPrimitive} model.
+ *
+ * @author Nils Bühner
+ * @see AbstractCrudService
+ *
+ */
+@Service("wpsPrimitiveService")
+public class WpsPrimitiveService<E extends WpsPrimitive, D extends WpsPrimitiveDao<E>> extends
+		WpsParameterService<E, D> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsPrimitiveService() {
+		this((Class<E>) WpsPrimitive.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the service.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected WpsPrimitiveService(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct dao here.
+	 * Otherwise, spring can not decide which dao has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("wpsPrimitiveDao")
+	public void setDao(D dao) {
+		this.dao = dao;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/WpsProcessExecuteService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/WpsProcessExecuteService.java
@@ -1,0 +1,48 @@
+package de.terrestris.shogun2.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import de.terrestris.shogun2.dao.WpsProcessExecuteDao;
+import de.terrestris.shogun2.model.wps.WpsProcessExecute;
+
+/**
+ * Service class for the {@link WpsProcessExecute} model.
+ *
+ * @author Nils Bühner
+ * @see AbstractCrudService
+ *
+ */
+@Service("wpsProcessExecuteService")
+public class WpsProcessExecuteService<E extends WpsProcessExecute, D extends WpsProcessExecuteDao<E>> extends
+		WpsReferenceService<E, D> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsProcessExecuteService() {
+		this((Class<E>) WpsProcessExecute.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the service.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected WpsProcessExecuteService(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct dao here.
+	 * Otherwise, spring can not decide which dao has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("wpsProcessExecuteDao")
+	public void setDao(D dao) {
+		this.dao = dao;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/WpsReferenceService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/WpsReferenceService.java
@@ -1,0 +1,48 @@
+package de.terrestris.shogun2.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import de.terrestris.shogun2.dao.WpsReferenceDao;
+import de.terrestris.shogun2.model.wps.WpsReference;
+
+/**
+ * Service class for the {@link WpsReference} model.
+ *
+ * @author Nils Bühner
+ * @see AbstractCrudService
+ *
+ */
+@Service("wpsReferenceService")
+public class WpsReferenceService<E extends WpsReference, D extends WpsReferenceDao<E>> extends
+		WpsParameterService<E, D> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsReferenceService() {
+		this((Class<E>) WpsReference.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the service.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected WpsReferenceService(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct dao here.
+	 * Otherwise, spring can not decide which dao has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("wpsReferenceDao")
+	public void setDao(D dao) {
+		this.dao = dao;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/PluginController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/PluginController.java
@@ -1,0 +1,53 @@
+/**
+ *
+ */
+package de.terrestris.shogun2.web;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import de.terrestris.shogun2.dao.PluginDao;
+import de.terrestris.shogun2.model.Plugin;
+import de.terrestris.shogun2.service.PluginService;
+
+/**
+ *
+ * @author Nils Bühner
+ *
+ */
+@Controller
+@RequestMapping("/plugins")
+public class PluginController<E extends Plugin, D extends PluginDao<E>, S extends PluginService<E, D>>
+		extends AbstractWebController<E, D, S> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public PluginController() {
+		this((Class<E>) Plugin.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected PluginController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct service here.
+	 * Otherwise, spring can not decide which service has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("pluginService")
+	public void setService(S service) {
+		this.service = service;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/WpsParameterController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/WpsParameterController.java
@@ -1,0 +1,53 @@
+/**
+ *
+ */
+package de.terrestris.shogun2.web;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import de.terrestris.shogun2.dao.WpsParameterDao;
+import de.terrestris.shogun2.model.wps.WpsParameter;
+import de.terrestris.shogun2.service.WpsParameterService;
+
+/**
+ *
+ * @author Nils Bühner
+ *
+ */
+@Controller
+@RequestMapping("/wpsparameters")
+public class WpsParameterController<E extends WpsParameter, D extends WpsParameterDao<E>, S extends WpsParameterService<E, D>>
+		extends AbstractWebController<E, D, S> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsParameterController() {
+		this((Class<E>) WpsParameter.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected WpsParameterController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct service here.
+	 * Otherwise, spring can not decide which service has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("wpsParameterService")
+	public void setService(S service) {
+		this.service = service;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/WpsPluginController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/WpsPluginController.java
@@ -1,0 +1,53 @@
+/**
+ *
+ */
+package de.terrestris.shogun2.web;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import de.terrestris.shogun2.dao.WpsPluginDao;
+import de.terrestris.shogun2.model.wps.WpsPlugin;
+import de.terrestris.shogun2.service.WpsPluginService;
+
+/**
+ *
+ * @author Nils Bühner
+ *
+ */
+@Controller
+@RequestMapping("/wpsplugins")
+public class WpsPluginController<E extends WpsPlugin, D extends WpsPluginDao<E>, S extends WpsPluginService<E, D>>
+		extends PluginController<E, D, S> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsPluginController() {
+		this((Class<E>) WpsPlugin.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected WpsPluginController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct service here.
+	 * Otherwise, spring can not decide which service has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("wpsPluginService")
+	public void setService(S service) {
+		this.service = service;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/WpsPrimitiveController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/WpsPrimitiveController.java
@@ -1,0 +1,53 @@
+/**
+ *
+ */
+package de.terrestris.shogun2.web;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import de.terrestris.shogun2.dao.WpsPrimitiveDao;
+import de.terrestris.shogun2.model.wps.WpsPrimitive;
+import de.terrestris.shogun2.service.WpsPrimitiveService;
+
+/**
+ *
+ * @author Nils Bühner
+ *
+ */
+@Controller
+@RequestMapping("/wpsprimitives")
+public class WpsPrimitiveController<E extends WpsPrimitive, D extends WpsPrimitiveDao<E>, S extends WpsPrimitiveService<E, D>>
+		extends WpsParameterController<E, D, S> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsPrimitiveController() {
+		this((Class<E>) WpsPrimitive.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected WpsPrimitiveController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct service here.
+	 * Otherwise, spring can not decide which service has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("wpsPrimitiveService")
+	public void setService(S service) {
+		this.service = service;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/WpsProcessExecuteController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/WpsProcessExecuteController.java
@@ -1,0 +1,53 @@
+/**
+ *
+ */
+package de.terrestris.shogun2.web;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import de.terrestris.shogun2.dao.WpsProcessExecuteDao;
+import de.terrestris.shogun2.model.wps.WpsProcessExecute;
+import de.terrestris.shogun2.service.WpsProcessExecuteService;
+
+/**
+ *
+ * @author Nils Bühner
+ *
+ */
+@Controller
+@RequestMapping("/wpsprocessexecutes")
+public class WpsProcessExecuteController<E extends WpsProcessExecute, D extends WpsProcessExecuteDao<E>, S extends WpsProcessExecuteService<E, D>>
+		extends WpsReferenceController<E, D, S> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsProcessExecuteController() {
+		this((Class<E>) WpsProcessExecute.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected WpsProcessExecuteController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct service here.
+	 * Otherwise, spring can not decide which service has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("wpsReferenceService")
+	public void setService(S service) {
+		this.service = service;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/WpsProcessExecuteController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/WpsProcessExecuteController.java
@@ -45,7 +45,7 @@ public class WpsProcessExecuteController<E extends WpsProcessExecute, D extends 
 	 */
 	@Override
 	@Autowired
-	@Qualifier("wpsReferenceService")
+	@Qualifier("wpsProcessExecuteService")
 	public void setService(S service) {
 		this.service = service;
 	}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/WpsReferenceController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/WpsReferenceController.java
@@ -1,0 +1,53 @@
+/**
+ *
+ */
+package de.terrestris.shogun2.web;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import de.terrestris.shogun2.dao.WpsReferenceDao;
+import de.terrestris.shogun2.model.wps.WpsReference;
+import de.terrestris.shogun2.service.WpsReferenceService;
+
+/**
+ *
+ * @author Nils Bühner
+ *
+ */
+@Controller
+@RequestMapping("/wpsreferences")
+public class WpsReferenceController<E extends WpsReference, D extends WpsReferenceDao<E>, S extends WpsReferenceService<E, D>>
+		extends WpsParameterController<E, D, S> {
+
+	/**
+	 * Default constructor, which calls the type-constructor
+	 */
+	@SuppressWarnings("unchecked")
+	public WpsReferenceController() {
+		this((Class<E>) WpsReference.class);
+	}
+
+	/**
+	 * Constructor that sets the concrete entity class for the controller.
+	 * Subclasses MUST call this constructor.
+	 */
+	protected WpsReferenceController(Class<E> entityClass) {
+		super(entityClass);
+	}
+
+	/**
+	 * We have to use {@link Qualifier} to define the correct service here.
+	 * Otherwise, spring can not decide which service has to be autowired here
+	 * as there are multiple candidates.
+	 */
+	@Override
+	@Autowired
+	@Qualifier("wpsReferenceService")
+	public void setService(S service) {
+		this.service = service;
+	}
+
+}


### PR DESCRIPTION
(There has just been a new release of shogun2: https://github.com/terrestris/shogun2/releases/tag/v0.1.2)

This PR will merge the current state of the `wps-plugins` branch (https://github.com/terrestris/shogun2/tree/wps-plugins) to master.

Essentially, the following new models will be introduced:

* `Plugin` as base class of `WpsPlugin`
* `WpsParameter` as (abstract) base class of
  * `WpsPrimitive` and
  * `WpsReference`, which again is the parent class of
    * `WpsProcessExecute`

(On top of the models, this PR also contains the corresponding `DAO`s, `Service`s and `Rest`-/`Controllers`.)

An `Application` now has a list of `Plugin`s, where a `Plugin` mainly is a piece of (JS/Ext-JS) `sourceCode` that could follow some kind of policy/guideline that is expected by a client (e.g. it could implement a `load` or `init` function, which is then interpreted by a client) and may (for example) be used to provide a basic input-GUI for a `WpsPrimitive`.

![wps-chainable-new](https://cloud.githubusercontent.com/assets/3939332/23165870/847e0ef2-f83e-11e6-8758-14ae55db9f90.png)
