### PR TITLE
Become compatible to latest spring versions

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -128,12 +128,12 @@
         <tomcat.version>8.0.38</tomcat.version>
 
         <!-- Core -->
-        <spring.version>4.2.9.RELEASE</spring.version>
-        <spring-security.version>4.0.4.RELEASE</spring-security.version>
+        <spring.version>4.3.7.RELEASE</spring.version>
+        <spring-security.version>4.2.2.RELEASE</spring-security.version>
         <!-- TODO: Raise log4j to version 2 -->
         <log4j.version>1.2.17</log4j.version>
         <slf4j.version>1.7.5</slf4j.version>
-        <jackson.version>2.6.7</jackson.version>
+        <jackson.version>2.8.7</jackson.version>
         <opencsv.version>3.9</opencsv.version>
         <ehcache.version>2.10.3</ehcache.version>
 


### PR DESCRIPTION
For a few months, some tests (REST-POSTs) became red when upgrading to the latest versions of the spring framework, so we had to rely on the version 4.2.9.RELEASE of spring. The problem was related to some changes in the context of JSON-de-/serializing.

As the `public ResponseEntity<E> save(@RequestBody E entity) {}` did not run anymore (as the entity could not be deserialized by jackson anymore), this method has been changed to make it also work with the latest spring versions (without touching any test) (now `public ResponseEntity<E> save(HttpServletRequest request) {}`). The main difference is that the body of the request will be parsed "manually" now:

```Java
BufferedReader reader = null;
reader = request.getReader();
E entity = objectMapper.readValue(reader, getEntityClass());
```

This PR updates the versions of spring and Jackson!