### PR TITLE
Save default values on wps process

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsPrimitive.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsPrimitive.java
@@ -26,11 +26,6 @@ public class WpsPrimitive extends WpsParameter {
 	/**
 	 *
 	 */
-	private String defaultTextValue;
-
-	/**
-	 *
-	 */
 	@ManyToOne
 	private Plugin inputPlugin;
 
@@ -38,20 +33,6 @@ public class WpsPrimitive extends WpsParameter {
 	 * Constructor
 	 */
 	public WpsPrimitive() {
-	}
-
-	/**
-	 * @return the defaultTextValue
-	 */
-	public String getDefaultTextValue() {
-		return defaultTextValue;
-	}
-
-	/**
-	 * @param defaultTextValue the defaultTextValue to set
-	 */
-	public void setDefaultTextValue(String defaultTextValue) {
-		this.defaultTextValue = defaultTextValue;
 	}
 
 	/**
@@ -79,7 +60,6 @@ public class WpsPrimitive extends WpsParameter {
 	public int hashCode() {
 		return new HashCodeBuilder(13, 47) // two randomly chosen prime numbers
 			.appendSuper(super.hashCode())
-			.append(getDefaultTextValue())
 			.append(getInputPlugin())
 			.toHashCode();
 	}
@@ -99,7 +79,6 @@ public class WpsPrimitive extends WpsParameter {
 
 		return new EqualsBuilder()
 			.appendSuper(super.equals(other))
-			.append(getDefaultTextValue(), other.getDefaultTextValue())
 			.append(getInputPlugin(), other.getInputPlugin())
 			.isEquals();
 	}
@@ -111,7 +90,6 @@ public class WpsPrimitive extends WpsParameter {
 	public String toString(){
 		return new ToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE)
 			.appendSuper(super.toString())
-			.append("defaultTextValue", defaultTextValue)
 			.append("inputPlugin", inputPlugin)
 			.toString();
 	}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsProcessExecute.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsProcessExecute.java
@@ -3,6 +3,10 @@ package de.terrestris.shogun2.model.wps;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
@@ -14,6 +18,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+
+import de.terrestris.shogun2.converter.PropertyValueConverter;
 
 /**
  *
@@ -45,11 +51,23 @@ public class WpsProcessExecute extends WpsReference {
 	private Map<String, WpsParameter> input = new HashMap<>();
 
 	/**
+	 *
+	 */
+	@ElementCollection
+	@MapKeyColumn(name="IDENTIFIER")
+	@Column(name="VALUE")
+	@CollectionTable(
+			name="WPSPROCESSEXECUTES_INPUTVALUES",
+			joinColumns=@JoinColumn(name="WPSEXECUTEPROCESS_ID")
+		)
+	@Convert(converter = PropertyValueConverter.class, attributeName="value")
+	private Map<String, Object> inputDefaultValues = new HashMap<>();
+
+	/**
 	 * Constructor
 	 */
 	public WpsProcessExecute() {
 	}
-
 
 	/**
 	 * @return the identifier
@@ -57,7 +75,6 @@ public class WpsProcessExecute extends WpsReference {
 	public String getIdentifier() {
 		return identifier;
 	}
-
 
 	/**
 	 * @param identifier the identifier to set
@@ -73,7 +90,6 @@ public class WpsProcessExecute extends WpsReference {
 		return input;
 	}
 
-
 	/**
 	 * @param input the input to set
 	 */
@@ -81,6 +97,19 @@ public class WpsProcessExecute extends WpsReference {
 		this.input = input;
 	}
 
+	/**
+	 * @return the inputDefaultValues
+	 */
+	public Map<String, Object> getInputDefaultValues() {
+		return inputDefaultValues;
+	}
+
+	/**
+	 * @param inputDefaultValues the inputDefaultValues to set
+	 */
+	public void setInputDefaultValues(Map<String, Object> inputDefaultValues) {
+		this.inputDefaultValues = inputDefaultValues;
+	}
 
 	/**
 	 * @see java.lang.Object#hashCode()


### PR DESCRIPTION
Do not save default values on a `WpsPrimitve` (which does not allow to the re-use of equal instances with different default values).

Instead, we'll store default values for input params on instances of `WpsProcessExecute`