### PR TITLE
Clone/Copy persisted trees

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/TreeNodeService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/TreeNodeService.java
@@ -1,10 +1,15 @@
 package de.terrestris.shogun2.service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import de.terrestris.shogun2.dao.TreeNodeDao;
+import de.terrestris.shogun2.helper.IdHelper;
+import de.terrestris.shogun2.model.tree.TreeFolder;
 import de.terrestris.shogun2.model.tree.TreeNode;
 
 /**
@@ -32,6 +37,50 @@ public class TreeNodeService<E extends TreeNode, D extends TreeNodeDao<E>> exten
 	 */
 	protected TreeNodeService(Class<E> entityClass) {
 		super(entityClass);
+	}
+
+	/**
+	 *
+	 * This unproxies and eagerly fetches the whole node/tree and detaches it
+	 * from the hibernate session before persisting a new "clone" instance in the database.
+	 * In case of a TreeFolder, each child node will also be re-persisted (as a new database entry).
+	 *
+	 * @param node
+	 * @return
+	 * @throws IllegalAccessException
+	 * @throws NoSuchFieldException
+	 */
+	@SuppressWarnings("unchecked")
+	public E cloneAndPersistTreeNode(E node) throws Exception {
+
+		if(node == null) {
+			throw new Exception("Node to clone must not be null.");
+		}
+
+		// unproxy the node to be sure that everything (on top level) is loaded eagerly
+		// before we continue to care about possible child notes and persistance
+		node = dao.unproxy(node);
+
+		if(node instanceof TreeFolder) {
+			List<E> children = (List<E>) ((TreeFolder) node).getChildren();
+			List<E> clonedChildren = new ArrayList<>();
+			for (E childNode : children) {
+				// recursive call for all children
+				clonedChildren.add(cloneAndPersistTreeNode(childNode));
+			}
+			((TreeFolder) node).setChildren((List<TreeNode>) children);
+		}
+
+		// detach the clone from the hibernate session to persist it as a new instance in the next step
+		dao.evict(node);
+
+		// set id to null to persist a new instance afterwards
+		IdHelper.setIdOnPersistentObject(node, null);
+
+		// persist the same object as a new entry in database
+		dao.saveOrUpdate(node);
+
+		return node;
 	}
 
 	/**


### PR DESCRIPTION
This PR allows you to clone existing `TreeNode`s, i.e. if you have a persisted tree (root) node, all child nodes and the tree/root node itself would be initialized, detached from the hibernate session and re-persisted as a new entry in the database when the new method `cloneAndPersistTreeNode` is called.

This is helpful if you want to copy/clone an `Application` with the underlying layer tree. If you would simply set the original root node of the layer tree for the copy-application, the same tree would be used.

With the changes of this PR, the whole tree can be copied/cloned.

For this, two new methods in the `GenericHibernateDao` have been introduced and are used within the new `cloneAndPersistTreeNode` method:

* `unproxy(E e)`, which eagerly initializes an entity (just to be sure that all data that would be fetched lazily is available)
* `evict(E e)` to detach an entity from the hibernate session, which allows us to set the ID to null afterwards, so that a call of `saveOrUpdate` will create a new database entry.

Please review and merge. Ping @marcjansen @annarieger 