### PR TITLE
Fix JPA annotation to also work in postgres

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Plugin.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Plugin.java
@@ -9,6 +9,7 @@ import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
+import javax.persistence.Lob;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 
@@ -44,11 +45,11 @@ public class Plugin extends PersistentObject {
 	private String xtype;
 
 	/** the JavaScript (JS) code of the plugin **/
-	@Column(length = Integer.MAX_VALUE)
+	@Lob
 	private String sourceCode;
 
 	/** the Cascading Style Sheets (CSS) of the plugin **/
-	@Column(length = Integer.MAX_VALUE)
+	@Lob
 	private String styleSheet;
 
 	/** A list of assigned {@link PluginUploadFile}s. */


### PR DESCRIPTION
The JPA annotation `@Column(length = Integer.MAX_VALUE)` (ping @dnlkoch) should only be used in case of `byte[]`, but not for `String` as postgres will not be able to create a varchar column with that size.

Using the `@Lob` annotation for `String` works fine for H2 and Postgres. In case of Postgres, a column of type `TEXT` will be created.