### PR TITLE
Precheck deletion of WpsProcessExecute

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/WpsProcessExecuteService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/WpsProcessExecuteService.java
@@ -1,5 +1,6 @@
 package de.terrestris.shogun2.service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.criterion.Restrictions;
@@ -97,6 +98,30 @@ public class WpsProcessExecuteService<E extends WpsProcessExecute, D extends Wps
 	@Qualifier("wpsProcessExecuteDao")
 	public void setDao(D dao) {
 		this.dao = dao;
+	}
+
+	/**
+	 *
+	 * @param wpsId
+	 * @return List of {@link WpsPlugin}s that are connected to the given {@link WpsProcessExecute}
+	 */
+	@PreAuthorize("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(#wpsId, 'de.terrestris.shogun2.model.wps.WpsProcessExecute', 'DELETE')")
+	public List<String> preCheckDelete(Integer wpsId) {
+		List<String> result = new ArrayList<>();
+
+		E wpsProcessExecute = this.dao.findById(wpsId);
+
+		if (wpsProcessExecute != null) {
+
+			List<WpsPlugin> pluginsWithWps = wpsPluginService.findAllWhereFieldEquals("process", wpsProcessExecute);
+
+			for (WpsPlugin plugin : pluginsWithWps) {
+				result.add(plugin.getName());
+			}
+
+		}
+
+		return result;
 	}
 
 	/**

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/WpsProcessExecuteController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/WpsProcessExecuteController.java
@@ -3,14 +3,22 @@
  */
 package de.terrestris.shogun2.web;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import de.terrestris.shogun2.dao.WpsProcessExecuteDao;
+import de.terrestris.shogun2.model.wps.WpsPlugin;
 import de.terrestris.shogun2.model.wps.WpsProcessExecute;
 import de.terrestris.shogun2.service.WpsProcessExecuteService;
+import de.terrestris.shogun2.util.data.ResultSet;
 
 /**
  *
@@ -48,6 +56,28 @@ public class WpsProcessExecuteController<E extends WpsProcessExecute, D extends 
 	@Qualifier("wpsProcessExecuteService")
 	public void setService(S service) {
 		this.service = service;
+	}
+
+	/**
+	 * Checks in which {@link WpsPlugin}s the given {@link WpsProcessExecute} is
+	 * contained (and from which it would be "disconnected" in case of
+	 * deletion).
+	 *
+	 * @param wpsProcessId
+	 *            ID of the {@link WpsProcessExecute}
+	 * @return
+	 */
+	@RequestMapping(value="preCheckDelete.action", method = RequestMethod.POST)
+	public ResponseEntity<?> preCheckDelete(@RequestParam("wpsProcessId") Integer wpsProcessId) {
+		List<String> result = null;
+		try {
+			result = service.preCheckDelete(wpsProcessId);
+		} catch (Exception e) {
+			final String msg = e.getMessage();
+			LOG.error("Could not pre-check WpsProcessExecute deletion: " + msg);
+			return new ResponseEntity<>(ResultSet.error(msg), HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+		return new ResponseEntity<>(ResultSet.success(result), HttpStatus.OK);
 	}
 
 }


### PR DESCRIPTION
Introduce a new web interface that allows to check from which plugins a WpsProcessExecute instance would be removed in case of deletion.

See https://github.com/terrestris/shogun2/pull/260