### PR TITLE
Add field resolution to MapConfig

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/map/MapConfig.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/map/MapConfig.java
@@ -81,6 +81,11 @@ public class MapConfig extends PersistentObject{
 	/**
 	 *
 	 */
+	private Double resolution;
+
+	/**
+	 *
+	 */
 	private Double maxResolution;
 
 	/**
@@ -202,6 +207,20 @@ public class MapConfig extends PersistentObject{
 	}
 
 	/**
+	 * @return the resolution
+	 */
+	public Double getResolution() {
+		return resolution;
+	}
+
+	/**
+	 * @param resolution the resolution to set
+	 */
+	public void setResolution(Double resolution) {
+		this.resolution = resolution;
+	}
+
+	/**
 	 * @return the maxResolution
 	 */
 	public Double getMaxResolution() {
@@ -275,6 +294,7 @@ public class MapConfig extends PersistentObject{
 				append(getExtent()).
 				append(getResolutions()).
 				append(getZoom()).
+				append(getResolution()).
 				append(getMaxResolution()).
 				append(getMinResolution()).
 				append(getRotation()).
@@ -302,6 +322,7 @@ public class MapConfig extends PersistentObject{
 				append(getExtent(), other.getExtent()).
 				append(getResolutions(), other.getResolutions()).
 				append(getZoom(), other.getZoom()).
+				append(getResolution(), other.getResolution()).
 				append(getMaxResolution(), other.getMaxResolution()).
 				append(getMinResolution(), other.getMinResolution()).
 				append(getRotation(), other.getRotation()).


### PR DESCRIPTION
This adds the field `resolution` to the `MapConfig` model where it can be used to persist the initial/current resolution of a map.