### PR TITLE
Introduce a findAllWhereFieldEquals method

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/GenericHibernateDao.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/GenericHibernateDao.java
@@ -110,19 +110,32 @@ public class GenericHibernateDao<E extends PersistentObject, ID extends Serializ
 	public List<E> findAllWhereFieldEquals(String fieldName, Object fieldEntity,
 			Criterion... criterion) {
 
-		final boolean isField = EntityUtil.isField(entityClass, fieldName, true);
+		Class<?> fieldEntityType = null;
+
+		if(fieldEntity != null) {
+			fieldEntityType = fieldEntity.getClass();
+		}
+
+		final boolean isField = EntityUtil.isField(entityClass, fieldName, fieldEntityType, true);
 
 		if (!isField) {
 			String errorMsg = String.format(
-				"There is no field '%s' in the type '%s'",
+				"There is no field '%s' in the type '%s' that accepts instances of '%s'",
 				fieldName,
-				entityClass.getName()
+				entityClass.getName(),
+				fieldEntityType.getName()
 			);
 			throw new IllegalArgumentException(errorMsg);
 		}
 
 		Criteria criteria = createDistinctRootEntityCriteria(criterion);
-		criteria.add(Restrictions.eq(fieldName, fieldEntity));
+
+		if(fieldEntity == null) {
+			criteria.add(Restrictions.isNull(fieldName));
+		} else {
+			criteria.add(Restrictions.eq(fieldName, fieldEntity));
+		}
+
 		return (List<E>) criteria.list();
 	}
 

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/GenericHibernateDao.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/dao/GenericHibernateDao.java
@@ -96,6 +96,37 @@ public class GenericHibernateDao<E extends PersistentObject, ID extends Serializ
 	}
 
 	/**
+	 * Returns a list of entity objects that have field named
+	 * <code>fieldName</code>, which has an object <code>fieldEntity</code>
+	 * as value.
+	 *
+	 * @param fieldName The name of the field
+	 * @param fieldEntity The element that should be set as value
+	 * @param criterion Additional criterions to apply (optional)
+	 *
+	 * @return The list of objects
+	 */
+	@SuppressWarnings("unchecked")
+	public List<E> findAllWhereFieldEquals(String fieldName, Object fieldEntity,
+			Criterion... criterion) {
+
+		final boolean isField = EntityUtil.isField(entityClass, fieldName, true);
+
+		if (!isField) {
+			String errorMsg = String.format(
+				"There is no field '%s' in the type '%s'",
+				fieldName,
+				entityClass.getName()
+			);
+			throw new IllegalArgumentException(errorMsg);
+		}
+
+		Criteria criteria = createDistinctRootEntityCriteria(criterion);
+		criteria.add(Restrictions.eq(fieldName, fieldEntity));
+		return (List<E>) criteria.list();
+	}
+
+	/**
 	 * Returns a list of entity objects that have a collection named
 	 * <code>fieldName</code>, which contains the passed
 	 * <code>subElement</code>.

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractCrudService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractCrudService.java
@@ -171,6 +171,21 @@ public abstract class AbstractCrudService<E extends PersistentObject, D extends 
 	}
 
 	/**
+	 * Returns a list of entity objects that have field named
+	 * <code>fieldName</code>, which has an object <code>fieldEntity</code>
+	 * as value.
+	 *
+	 * @param fieldName The name of the field
+	 * @param fieldEntity The element that should be set as value
+	 *
+	 * @return The list of objects
+	 */
+	@PostFilter("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(filterObject, 'READ')")
+	public List<E> findAllWhereFieldEquals(String fieldName, Object fieldEntity) {
+		return dao.findAllWhereFieldEquals(fieldName, fieldEntity);
+	}
+
+	/**
 	 * Returns a list of entity objects that have a collection named
 	 * <code>fieldName</code>, which contains the passed
 	 * <code>subElement</code>.

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractCrudService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractCrudService.java
@@ -176,13 +176,13 @@ public abstract class AbstractCrudService<E extends PersistentObject, D extends 
 	 * as value.
 	 *
 	 * @param fieldName The name of the field
-	 * @param fieldEntity The element that should be set as value
+	 * @param fieldValue The element that should be set as value
 	 *
 	 * @return The list of objects
 	 */
 	@PostFilter("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(filterObject, 'READ')")
