### PR TITLE
Simplify file upload

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/FileController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/FileController.java
@@ -16,14 +16,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import de.terrestris.shogun2.dao.FileDao;
 import de.terrestris.shogun2.model.File;
 import de.terrestris.shogun2.service.FileService;
 import de.terrestris.shogun2.util.data.ResultSet;
-import de.terrestris.shogun2.util.json.Shogun2JsonObjectMapper;
 
 /**
  *
@@ -65,21 +61,13 @@ public class FileController<E extends File, D extends FileDao<E>, S extends File
 	}
 
 	/**
-	 * Use the object mapper from the spring context, if available (e.g.
-	 * {@link Shogun2JsonObjectMapper}). If not available, the default
-	 * implementation will be used.
-	 */
-	@Autowired(required = false)
-	private ObjectMapper objectMapper;
-
-	/**
 	 * Persists a file as bytearray in the database
 	 *
 	 * @param uploadedFile
 	 * @return
 	 */
 	@RequestMapping(value = "/upload.action", method = RequestMethod.POST)
-	public ResponseEntity<String> uploadFile(
+	public ResponseEntity<?> uploadFile(
 			@RequestParam("file") MultipartFile uploadedFile) {
 
 		LOG.debug("Requested to upload a multipart-file");
@@ -96,28 +84,11 @@ public class FileController<E extends File, D extends FileDao<E>, S extends File
 					e.getMessage());
 		}
 
-		// we have to return the response-Map as String to be browser conform.
-		// as this controller is typically being called by a form.submit() the
-		// browser expects a response with the Content-Type header set to
-		// "text/html".
 		final HttpHeaders responseHeaders = new HttpHeaders();
-		responseHeaders.setContentType(MediaType.TEXT_HTML);
+		responseHeaders.setContentType(MediaType.APPLICATION_JSON_UTF8);
 
 		// rewrite the response-Map as String
-		String responseMapAsString = null;
-		try {
-			// try to use autowired object mapper from spring context
-			ObjectMapper om = (objectMapper != null) ? objectMapper : new ObjectMapper();
-			responseMapAsString = om.writeValueAsString(responseMap);
-		} catch (JsonProcessingException e) {
-			String errMsg = "Error while rewriting the response Map to a String: " + e.getMessage();
-			LOG.error(errMsg);
-
-			// use errorMsg if serialization as json failed
-			responseMapAsString = errMsg;
-		}
-
-		return new ResponseEntity<String>(responseMapAsString, responseHeaders, HttpStatus.OK);
+		return new ResponseEntity<>(responseMap, responseHeaders, HttpStatus.OK);
 	}
 
 	/**

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/web/FileControllerTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/web/FileControllerTest.java
@@ -89,7 +89,7 @@ public class FileControllerTest {
 		mockMvc.perform(
 			MockMvcRequestBuilders.fileUpload("/file/upload.action").file(mockMultipartFile))
 				.andExpect(status().isOk())
-				.andExpect(content().contentType(MediaType.TEXT_HTML))
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
 				.andExpect(jsonPath("$.*", hasSize(3)))
 				.andExpect(jsonPath("$.success", is(true)))
 				.andExpect(jsonPath("$.total", is(1)))
@@ -120,7 +120,7 @@ public class FileControllerTest {
 		mockMvc.perform(
 			MockMvcRequestBuilders.fileUpload("/file/upload.action").file(file))
 				.andExpect(status().isOk())
-				.andExpect(content().contentType(MediaType.TEXT_HTML))
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
 				.andExpect(jsonPath("$.*", hasSize(2)))
 				.andExpect(jsonPath("$.success", is(false)))
 				.andExpect(jsonPath("$.message", containsString(errorMessage)));


### PR DESCRIPTION
This is a simplification of the file upload. When using the Ext framework with a fileupload field and form.submit(), the response content type had to be text/html in the past, so a result json was sent as a string (and parsed in the client again).

It seems that it is now possible to return the json with the correct content type (application/json), which allows a simplification of the code.