### PR TITLE
Use UTF-8 charset as default/fallback in interceptor

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
@@ -475,6 +475,12 @@ public class GeoServerInterceptorService {
 					// parse the content type of the request
 					ContentType contentType = ContentType.parse(request.getContentType());
 
+					if(contentType.getCharset() == null) {
+						// use UTF-8 charset if charset could not be parsed from the content type
+						// of the request
+						contentType = contentType.withCharset("UTF-8");
+					}
+
 					// perform the POST request to the URI with queryString and with the given body
 					httpResponse = HttpUtil.post(requestUri, body, contentType);
 				} else {


### PR DESCRIPTION
If charset cannot be parsed from the content type of a request (e.g. if content type is only `text/xml` but not `text/xml; charset=utf-8`), we should use UTF-8 as the default/fallback.