### PR TITLE
Allow configurable sparse output of REST GET requests

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/rest/AbstractRestController.java
@@ -55,8 +55,8 @@ public abstract class AbstractRestController<E extends PersistentObject, D exten
 	 * @return
 	 */
 	@RequestMapping(method = RequestMethod.GET)
-	public ResponseEntity<List<E>> findAll() {
-		final List<E> resultList = this.service.findAll();
+	public ResponseEntity<List<E>> findAll(@RequestParam MultiValueMap<String,String> requestParams) {
+		final List<E> resultList = this.service.findAllRestricted(requestParams);
 
 		if (resultList != null && !resultList.isEmpty()) {
 			LOG.trace("Found a total of " + resultList.size()

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/entity/EntityUtil.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/entity/EntityUtil.java
@@ -3,6 +3,8 @@ package de.terrestris.shogun2.util.entity;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -22,6 +24,11 @@ import org.springframework.util.MultiValueMap;
  *
  */
 public class EntityUtil {
+
+	/**
+	 * The parameter that might contain a list of fieldNames to restrict the entity to.
+	 */
+	public final static String RESTRICT_FIELDS_PARAM = "output:only";
 
 	/**
 	 * @param clazz
@@ -84,6 +91,154 @@ public class EntityUtil {
 	}
 
 	/**
+	 * Returns a list of fieldNames of the passed class that can be used to either
+	 *
+	 * <ul>
+	 *   <li>filter results with, see {@link validFieldNamesWithCastedValues}, or</li>
+	 *   <li>restrict output of queries, see {@link determineRestrictFields} </li>
+	 * </ul>
+	 *
+	 * @param entityClass
+	 * @return
+	 */
+	public static List<String> getFilterableOrRestrictableFieldNames(Class<?> entityClass) {
+		List<Field> allFields = FieldUtils.getAllFieldsList(entityClass);
+		List<String> restrictableFields = new ArrayList<String>();
+		for (Field field : allFields) {
+			final Class<?> fieldType = field.getType();
+			final String fieldName = field.getName();
+			final int fieldModifiers = field.getModifiers();
+
+			final boolean isPrimitiveOrWrapper = ClassUtils.isPrimitiveOrWrapper(fieldType);
+			final boolean isString = fieldType.equals(String.class);
+			final boolean isStatic = Modifier.isStatic(fieldModifiers);
+			final boolean isPrivate = Modifier.isPrivate(fieldModifiers);
+
+			// extract only non-static private fields that are primitive or
+			// primitive wrapper types or String
+			if((isPrimitiveOrWrapper || isString) && isPrivate && !isStatic) {
+				restrictableFields.add(fieldName);
+			}
+		}
+		return restrictableFields;
+	}
+
+	/**
+	 * A small utility method that will turn a passed list with comma separated strings into
+	 * a list which has single elements:
+	 *
+	 * Examples:
+	 *
+	 * <table>
+	 *   <thead>
+	 *     <tr>
+	 *       <th>in</th><th>out</th><th>in.size()</th><th>out.size()</th>
+	 *     </tr>
+	 *   </thead>
+	 *   <tbody>
+	 *     <tr>
+	 *       <td><code>null</code></td><td><code>null</code></td>
+	 *       <td>n.a.</td><td>n.a.</td>
+	 *     </tr>
+	 *     <tr>
+	 *       <td><code>[null]</code></td><td><code>null</code></td>
+	 *       <td>1</td><td>n.a.</td>
+	 *     </tr>
+	 *     <tr>
+	 *       <td><code>["foo"]</code></td><td><code>["foo"]</code></td>
+	 *       <td>1</td><td>1</td>
+	 *     </tr>
+	 *     <tr>
+	 *       <td><code>["foo,bar"]</code></td>
+	 *       <td><code>["foo", "bar"]</code></td>
+	 *       <td>1</td><td>2</td>
+	 *     </tr>
+	 *     <tr>
+	 *       <td><code>["foo", "bar"]</code></td>
+	 *       <td><code>["foo", "bar"]</code></td>
+	 *       <td>2</td><td>2</td>
+	 *     </tr>
+	 *     <tr>
+	 *       <td><code>["foo,humpty", "bar,dumpty"]</code></td>
+	 *       <td><code>["foo", "humpty", "bar", "dumpty"]</code></td>
+	 *       <td>2</td><td>4</td>
+	 *     </tr>
+	 *   </tbody>
+	 * </table>
+	 *
+	 * @param listOfCommaSeparatedValues
+	 * @return
+	 */
+	public static List<String> listFromCommaSeparatedStringList(List<String> listOfCommaSeparatedValues) {
+		if (listOfCommaSeparatedValues == null) {
+			return null;
+		}
+		List<String> outList = new ArrayList<String>();
+		for (String commaSeparatedValues : listOfCommaSeparatedValues) {
+			if (commaSeparatedValues != null) {
+				List<String> values = Arrays.asList(
+					commaSeparatedValues.split("\\s*,\\s*")
+				);
+				outList.addAll(values);
+			}
+		}
+		if(outList.size() == 0) {
+			return null;
+		}
+		return outList;
+	}
+
+	/**
+	 * Returns a list of fieldnames to restrict the output to. This list is the
+	 * intersection of fields that are possible to be restricted and the names
+	 * that are actually requested in the <code>requestedFilter</code>.
+	 *
+	 * Only the key {@value RESTRICT_FIELDS_PARAM} is taken as list of requested
+	 * fieldName to restrict by, the value is treated in a case-insensitive matter.
+	 *
+	 * The returned list will have casing as they appear in the class, regardless
+	 * of the case of the values that appear in <code>RESTRICT_FIELDS_PARAM</code>.
+	 *
+	 * @param requestedFilter
+	 * @param entityClass
+	 * @return
+	 */
+	public static List<String> determineRestrictFields(MultiValueMap<String, String> requestedFilter,  Class<?> entityClass) {
+		if (requestedFilter == null) {
+			return null;
+		}
+		List<String> restrictFieldsTo = null;
+		Set<String> keys = requestedFilter.keySet();
+		for (String key : keys) {
+			if (RESTRICT_FIELDS_PARAM.equalsIgnoreCase(key)) {
+				restrictFieldsTo = listFromCommaSeparatedStringList(
+					requestedFilter.get(key)
+				);
+			}
+		}
+		if (restrictFieldsTo == null) {
+			return null;
+		}
+
+		List<String> restrictableFieldNames = getFilterableOrRestrictableFieldNames(entityClass);
+		List<String> filteredRestrictTo = new ArrayList<String>();
+
+		for (String restrictableFieldName : restrictableFieldNames) {
+			for (String requestedRestrictTo : restrictFieldsTo) {
+				if (restrictableFieldName.equalsIgnoreCase(requestedRestrictTo)) {
+					filteredRestrictTo.add(restrictableFieldName);
+				}
+			}
+		}
+
+		if (filteredRestrictTo.size() == 0) {
+			filteredRestrictTo = null;
+		}
+
+		return filteredRestrictTo;
+	}
+
+	/**
 	 * This method returns a multi value map, where the keys are the
 	 * intersection of (non-static private) field names of the given entity
 	 * class and the given set of requested/input field names (which are the
@@ -109,32 +264,17 @@ public class EntityUtil {
 
 		Set<String> inputFieldNames = requestedFilter.keySet();
 
-		List<Field> allFields = FieldUtils.getAllFieldsList(entityClass);
-
 		// Regarding case insensitivity: build a map that maps from the input field name to its original field name,
 		// but add only those fields to the map that exist in the entity
 		Map<String, String> validInputFieldNameToOrigFieldName = new HashMap<>();
 
-		for (Field field : allFields) {
-			final Class<?> fieldType = field.getType();
-			final String fieldName = field.getName();
-			final int fieldModifiers = field.getModifiers();
-
-			final boolean isPrimitiveOrWrapper = ClassUtils.isPrimitiveOrWrapper(fieldType);
-			final boolean isString = fieldType.equals(String.class);
-			final boolean isStatic = Modifier.isStatic(fieldModifiers);
-			final boolean isPrivate = Modifier.isPrivate(fieldModifiers);
-
-			// extract only non-static private fields that are primitive or
-			// primitive wrapper types or String
-			if((isPrimitiveOrWrapper || isString) && isPrivate && !isStatic) {
-
-				// find the corresponding field in the input
-				for(String inputFieldName : inputFieldNames) {
-					if(fieldName.toLowerCase().equals(inputFieldName.toLowerCase())) {
-						validInputFieldNameToOrigFieldName.put(inputFieldName, fieldName);
-						break;
-					}
+		List<String> filterableFieldNames = getFilterableOrRestrictableFieldNames(entityClass);
+		for (String filterableFieldName : filterableFieldNames) {
+			// find the corresponding field in the input
+			for (String inputFieldName : inputFieldNames) {
+				if (filterableFieldName.equalsIgnoreCase(inputFieldName)) {
+					validInputFieldNameToOrigFieldName.put(inputFieldName, filterableFieldName);
+					break;
 				}
 			}
 		}

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/rest/AbstractRestControllerTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/rest/AbstractRestControllerTest.java
@@ -31,6 +31,8 @@ import org.mockito.stubbing.Answer;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -152,7 +154,8 @@ public class AbstractRestControllerTest {
 
 		TestModel second = buildTestInstanceWithValue(secondValue);
 
-		when(serviceMock.findAll()).thenReturn(Arrays.asList(first, second));
+		MultiValueMap<String, String> emptyMap = new LinkedMultiValueMap<>();
+		when(serviceMock.findAllRestricted(emptyMap)).thenReturn(Arrays.asList(first, second));
 
 		// Test GET method
 		mockMvc.perform(get("/tests"))
@@ -163,7 +166,7 @@ public class AbstractRestControllerTest {
 				.andExpect(jsonPath("$[0].testValue", is(firstValue)))
 				.andExpect(jsonPath("$[1].testValue", is(secondValue)));
 
-		verify(serviceMock, times(1)).findAll();
+		verify(serviceMock, times(1)).findAllRestricted(emptyMap);
 		verifyNoMoreInteractions(serviceMock);
 	}
 


### PR DESCRIPTION
This adds the possibility to optionally get a sparse result from REST GET calls against the abstract REST controller. This can be usefull if you are not interested in the complete representation of objects, but only certain fields are important for you.

In order to only get e.g. the fields `name` and `id` of all entities `TestEntity` (mapped to `/rest/testentity`): the following request can be used:

    /rest/testentity?output:only=name,id

All other fields of the returned objects will be `null`.

This can be combined with the existing `filter`-API:

    /rest/testentity/filter?id=42&output:only=name,id

The above will give you back the sparse `TestEntity` serialisation where only the fields `name` and `id` have real values, others are `null`.

This implementation is backwards compatible for the REST API.

I didn't find time to add tests for now, but wanted to get feedback fast; so please review.