-	public List<E> findAllWhereFieldEquals(String fieldName, Object fieldEntity) {
-		return dao.findAllWhereFieldEquals(fieldName, fieldEntity);
+	public List<E> findAllWhereFieldEquals(String fieldName, Object fieldValue) {
+		return dao.findAllWhereFieldEquals(fieldName, fieldValue);
 	}
 
 	/**

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/entity/EntityUtil.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/entity/EntityUtil.java
@@ -24,6 +24,20 @@ import org.springframework.util.MultiValueMap;
 public class EntityUtil {
 
 	/**
+	 * @param clazz
+	 * @param fieldName
+	 * @param forceAccess
+	 * @return
+	 */
+	public static boolean isField(Class<?> clazz, String fieldName, boolean forceAccess) {
+		Field field = FieldUtils.getField(clazz, fieldName, forceAccess);
+		if (field == null) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
 	 * Checks whether the given <code>fieldName</code> in <code>clazz</code> is
 	 * a collection field with elements of type
 	 * <code>collectionElementType</code>.

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/entity/EntityUtil.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/entity/EntityUtil.java
@@ -26,15 +26,24 @@ public class EntityUtil {
 	/**
 	 * @param clazz
 	 * @param fieldName
+	 * @param fieldEntityType
 	 * @param forceAccess
 	 * @return
 	 */
-	public static boolean isField(Class<?> clazz, String fieldName, boolean forceAccess) {
+	public static boolean isField(Class<?> clazz, String fieldName, Class<?> fieldEntityType, boolean forceAccess) {
 		Field field = FieldUtils.getField(clazz, fieldName, forceAccess);
 		if (field == null) {
 			return false;
 		}
-		return true;
+
+		final Class<?> fieldType = field.getType();
+
+		// we'll also return true if the fieldEntityType is null, i.e. "unknown"
+		if(fieldEntityType == null || fieldType.isAssignableFrom(fieldEntityType)) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/dao/GenericHibernateDaoTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/dao/GenericHibernateDaoTest.java
@@ -740,4 +740,57 @@ public class GenericHibernateDaoTest {
 
 		assertTrue("findAllWithCollectionContaining() does throw with invalid collection field", catchedException);
 	}
+
+	/**
+	 * Tests whether findAllWhereFieldEquals works as expected
+	 * in common usage.
+	 */
+	@Test
+	public void findAllWhereFieldEquals_commonUsage() {
+
+		Application a1_1 = this.getMockApp("a1");
+		a1_1.setDescription("a1_1");
+
+		Application a1_2 = this.getMockApp("a1");
+		a1_2.setDescription("a1_2");
+
+		Application a2 = this.getMockApp("a2");
+
+		appDao.saveOrUpdate(a1_1);
+		appDao.saveOrUpdate(a1_2);
+		appDao.saveOrUpdate(a2);
+
+		List<Application> expectSize2List = this.appDao.findAllWhereFieldEquals("name", "a1");
+		assertEquals(2, expectSize2List.size());
+
+		List<Application> expectSize1List = this.appDao.findAllWhereFieldEquals("name", "a2");
+		assertEquals(1, expectSize1List.size());
+
+		List<Application> expectSize0List = this.appDao.findAllWhereFieldEquals("name", "a3");
+		assertEquals(0, expectSize0List.size());
+
+		Criterion descIsA1_1 = Restrictions.eq("description", "a1_1");
+		List<Application> expectDescIsCorrectSize1List = this.appDao.findAllWhereFieldEquals("name", "a1", descIsA1_1);
+		assertEquals(1, expectDescIsCorrectSize1List.size());
+	}
+
+	/**
+	 * Tests whether findAllWhereFieldEquals throws exception if field is not a field.
+	 */
+	@Test
+	public void findAllWhereFieldEquals_shouldThrowIfFieldIsNotAField() {
+
+		boolean catchedException = false;
+
+		try {
+			this.appDao.findAllWhereFieldEquals("non_existing_field", "value");
+		} catch (Exception e) {
+			String msg = e.getMessage();
+			assertEquals("There is no field 'non_existing_field' in the type "
+					+ "'de.terrestris.shogun2.model.Application'", msg);
+			catchedException = true;
+		}
+
+		assertTrue("findAllWhereFieldEquals() does throw with invalid field", catchedException);
+	}
 }

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/dao/GenericHibernateDaoTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/dao/GenericHibernateDaoTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -30,6 +31,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.shogun2.model.Application;
+import de.terrestris.shogun2.model.Plugin;
 import de.terrestris.shogun2.paging.PagingResult;
 
 /**
@@ -39,16 +41,28 @@ import de.terrestris.shogun2.paging.PagingResult;
  * could have been picked.
  */
 @Repository
-class ConcreteDao extends GenericHibernateDao<Application, Integer> {
-	protected ConcreteDao() {
+class AppTestDao extends GenericHibernateDao<Application, Integer> {
+	protected AppTestDao() {
 		super(Application.class);
+	}
+}
+
+/**
+ *
+ * @author Nils Bühner
+ *
+ */
+@Repository
+class PluginTestDao extends GenericHibernateDao<Plugin, Integer> {
+	protected PluginTestDao() {
+		super(Plugin.class);
 	}
 }
 
 /**
  * This class will test the {@link GenericHibernateDao}. As
  * {@link GenericHibernateDao} is an abstract class, we cannot instantiate it.
- * Instead we will use the {@link ConcreteDao} (as the most basic extension of
+ * Instead we will use the {@link AppTestDao} (as the most basic extension of
  * {@link GenericHibernateDao}) to test the logic contained in
  * {@link GenericHibernateDao}.
  *
@@ -62,12 +76,18 @@ class ConcreteDao extends GenericHibernateDao<Application, Integer> {
 public class GenericHibernateDaoTest {
 
 	/**
-	 * We use the {@link ConcreteDao} to test the behaviour of the
+	 * We use the {@link AppTestDao} to test the behaviour of the
 	 * {@link GenericHibernateDao} (which is an abstract class and cannot be
 	 * instantiated).
 	 */
 	@Autowired
-	ConcreteDao dao;
+	AppTestDao appDao;
+
+	/**
+	 *
+	 */
+	@Autowired
+	PluginTestDao pluginDao;
 
 	private Set<String> usedRandomStrings = new HashSet<String>();
 
@@ -148,7 +168,7 @@ public class GenericHibernateDaoTest {
 
 		Application app = getMockApp(appName);
 
-		dao.saveOrUpdate(app);
+		appDao.saveOrUpdate(app);
 
 		return app;
 	}
@@ -170,7 +190,7 @@ public class GenericHibernateDaoTest {
 			Thread.sleep(1);
 
 			// ... then save
-			dao.saveOrUpdate(app);
+			appDao.saveOrUpdate(app);
 
 			ReadableDateTime after = app.getModified();
 
@@ -206,7 +226,7 @@ public class GenericHibernateDaoTest {
 			Thread.sleep(1);
 
 			// ... and only then save, modified should differ now
-			dao.saveOrUpdate(app);
+			appDao.saveOrUpdate(app);
 			ReadableDateTime after = app.getModified();
 
 			// They should be different
@@ -229,7 +249,7 @@ public class GenericHibernateDaoTest {
 	public void saveOrUpdate_shouldUpdateModified() {
 		// first create an application and save it.
 		Application app = new Application("Some Name", "Some description");
-		dao.saveOrUpdate(app);
+		appDao.saveOrUpdate(app);
 
 		ReadableDateTime before = app.getModified();
 
@@ -238,7 +258,7 @@ public class GenericHibernateDaoTest {
 			// change the application
 			app.setName("Some other name");
 			app.setDescription("Changed description");
-			dao.saveOrUpdate(app);
+			appDao.saveOrUpdate(app);
 			ReadableDateTime after = app.getModified();
 
 			// They should be different
@@ -262,7 +282,7 @@ public class GenericHibernateDaoTest {
 		assertNull(app.getId());
 
 		// Test CREATE
-		dao.saveOrUpdate(app);
+		appDao.saveOrUpdate(app);
 
 		Integer id = app.getId();
 
@@ -276,7 +296,7 @@ public class GenericHibernateDaoTest {
 		app.setName(changedNameOfApp);
 		app.setDescription(changedDescOfApp);
 
-		dao.saveOrUpdate(app);
+		appDao.saveOrUpdate(app);
 
 		assertEquals(id, app.getId());
 		assertEquals(changedNameOfApp, app.getName());
@@ -288,7 +308,7 @@ public class GenericHibernateDaoTest {
 	 */
 	@Test
 	public void findById_shouldReturnNullForNonExistingId() {
-		Application app = dao.findById(-90210);
+		Application app = appDao.findById(-90210);
 		assertNull(app);
 	}
 
@@ -299,7 +319,7 @@ public class GenericHibernateDaoTest {
 	public void findById_shouldRetrieveApplication() {
 		Application app = getRandomSavedMockApp();
 		Integer id = app.getId();
-		Application queriedApp = dao.findById(id);
+		Application queriedApp = appDao.findById(id);
 
 		// ... verify we could get it:
 		assertNotNull(queriedApp);
@@ -319,8 +339,8 @@ public class GenericHibernateDaoTest {
 		Integer firstId = firstApp.getId();
 		Integer secondId = secondApp.getId();
 
-		Application queriedFirst = dao.findById(firstId);
-		Application queriedSecond = dao.findById(secondId);
+		Application queriedFirst = appDao.findById(firstId);
+		Application queriedSecond = appDao.findById(secondId);
 
 		assertEquals(firstApp, queriedFirst);
 		assertEquals(secondApp, queriedSecond);
@@ -333,15 +353,15 @@ public class GenericHibernateDaoTest {
 	public void delete_shouldDelete() {
 		Application app = getRandomSavedMockApp();
 		Integer id = app.getId();
-		int numBefore = dao.findAll().size();
+		int numBefore = appDao.findAll().size();
 
 		// ... delete the app
-		dao.delete(app);
+		appDao.delete(app);
 
-		int numAfter = dao.findAll().size();
+		int numAfter = appDao.findAll().size();
 
 		// ...try to get it by id
-		Application queriedAppAfter = dao.findById(id);
+		Application queriedAppAfter = appDao.findById(id);
 
 		assertNull(queriedAppAfter);
 		assertEquals(numBefore, numAfter + 1);
@@ -355,7 +375,7 @@ public class GenericHibernateDaoTest {
 		Application app = getRandomUnsavedMockApp();
 
 		// ... delete the unsaved app
-		dao.delete(app);
+		appDao.delete(app);
 
 		assertTrue(true);
 	}
@@ -365,7 +385,7 @@ public class GenericHibernateDaoTest {
 	 */
 	@Test
 	public void findAll_shouldReturnEmptyListWhenNothingPersisted() {
-		List<Application> all = this.dao.findAll();
+		List<Application> all = this.appDao.findAll();
 
 		assertTrue("findAll() returns list with correct size", all.size() == 0);
 	}
@@ -379,7 +399,7 @@ public class GenericHibernateDaoTest {
 		Application app1 = this.getRandomSavedMockApp();
 		Application app2 = this.getRandomSavedMockApp();
 
-		List<Application> all = this.dao.findAll();
+		List<Application> all = this.appDao.findAll();
 
 		assertTrue("findAll() returns list with correct size", all.size() == 2);
 
@@ -398,16 +418,16 @@ public class GenericHibernateDaoTest {
 		List<Application> got;
 		Criterion c = Restrictions.eq("id", 1);
 
-		got = dao.findByCriteria();
+		got = appDao.findByCriteria();
 		assertTrue("findByCriteria() doesn't throw when no argument", true);
 
-		got = dao.findByCriteria((Criterion) null);
+		got = appDao.findByCriteria((Criterion) null);
 		assertTrue("findByCriteria() doesn't throw when null argument", true);
 
-		got = dao.findByCriteria(c);
+		got = appDao.findByCriteria(c);
 		assertTrue("findByCriteria() doesn't throw when sane argument", true);
 
-		got = dao.findByCriteria(c, (Criterion) null);
+		got = appDao.findByCriteria(c, (Criterion) null);
 		assertTrue("findByCriteria() doesn't throw when arguments mixed", true);
 	}
 
@@ -421,7 +441,7 @@ public class GenericHibernateDaoTest {
 		Application app2 = getRandomSavedMockApp();
 		Criterion c1 = Restrictions.eq("name", app1.getName());
 
-		List<Application> got = dao.findByCriteria(c1);
+		List<Application> got = appDao.findByCriteria(c1);
 
 		assertTrue("findByCriteria() returned expected number of apps",
 				got.size() == 1);
@@ -460,7 +480,7 @@ public class GenericHibernateDaoTest {
 
 		or.add(c1).add(c3);
 
-		List<Application> got = dao.findByCriteria(or);
+		List<Application> got = appDao.findByCriteria(or);
 
 		assertTrue("findByCriteria() returned expected number of apps",
 				got.size() == 2);
@@ -493,7 +513,7 @@ public class GenericHibernateDaoTest {
 		Criterion c1name = Restrictions.eq("name", app1.getName());
 		Criterion c1modified = Restrictions.eq("modified", app1.getModified());
 
-		List<Application> got = dao.findByCriteria(c1name, c1modified);
+		List<Application> got = appDao.findByCriteria(c1name, c1modified);
 
 		assertTrue("findByCriteria() returned expected number of apps",
 				got.size() == 1);
@@ -515,7 +535,7 @@ public class GenericHibernateDaoTest {
 		Set<Application> mockApps = getNrOfRandomSavedMockApps(nrOfMockApps);
 
 		int firstResult = 2;
-		PagingResult<Application> r = dao.findByCriteriaWithSortingAndPaging(firstResult, null , null);
+		PagingResult<Application> r = appDao.findByCriteriaWithSortingAndPaging(firstResult, null , null);
 
 		List<Application> queriedApps = r.getResultList();
 
@@ -536,7 +556,7 @@ public class GenericHibernateDaoTest {
 		Set<Application> mockApps = getNrOfRandomSavedMockApps(nrOfMockApps);
 
 		int maxResults = 3;
-		PagingResult<Application> r = dao.findByCriteriaWithSortingAndPaging(null, maxResults , null);
+		PagingResult<Application> r = appDao.findByCriteriaWithSortingAndPaging(null, maxResults , null);
 
 		List<Application> queriedApps = r.getResultList();
 
@@ -558,13 +578,13 @@ public class GenericHibernateDaoTest {
 
 		// get them in ASC order by id
 		List<Order> ascOrder = Arrays.asList(Order.asc("id"));
-		PagingResult<Application> ascResults = dao.findByCriteriaWithSortingAndPaging(null, null, ascOrder);
+		PagingResult<Application> ascResults = appDao.findByCriteriaWithSortingAndPaging(null, null, ascOrder);
 
 		List<Application> ascApps = ascResults.getResultList();
 
 		// get them in DESC order by id
 		List<Order> descOrder = Arrays.asList(Order.desc("id"));
-		PagingResult<Application> descResults = dao.findByCriteriaWithSortingAndPaging(null, null, descOrder);
+		PagingResult<Application> descResults = appDao.findByCriteriaWithSortingAndPaging(null, null, descOrder);
 
 		List<Application> descApps = descResults.getResultList();
 
@@ -606,7 +626,7 @@ public class GenericHibernateDaoTest {
 		Criterion crit = Restrictions.sqlRestriction("{alias}.id % 2 = 1");
 
 		// query
-		PagingResult<Application> pagingResult = dao.findByCriteriaWithSortingAndPaging(firstResult, maxResults , order, crit);
+		PagingResult<Application> pagingResult = appDao.findByCriteriaWithSortingAndPaging(firstResult, maxResults , order, crit);
 
 		List<Application> resultApps = pagingResult.getResultList();
 
@@ -629,5 +649,95 @@ public class GenericHibernateDaoTest {
 			}
 			previousMax = id;
 		}
+	}
+
+	/**
+	 * Tests whether findAllWithCollectionContaining works as expected
+	 * in common usage.
+	 */
+	@Test
+	public void findAllWithCollectionContaining_commonUsage() {
+
+		List<Plugin> pluginsP1andP2 = new ArrayList<>();
+		List<Plugin> pluginsP2andP3 = new ArrayList<>();
+
+		Plugin p1 = new Plugin();
+		p1.setName("p1");
+		p1.setClassName("p1");
+
+		Plugin p2 = new Plugin();
+		p2.setName("p2");
+		p2.setClassName("p2");
+
+		Plugin p3 = new Plugin();
+		p3.setName("p3");
+		p3.setClassName("p3");
+
+		Plugin p4 = new Plugin();
+		p4.setName("p4");
+		p4.setClassName("p4");
+
+		this.pluginDao.saveOrUpdate(p1);
+		this.pluginDao.saveOrUpdate(p2);
+		this.pluginDao.saveOrUpdate(p3);
+		this.pluginDao.saveOrUpdate(p4);
+
+		pluginsP1andP2.add(p1);
+		pluginsP1andP2.add(p2);
+
+		pluginsP2andP3.add(p2);
+		pluginsP2andP3.add(p3);
+
+		Application a1 = this.getMockApp("a1");
+		a1.setPlugins(pluginsP1andP2);
+
+		Application a2 = this.getMockApp("a2");
+		a2.setPlugins(pluginsP2andP3);
+
+		appDao.saveOrUpdate(a1);
+		appDao.saveOrUpdate(a2);
+
+		// p1 is in a1 only
+		List<Application> expectSize1List = this.appDao.findAllWithCollectionContaining("plugins", p1);
+		assertEquals(1, expectSize1List.size());
+
+		// p2 is in a1 and a2
+		List<Application> expectSize2List = this.appDao.findAllWithCollectionContaining("plugins", p2);
+		assertEquals(2, expectSize2List.size());
+
+		// p4 does not exist in a1 or a2
+		List<Application> expectSize0List = this.appDao.findAllWithCollectionContaining("plugins", p4);
+		assertEquals(0, expectSize0List.size());
+
+		// do some tests with additional criteria
+		Criterion nameIsA1 = Restrictions.eq("name", "a1");
+
+		// A1 contains p1
+		List<Application> nameIsA1Size1List = this.appDao.findAllWithCollectionContaining("plugins", p1, nameIsA1);
+		assertEquals(1, nameIsA1Size1List.size());
+
+		// A1 does not contain p3
+		List<Application> nameIsA1Size0List = this.appDao.findAllWithCollectionContaining("plugins", p3, nameIsA1);
+		assertEquals(0, nameIsA1Size0List.size());
+	}
+
+	/**
+	 * Tests whether findAllWithCollectionContaining throws exception if field is not a collection field.
+	 */
+	@Test
+	public void findAllWithCollectionContaining_shouldThrowIfFieldIsNotCollectionField() {
+
+		boolean catchedException = false;
+
+		try {
+			this.appDao.findAllWithCollectionContaining("no_collection_field", new Plugin());
+		} catch (Exception e) {
+			String msg = e.getMessage();
+			assertEquals("There is no collection field 'no_collection_field' with element type "
+					+ "'de.terrestris.shogun2.model.Plugin' in the type 'de.terrestris.shogun2.model.Application'", msg);
+			catchedException = true;
+		}
+
+		assertTrue("findAllWithCollectionContaining() does throw with invalid collection field", catchedException);
 	}
 }

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/dao/GenericHibernateDaoTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/dao/GenericHibernateDaoTest.java
@@ -743,10 +743,10 @@ public class GenericHibernateDaoTest {
 
 	/**
 	 * Tests whether findAllWhereFieldEquals works as expected
-	 * in common usage.
+	 * in common usage (searching for values)
 	 */
 	@Test
-	public void findAllWhereFieldEquals_commonUsage() {
+	public void findAllWhereFieldEquals_commonUsage_withValue() {
 
 		Application a1_1 = this.getMockApp("a1");
 		a1_1.setDescription("a1_1");
@@ -775,6 +775,43 @@ public class GenericHibernateDaoTest {
 	}
 
 	/**
+	 * Tests whether findAllWhereFieldEquals works as expected
+	 * in common usage (searching for null values)
+	 */
+	@Test
+	public void findAllWhereFieldEquals_commonUsage_withNull() {
+
+		Application a1_1 = this.getMockApp("a1");
+		a1_1.setDescription("a1_1");
+		a1_1.setOpen(true);
+
+		Application a1_2 = this.getMockApp("a1");
+		a1_2.setDescription(null);
+		a1_2.setOpen(true);
+
+		Application a2 = this.getMockApp("a2");
+		a2.setDescription(null);
+		a2.setOpen(null);
+
+		appDao.saveOrUpdate(a1_1);
+		appDao.saveOrUpdate(a1_2);
+		appDao.saveOrUpdate(a2);
+
+		List<Application> expectSize2List = this.appDao.findAllWhereFieldEquals("description", null);
+		assertEquals(2, expectSize2List.size());
+
+		List<Application> expectSize1List = this.appDao.findAllWhereFieldEquals("open", null);
+		assertEquals(1, expectSize1List.size());
+
+		List<Application> expectSize0List = this.appDao.findAllWhereFieldEquals("name", null);
+		assertEquals(0, expectSize0List.size());
+
+		Criterion nameIsA1 = Restrictions.eq("name", "a1");
+		List<Application> expectNameIsCorrectSize1List = this.appDao.findAllWhereFieldEquals("description", null, nameIsA1);
+		assertEquals(1, expectNameIsCorrectSize1List.size());
+	}
+
+	/**
 	 * Tests whether findAllWhereFieldEquals throws exception if field is not a field.
 	 */
 	@Test
@@ -787,7 +824,7 @@ public class GenericHibernateDaoTest {
 		} catch (Exception e) {
 			String msg = e.getMessage();
 			assertEquals("There is no field 'non_existing_field' in the type "
-					+ "'de.terrestris.shogun2.model.Application'", msg);
+					+ "'de.terrestris.shogun2.model.Application' that accepts instances of 'java.lang.String'", msg);
 			catchedException = true;
 		}
 

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/AbstractCrudServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/AbstractCrudServiceTest.java
@@ -303,10 +303,43 @@ public abstract class AbstractCrudServiceTest<E extends PersistentObject, D exte
 	 */
 	@SuppressWarnings("unchecked")
 	@Test
-	public void findAllWhereFieldEquals_shouldWorkAsExpected() {
+	public void findAllWhereFieldEquals_shouldWorkAsExpected_withValues() {
 
 		final String fieldName = "id";
 		final Integer value = 42;
+
+		doAnswer(new Answer<List<E>>() {
+			public List<E> answer(InvocationOnMock invocation)
+					throws InstantiationException, IllegalAccessException, NoSuchFieldException {
+				E po = (E) implToTest.getClass().newInstance();
+
+				// set id like the dao does
+				IdHelper.setIdOnPersistentObject(po, value);
+
+				List<E> r = new ArrayList<>();
+				r.add(po);
+				return r ;
+			}
+		}).when(dao).findAllWhereFieldEquals(fieldName, value);
+
+		List<E> resultList = crudService.findAllWhereFieldEquals(fieldName, value);
+
+		assertNotNull(resultList);
+		assertTrue(resultList.size() == 1);
+
+		// be sure that dao method has been executed exactly once
+		verify(dao, times(1)).findAllWhereFieldEquals(fieldName, value);
+	}
+
+	/**
+	 *
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void findAllWhereFieldEquals_shouldWorkAsExpected_withNull() {
+
+		final String fieldName = "id";
+		final Integer value = null;
 
 		doAnswer(new Answer<List<E>>() {
 			public List<E> answer(InvocationOnMock invocation)

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/AbstractCrudServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/AbstractCrudServiceTest.java
@@ -305,8 +305,8 @@ public abstract class AbstractCrudServiceTest<E extends PersistentObject, D exte
 	@Test
 	public void findAllWhereFieldEquals_shouldWorkAsExpected() {
 
-		String fieldName = "id";
-		Integer value = 42;
+		final String fieldName = "id";
+		final Integer value = 42;
 
 		doAnswer(new Answer<List<E>>() {
 			public List<E> answer(InvocationOnMock invocation)
@@ -338,8 +338,8 @@ public abstract class AbstractCrudServiceTest<E extends PersistentObject, D exte
 	@Test
 	public void findAllWithCollectionContaining_shouldWorkAsExpected() {
 
-		String fieldName = "id";
-		Integer value = 42;
+		final String fieldName = "id";
+		final Integer value = 42;
 
 		doAnswer(new Answer<List<E>>() {
 			public List<E> answer(InvocationOnMock invocation)

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/AbstractCrudServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/AbstractCrudServiceTest.java
@@ -298,4 +298,40 @@ public abstract class AbstractCrudServiceTest<E extends PersistentObject, D exte
 		// maybe this test can be enhanced...
 	}
 
+	/**
+	 *
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void findAllWhereFieldEquals_shouldWorkAsExpected() {
+
+		String fieldName = "id";
+		Integer value = 42;
+
+		doAnswer(new Answer<List<E>>() {
+			public List<E> answer(InvocationOnMock invocation)
+					throws InstantiationException, IllegalAccessException, NoSuchFieldException {
+				E po = (E) implToTest.getClass().newInstance();
+
+				// set id like the dao does
+				IdHelper.setIdOnPersistentObject(po, value);
+
+				List<E> r = new ArrayList<>();
+				r.add(po);
+				return r ;
+			}
+		}).when(dao).findAllWhereFieldEquals(fieldName, value);
+
+		// id has to be NULL before the service method is called
+		assertNull(implToTest.getId());
+
+		List<E> resultList = crudService.findAllWhereFieldEquals(fieldName, value);
+
+		assertNotNull(resultList);
+		assertTrue(resultList.size() == 1);
+
+		// be sure that dao method has been executed exactly once
+		verify(dao, times(1)).findAllWhereFieldEquals(fieldName, value);
+	}
+
 }

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/AbstractCrudServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/AbstractCrudServiceTest.java
@@ -322,9 +322,6 @@ public abstract class AbstractCrudServiceTest<E extends PersistentObject, D exte
 			}
 		}).when(dao).findAllWhereFieldEquals(fieldName, value);
 
-		// id has to be NULL before the service method is called
-		assertNull(implToTest.getId());
-
 		List<E> resultList = crudService.findAllWhereFieldEquals(fieldName, value);
 
 		assertNotNull(resultList);
@@ -332,6 +329,39 @@ public abstract class AbstractCrudServiceTest<E extends PersistentObject, D exte
 
 		// be sure that dao method has been executed exactly once
 		verify(dao, times(1)).findAllWhereFieldEquals(fieldName, value);
+	}
+
+	/**
+	 *
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void findAllWithCollectionContaining_shouldWorkAsExpected() {
+
+		String fieldName = "id";
+		Integer value = 42;
+
+		doAnswer(new Answer<List<E>>() {
+			public List<E> answer(InvocationOnMock invocation)
+					throws InstantiationException, IllegalAccessException, NoSuchFieldException {
+				E po = (E) implToTest.getClass().newInstance();
+
+				// set id like the dao does
+				IdHelper.setIdOnPersistentObject(po, value);
+
+				List<E> r = new ArrayList<>();
+				r.add(po);
+				return r ;
+			}
+		}).when(dao).findAllWithCollectionContaining(fieldName, implToTest);
+
+		List<E> resultList = crudService.findAllWithCollectionContaining(fieldName, implToTest);
+
+		assertNotNull(resultList);
+		assertTrue(resultList.size() == 1);
+
+		// be sure that dao method has been executed exactly once
+		verify(dao, times(1)).findAllWithCollectionContaining(fieldName, implToTest);
 	}
 
 }

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/entity/EntityUtilTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/entity/EntityUtilTest.java
@@ -377,16 +377,36 @@ public class EntityUtilTest {
 	public void test_isField_forPrivateField() {
 		boolean isField;
 
-		isField = EntityUtil.isField(SimpleEntity.class, "privateField", false);
+		isField = EntityUtil.isField(SimpleEntity.class, "privateField", String.class, false);
 		assertFalse(isField);
 
-		isField = EntityUtil.isField(SimpleEntity.class, "privateField", true);
+		isField = EntityUtil.isField(SimpleEntity.class, "privateField", String.class, true);
 		assertTrue(isField);
 
-		isField = EntityUtil.isField(SimpleChildEntity.class, "privateField", false);
+		isField = EntityUtil.isField(SimpleChildEntity.class, "privateField", String.class, false);
 		assertFalse(isField);
 
-		isField = EntityUtil.isField(SimpleChildEntity.class, "privateField", true);
+		isField = EntityUtil.isField(SimpleChildEntity.class, "privateField", String.class, true);
+		assertTrue(isField);
+
+		// field is not integer
+		isField = EntityUtil.isField(SimpleEntity.class, "privateField", Integer.class, false);
+		assertFalse(isField);
+
+		isField = EntityUtil.isField(SimpleEntity.class, "privateField", Integer.class, true);
+		assertFalse(isField);
+
+		isField = EntityUtil.isField(SimpleChildEntity.class, "privateField", Integer.class, false);
+		assertFalse(isField);
+
+		isField = EntityUtil.isField(SimpleChildEntity.class, "privateField", Integer.class, true);
+		assertFalse(isField);
+
+		// "unknown" fieldEntityType
+		isField = EntityUtil.isField(SimpleEntity.class, "privateField", null, true);
+		assertTrue(isField);
+
+		isField = EntityUtil.isField(SimpleChildEntity.class, "privateField", null, true);
 		assertTrue(isField);
 	}
 
@@ -394,16 +414,36 @@ public class EntityUtilTest {
 	public void test_isField_forProtectedField() {
 		boolean isField;
 
-		isField = EntityUtil.isField(SimpleEntity.class, "protectedField", false);
+		isField = EntityUtil.isField(SimpleEntity.class, "protectedField", String.class, false);
 		assertFalse(isField);
 
-		isField = EntityUtil.isField(SimpleEntity.class, "protectedField", true);
+		isField = EntityUtil.isField(SimpleEntity.class, "protectedField", String.class, true);
 		assertTrue(isField);
 
-		isField = EntityUtil.isField(SimpleChildEntity.class, "protectedField", false);
+		isField = EntityUtil.isField(SimpleChildEntity.class, "protectedField", String.class, false);
 		assertFalse(isField);
 
-		isField = EntityUtil.isField(SimpleChildEntity.class, "protectedField", true);
+		isField = EntityUtil.isField(SimpleChildEntity.class, "protectedField", String.class, true);
+		assertTrue(isField);
+
+		// field is not integer
+		isField = EntityUtil.isField(SimpleEntity.class, "protectedField", Integer.class, false);
+		assertFalse(isField);
+
+		isField = EntityUtil.isField(SimpleEntity.class, "protectedField", Integer.class, true);
+		assertFalse(isField);
+
+		isField = EntityUtil.isField(SimpleChildEntity.class, "protectedField", Integer.class, false);
+		assertFalse(isField);
+
+		isField = EntityUtil.isField(SimpleChildEntity.class, "protectedField", Integer.class, true);
+		assertFalse(isField);
+
+		// "unknown" fieldEntityType
+		isField = EntityUtil.isField(SimpleEntity.class, "protectedField", null, true);
+		assertTrue(isField);
+
+		isField = EntityUtil.isField(SimpleChildEntity.class, "protectedField", null, true);
 		assertTrue(isField);
 	}
 
@@ -411,16 +451,36 @@ public class EntityUtilTest {
 	public void test_isField_forPublicField() {
 		boolean isField;
 
-		isField = EntityUtil.isField(SimpleEntity.class, "publicField", false);
+		isField = EntityUtil.isField(SimpleEntity.class, "publicField", String.class, false);
 		assertTrue(isField);
 
-		isField = EntityUtil.isField(SimpleEntity.class, "publicField", true);
+		isField = EntityUtil.isField(SimpleEntity.class, "publicField", String.class, true);
 		assertTrue(isField);
 
-		isField = EntityUtil.isField(SimpleChildEntity.class, "publicField", false);
+		isField = EntityUtil.isField(SimpleChildEntity.class, "publicField", String.class, false);
 		assertTrue(isField);
 
-		isField = EntityUtil.isField(SimpleChildEntity.class, "publicField", true);
+		isField = EntityUtil.isField(SimpleChildEntity.class, "publicField", String.class, true);
+		assertTrue(isField);
+
+		// field is not integer
+		isField = EntityUtil.isField(SimpleEntity.class, "publicField", Integer.class, false);
+		assertFalse(isField);
+
+		isField = EntityUtil.isField(SimpleEntity.class, "publicField", Integer.class, true);
+		assertFalse(isField);
+
+		isField = EntityUtil.isField(SimpleChildEntity.class, "publicField", Integer.class, false);
+		assertFalse(isField);
+
+		isField = EntityUtil.isField(SimpleChildEntity.class, "publicField", Integer.class, true);
+		assertFalse(isField);
+
+		// "unknown" fieldEntityType
+		isField = EntityUtil.isField(SimpleEntity.class, "publicField", null, true);
+		assertTrue(isField);
+
+		isField = EntityUtil.isField(SimpleChildEntity.class, "publicField", null, false);
 		assertTrue(isField);
 	}
 
@@ -428,11 +488,21 @@ public class EntityUtilTest {
 	public void test_isField_forNonExistingField() {
 		boolean isField;
 
-		isField = EntityUtil.isField(SimpleEntity.class, "non_existing_field", false);
+		isField = EntityUtil.isField(SimpleEntity.class, "non_existing_field", String.class, false);
 		assertFalse(isField);
 
-		isField = EntityUtil.isField(SimpleEntity.class, "non_existing_field", true);
+		isField = EntityUtil.isField(SimpleEntity.class, "non_existing_field", String.class, true);
 		assertFalse(isField);
 
+		// field is not integer
+		isField = EntityUtil.isField(SimpleEntity.class, "non_existing_field", Integer.class, false);
+		assertFalse(isField);
+
+		isField = EntityUtil.isField(SimpleEntity.class, "non_existing_field", Integer.class, true);
+		assertFalse(isField);
+
+		// "unknown" fieldEntityType
+		isField = EntityUtil.isField(SimpleEntity.class, "non_existing_field", null, true);
+		assertFalse(isField);
 	}
 }

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/entity/EntityUtilTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/entity/EntityUtilTest.java
@@ -282,6 +282,7 @@ public class EntityUtilTest {
 		isCollectionField = EntityUtil.isCollectionField(
 			EntityWithCollections.class, "publicNeitherListNorSet", TestClassParent.class, false
 		);
+		assertFalse(isCollectionField);
 	}
 
 	@Test
@@ -298,6 +299,7 @@ public class EntityUtilTest {
 		isCollectionField = EntityUtil.isCollectionField(
 			EntityWithCollections.class, "publicNeitherListNorSet", TestClassChild.class, false
 		);
+		assertFalse(isCollectionField);
 	}
 
 	@Test
@@ -314,6 +316,7 @@ public class EntityUtilTest {
 		isCollectionField = EntityUtil.isCollectionField(
 			EntityWithCollections.class, "publicNeitherListNorSet", TestClassGrandChild.class, false
 		);
+		assertFalse(isCollectionField);
 	}
 
 
@@ -333,6 +336,7 @@ public class EntityUtilTest {
 		isCollectionField = EntityUtil.isCollectionField(
 			EntityWithCollections.class, "thisFieldIsNotThere", TestClassParent.class, false
 		);
+		assertFalse(isCollectionField);
 	}
 
 	@Test
@@ -349,6 +353,7 @@ public class EntityUtilTest {
 		isCollectionField = EntityUtil.isCollectionField(
 			EntityWithCollections.class, "thisFieldIsNotThere", TestClassChild.class, false
 		);
+		assertFalse(isCollectionField);
 	}
 
 	@Test
@@ -365,6 +370,7 @@ public class EntityUtilTest {
 		isCollectionField = EntityUtil.isCollectionField(
 			EntityWithCollections.class, "thisFieldIsNotThere", TestClassGrandChild.class, false
 		);
+		assertFalse(isCollectionField);
 	}
 
 	@Test

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/entity/EntityUtilTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/entity/EntityUtilTest.java
@@ -50,6 +50,17 @@ public class EntityUtilTest {
 		public String publicNeitherListNorSet;
 	}
 
+	private class SimpleEntity extends PersistentObject {
+
+		private String privateField;
+		protected String protectedField;
+		public String publicField;
+	}
+
+	private class SimpleChildEntity extends SimpleEntity {
+
+	}
+
 	//
 	// End setup code
 	//
@@ -354,5 +365,68 @@ public class EntityUtilTest {
 		isCollectionField = EntityUtil.isCollectionField(
 			EntityWithCollections.class, "thisFieldIsNotThere", TestClassGrandChild.class, false
 		);
+	}
+
+	@Test
+	public void test_isField_forPrivateField() {
+		boolean isField;
+
+		isField = EntityUtil.isField(SimpleEntity.class, "privateField", false);
+		assertFalse(isField);
+
+		isField = EntityUtil.isField(SimpleEntity.class, "privateField", true);
+		assertTrue(isField);
+
+		isField = EntityUtil.isField(SimpleChildEntity.class, "privateField", false);
+		assertFalse(isField);
+
+		isField = EntityUtil.isField(SimpleChildEntity.class, "privateField", true);
+		assertTrue(isField);
+	}
+
+	@Test
+	public void test_isField_forProtectedField() {
+		boolean isField;
+
+		isField = EntityUtil.isField(SimpleEntity.class, "protectedField", false);
+		assertFalse(isField);
+
+		isField = EntityUtil.isField(SimpleEntity.class, "protectedField", true);
+		assertTrue(isField);
+
+		isField = EntityUtil.isField(SimpleChildEntity.class, "protectedField", false);
+		assertFalse(isField);
+
+		isField = EntityUtil.isField(SimpleChildEntity.class, "protectedField", true);
+		assertTrue(isField);
+	}
+
+	@Test
+	public void test_isField_forPublicField() {
+		boolean isField;
+
+		isField = EntityUtil.isField(SimpleEntity.class, "publicField", false);
+		assertTrue(isField);
+
+		isField = EntityUtil.isField(SimpleEntity.class, "publicField", true);
+		assertTrue(isField);
+
+		isField = EntityUtil.isField(SimpleChildEntity.class, "publicField", false);
+		assertTrue(isField);
+
+		isField = EntityUtil.isField(SimpleChildEntity.class, "publicField", true);
+		assertTrue(isField);
+	}
+
+	@Test
+	public void test_isField_forNonExistingField() {
+		boolean isField;
+
+		isField = EntityUtil.isField(SimpleEntity.class, "non_existing_field", false);
+		assertFalse(isField);
+
+		isField = EntityUtil.isField(SimpleEntity.class, "non_existing_field", true);
+		assertFalse(isField);
+
 	}
 }


### PR DESCRIPTION
This introduces a `findAllWhereFieldEquals` method to DAO and service layer, which is very useful and can be used with `PersistentObject`s and primitve types, too.