### PR TITLE
Avoid doubled parameters in interceptor post

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
@@ -475,18 +475,17 @@ public class GeoServerInterceptorService {
 					// parse the content type of the request
 					ContentType contentType = ContentType.parse(request.getContentType());
 
-					// perform the request with the given parameters
+					// perform the POST request to the URI with queryString and with the given body
 					httpResponse = HttpUtil.post(requestUri, body, contentType);
 				} else {
 
-					// perform the request with the given parameters
+					// perform the POST request with the given name value pairs,
 					httpResponse = HttpUtil.post(requestUri, allQueryParams);
 				}
 
 			} else {
 				// otherwise throw an exception
-				throw new InterceptorException("Only GET or POST method "
-						+ "is allowed");
+				throw new InterceptorException("Only GET or POST method is allowed");
 			}
 
 		} catch (URISyntaxException | UnsupportedEncodingException e) {
@@ -497,7 +496,8 @@ public class GeoServerInterceptorService {
 	}
 
 	/**
-	 * Adjusted from http://stackoverflow.com/a/26177982
+	 * Returns a new URI with the passed queryString (e.g. foo=bar&baz=123) appended to the passed URI. Adjusted from
+	 * http://stackoverflow.com/a/26177982.
 	 *
 	 * @param uri
 	 * @param appendQuery

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
@@ -505,6 +505,9 @@ public class GeoServerInterceptorService {
 	 * @throws URISyntaxException
 	 */
 	public static URI appendQueryString(URI uri, String appendQuery) {
+		if (uri == null || appendQuery == null || appendQuery.isEmpty()) {
+			return uri;
+		}
 		String newQuery = uri.getQuery();
 		if (newQuery == null) {
 			newQuery = appendQuery;

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
@@ -476,7 +476,7 @@ public class GeoServerInterceptorService {
 							contentType);
 				} else {
 					// perform the request with the given parameters
-					httpResponse = HttpUtil.post(fullRequestUri, queryParams);
+					httpResponse = HttpUtil.post(requestUri, queryParams);
 				}
 
 			} else {

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/GeoServerInterceptorServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/GeoServerInterceptorServiceTest.java
@@ -1,12 +1,14 @@
 package de.terrestris.shogun2.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
@@ -336,9 +338,90 @@ public class GeoServerInterceptorServiceTest {
 
 	@Test(expected=InterceptorException.class)
 	public void get_no_specific_rule() throws Exception {
-
 		getMostSpecificRule("WMS-T", "GetFeatureInfo", "bvb:reus", "REQUEST");
+	}
 
+	@Test
+	public void test_appendQueryString() throws URISyntaxException {
+		URI uri = new URI("http://example.com/index.html");
+		String appendQuery = "foo=bar&humpty=dumpty";
+		URI got = GeoServerInterceptorService.appendQueryString(uri, appendQuery);
+		assertEquals("http://example.com/index.html?foo=bar&humpty=dumpty", got.toString());
+	}
+
+	@Test
+	public void test_appendQueryString_appendsToExistingParams() throws URISyntaxException {
+		URI uri = new URI("http://example.com/index.html?FC=effzeh");
+		String appendQuery = "foo=bar&humpty=dumpty";
+		URI got = GeoServerInterceptorService.appendQueryString(uri, appendQuery);
+		assertEquals("http://example.com/index.html?FC=effzeh&foo=bar&humpty=dumpty", got.toString());
+	}
+
+	@Test
+	public void test_appendQueryString_appendsToExistingParamsOfEqualName() throws URISyntaxException {
+		URI uri = new URI("http://example.com/index.html?foo=baz");
+		String appendQuery = "foo=bar&humpty=dumpty";
+		URI got = GeoServerInterceptorService.appendQueryString(uri, appendQuery);
+		assertEquals("http://example.com/index.html?foo=baz&foo=bar&humpty=dumpty", got.toString());
+	}
+
+	@Test
+	public void test_appendQueryString_handlesHttpsScheme() throws URISyntaxException {
+		URI uri = new URI("https://example.com/index.html");
+		String appendQuery = "foo=bar&humpty=dumpty";
+		URI got = GeoServerInterceptorService.appendQueryString(uri, appendQuery);
+		assertEquals("https://example.com/index.html?foo=bar&humpty=dumpty", got.toString());
+	}
+
+	@Test
+	public void test_appendQueryString_handlesAuthority() throws URISyntaxException {
+		URI uri = new URI("http://user:secret@example.com/index.html");
+		String appendQuery = "foo=bar&humpty=dumpty";
+		URI got = GeoServerInterceptorService.appendQueryString(uri, appendQuery);
+		assertEquals("http://user:secret@example.com/index.html?foo=bar&humpty=dumpty", got.toString());
+	}
+
+	@Test
+	public void test_appendQueryString_handlesFragment() throws URISyntaxException {
+		URI uri = new URI("http://example.com/index.html#my-fragment");
+		String appendQuery = "foo=bar&humpty=dumpty";
+		URI got = GeoServerInterceptorService.appendQueryString(uri, appendQuery);
+		assertEquals("http://example.com/index.html?foo=bar&humpty=dumpty#my-fragment", got.toString());
+	}
+
+	@Test
+	public void test_appendQueryString_handlesComplexCombination() throws URISyntaxException {
+		URI uri = new URI("https://user:secret@example.com/index.html#my-fragment");
+		String appendQuery = "foo=bar&humpty=dumpty";
+		URI got = GeoServerInterceptorService.appendQueryString(uri, appendQuery);
+		assertEquals("https://user:secret@example.com/index.html?foo=bar&humpty=dumpty#my-fragment", got.toString());
+	}
+
+	@Test
+	public void test_appendQueryString_no_uri_no_appendQuery() {
+		URI uri = null;
+		String appendQuery = null;
+		URI got = GeoServerInterceptorService.appendQueryString(uri, appendQuery);
+		// we don't throw, but should always return null
+		assertNull(got);
+	}
+
+	@Test
+	public void test_appendQueryString_no_uri() {
+		URI uri = null;
+		String appendQuery = "foo=bar&humpty=dumpty";
+		URI got = GeoServerInterceptorService.appendQueryString(uri, appendQuery);
+		// we don't throw, but should always return null
+		assertNull(got);
+	}
+
+	@Test
+	public void test_appendQueryString_no_appendQuery() throws URISyntaxException {
+		URI uri = new URI("http://example.com/index.html");
+		String appendQuery = null;
+		URI got = GeoServerInterceptorService.appendQueryString(uri, appendQuery);
+		// return the passed uri
+		assertEquals(uri, got);
 	}
 
 	/**


### PR DESCRIPTION
This removes doubled parameters in an interceptor POST request.
This is open for discussion, i am especially interested in the opinion of @dnlkoch.

The issue i had was an clientside POST with KVPs. This request will be forwarded by the interceptor to the source with KVPs in the BaseUrl and also in the body, leading to doubled KVPs which the GeoServer often does not like.

This change of course would remove the option to have a URL-Get parameter combined with a POST body, but i think this should nearly never be a usecase