### PR TITLE
Use system JDK when compiling shogun2

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -398,8 +398,8 @@
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Just a minor change.

When compiling/building SHOGun2, the system JDK will be used (as `jdk.version`) is set in a profile based on the JDK in use...