### PR TITLE
Fix check of collection field

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/entity/EntityUtil.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/entity/EntityUtil.java
@@ -33,7 +33,7 @@ public class EntityUtil {
 	 * @param fieldName
 	 *            The name of the collection field
 	 * @param collectionElementType
-	 *            The type of the elements of the collection
+	 *            The type of the concrete element in the collection
 	 * @param forceAccess
 	 *            whether to break scope restrictions using the
 	 *            {@link java.lang.reflect.AccessibleObject#setAccessible(boolean)}
@@ -53,8 +53,8 @@ public class EntityUtil {
 
 		if (Collection.class.isAssignableFrom(field.getType())) {
 			ParameterizedType collType = (ParameterizedType) field.getGenericType();
-			Class<?> actualElementTypeOfCollection = (Class<?>) collType.getActualTypeArguments()[0];
-			isCollectionField = collectionElementType.isAssignableFrom(actualElementTypeOfCollection);
+			Class<?> elementTypeOfCollection = (Class<?>) collType.getActualTypeArguments()[0];
+			isCollectionField = elementTypeOfCollection.isAssignableFrom(collectionElementType);
 		}
 
 		return isCollectionField;

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/entity/EntityUtilTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/entity/EntityUtilTest.java
@@ -1,0 +1,358 @@
+package de.terrestris.shogun2.util.entity;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+
+import de.terrestris.shogun2.model.PersistentObject;
+
+
+/**
+ * @author Marc Jansen
+ */
+@SuppressWarnings({ "unused", "serial" })
+public class EntityUtilTest {
+
+	//
+	// Start setup code
+	//
+	private class TestClassParent extends PersistentObject {
+	}
+
+	private class TestClassChild extends TestClassParent {
+	}
+
+	private class TestClassGrandChild extends TestClassChild {
+	}
+
+	private class EntityWithCollections extends PersistentObject {
+
+		private Set<TestClassParent> privateSetOfTestClassParents;
+		private List<TestClassParent> privateListOfTestClassParents;
+		public Set<TestClassParent> publicSetOfTestClassParents;
+		public List<TestClassParent> publicListOfTestClassParents;
+
+		private Set<TestClassChild> privateSetOfTestClassChildren;
+		private List<TestClassChild> privateListOfTestClassChildren;
+		public Set<TestClassChild> publicSetOfTestClassChildren;
+		public List<TestClassChild> publicListOfTestClassChildren;
+
+		private Set<TestClassGrandChild> privateSetOfTestClassGrandChildren;
+		private List<TestClassGrandChild> privateListOfTestClassGrandChildren;
+		public Set<TestClassGrandChild> publicSetOfTestClassGrandChildren;
+		public List<TestClassGrandChild> publicListOfTestClassGrandChildren;
+
+		private String privateNeitherListNorSet;
+		public String publicNeitherListNorSet;
+	}
+
+	//
+	// End setup code
+	//
+
+
+	// +------------------------------------------+
+	// | Tests for the method `isCollectionField` |
+	// +------------------------------------------+
+
+	// ----- test the collections that accept parents or any child class of it
+
+	@Test
+	public void test_isCollectionField_returnsTrueWhenSetFieldParent_passedParent() {
+		boolean isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateSetOfTestClassParents", TestClassParent.class, true
+		);
+		assertTrue(isCollectionField);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsTrueWhenListFieldParent_passedParent() {
+		boolean isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateListOfTestClassParents", TestClassParent.class, true
+		);
+		assertTrue(isCollectionField);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsTrueWhenSetFieldParent_passedChild() {
+		boolean isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateSetOfTestClassParents", TestClassChild.class, true
+		);
+		assertTrue(isCollectionField);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsTrueWhenListFieldParent_passedChild() {
+		boolean isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateListOfTestClassParents", TestClassChild.class, true
+		);
+		assertTrue(isCollectionField);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsTrueWhenSetFieldParent_passedGrandChild() {
+		boolean isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateSetOfTestClassParents", TestClassGrandChild.class, true
+		);
+		assertTrue(isCollectionField);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsTrueWhenListFieldParent_passedGrandChild() {
+		boolean isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateListOfTestClassParents", TestClassGrandChild.class, true
+		);
+		assertTrue(isCollectionField);
+	}
+
+
+	// ----- test the collections that accept children or any child class of it
+
+	@Test
+	public void test_isCollectionField_returnsFalseWhenSetFieldChild_passedParent() {
+		boolean isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateSetOfTestClassChildren", TestClassParent.class, true
+		);
+		assertFalse(isCollectionField);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsFalseWhenListFieldChild_passedParent() {
+		boolean isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateListOfTestClassChildren", TestClassParent.class, true
+		);
+		assertFalse(isCollectionField);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsTrueWhenSetFieldChild_passedChild() {
+		boolean isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateSetOfTestClassChildren", TestClassChild.class, true
+		);
+		assertTrue(isCollectionField);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsTrueWhenListFieldChild_passedChild() {
+		boolean isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateListOfTestClassChildren", TestClassChild.class, true
+		);
+		assertTrue(isCollectionField);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsTrueWhenSetFieldChild_passedGrandChild() {
+		boolean isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateSetOfTestClassChildren", TestClassGrandChild.class, true
+		);
+		assertTrue(isCollectionField);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsTrueWhenListFieldChild_passedGrandChild() {
+		boolean isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateListOfTestClassChildren", TestClassGrandChild.class, true
+		);
+		assertTrue(isCollectionField);
+	}
+
+
+	// ----- test the collections that accept only grandchilds
+
+	@Test
+	public void test_isCollectionField_returnsFalseWhenSetFieldGrandChild_passedParent() {
+		boolean isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateSetOfTestClassGrandChildren", TestClassParent.class, true
+		);
+		assertFalse(isCollectionField);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsFalseWhenListFieldGrandChild_passedParent() {
+		boolean isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateListOfTestClassGrandChildren", TestClassParent.class, true
+		);
+		assertFalse(isCollectionField);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsTrueWhenSetFieldGrandChild_passedChild() {
+		boolean isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateSetOfTestClassGrandChildren", TestClassChild.class, true
+		);
+		assertFalse(isCollectionField);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsTrueWhenListFieldGrandChild_passedChild() {
+		boolean isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateListOfTestClassGrandChildren", TestClassChild.class, true
+		);
+		assertFalse(isCollectionField);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsTrueWhenSetFieldGrandChild_passedGrandChild() {
+		boolean isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateSetOfTestClassChildren", TestClassGrandChild.class, true
+		);
+		assertTrue(isCollectionField);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsTrueWhenListFieldGrandChild_passedGrandChild() {
+		boolean isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "publicListOfTestClassChildren", TestClassGrandChild.class, true
+		);
+		assertTrue(isCollectionField);
+	}
+
+
+	// ---- test private / public visibility of fields
+
+	@Test
+	public void test_isCollectionField_returnsFalseWhenForceAccessIsFalse_forPrivateFields() {
+		boolean isCollectionField;
+
+		isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateListOfTestClassParents", TestClassGrandChild.class, false
+		);
+		assertFalse(isCollectionField);
+
+		isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateListOfTestClassChildren", TestClassGrandChild.class, false
+		);
+		assertFalse(isCollectionField);
+
+		isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateListOfTestClassGrandChildren", TestClassGrandChild.class, false
+		);
+		assertFalse(isCollectionField);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsTrueWhenForceAccessIsFalse_forPublicFields() {
+		boolean isCollectionField;
+
+		isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "publicListOfTestClassParents", TestClassGrandChild.class, false
+		);
+		assertTrue(isCollectionField);
+
+		isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "publicListOfTestClassChildren", TestClassGrandChild.class, false
+		);
+		assertTrue(isCollectionField);
+
+		isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "publicListOfTestClassGrandChildren", TestClassGrandChild.class, false
+		);
+		assertTrue(isCollectionField);
+	}
+
+
+	// ---- test non-collection field
+
+	@Test
+	public void test_isCollectionField_returnsFalse_forNonCollectionFields_passedParent() {
+		boolean isCollectionField;
+
+		// concrete entity class has no effect:
+		isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateNeitherListNorSet", TestClassParent.class, true
+		);
+		assertFalse(isCollectionField);
+
+		// forceAccess has no effect:
+		isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "publicNeitherListNorSet", TestClassParent.class, false
+		);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsFalse_forNonCollectionFields_passedChild() {
+		boolean isCollectionField;
+
+		// concrete entity class has no effect:
+		isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateNeitherListNorSet", TestClassChild.class, true
+		);
+		assertFalse(isCollectionField);
+
+		// forceAccess has no effect:
+		isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "publicNeitherListNorSet", TestClassChild.class, false
+		);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsFalse_forNonCollectionFields_passedGrandChild() {
+		boolean isCollectionField;
+
+		// concrete entity class has no effect:
+		isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "privateNeitherListNorSet", TestClassGrandChild.class, true
+		);
+		assertFalse(isCollectionField);
+
+		// forceAccess has no effect:
+		isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "publicNeitherListNorSet", TestClassGrandChild.class, false
+		);
+	}
+
+
+	// ---- test not existing fields
+
+	@Test
+	public void test_isCollectionField_returnsFalse_forNotExistingFields_passedParent() {
+		boolean isCollectionField;
+
+		// concrete entity class has no effect:
+		isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "thisFieldIsNotThere", TestClassParent.class, true
+		);
+		assertFalse(isCollectionField);
+
+		// forceAccess has no effect:
+		isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "thisFieldIsNotThere", TestClassParent.class, false
+		);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsFalse_forNotExistingFields_passedChild() {
+		boolean isCollectionField;
+
+		// concrete entity class has no effect:
+		isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "thisFieldIsNotThere", TestClassChild.class, true
+		);
+		assertFalse(isCollectionField);
+
+		// forceAccess has no effect:
+		isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "thisFieldIsNotThere", TestClassChild.class, false
+		);
+	}
+
+	@Test
+	public void test_isCollectionField_returnsFalse_forNotExistingFields_passedGrandChild() {
+		boolean isCollectionField;
+
+		// concrete entity class has no effect:
+		isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "thisFieldIsNotThere", TestClassGrandChild.class, true
+		);
+		assertFalse(isCollectionField);
+
+		// forceAccess has no effect:
+		isCollectionField = EntityUtil.isCollectionField(
+			EntityWithCollections.class, "thisFieldIsNotThere", TestClassGrandChild.class, false
+		);
+	}
+}


### PR DESCRIPTION
This fixes a bug that occures when using the `isCollectionField` method and a concrete element in the collection is a subtype of the element type declaration of the collection...

@marcjansen :rofl: 