### PR TITLE
Add endpoint to retrieve all request mappings as JSON

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/EndpointDocService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/EndpointDocService.java
@@ -1,0 +1,38 @@
+package de.terrestris.shogun2.service;
+
+import java.util.Set;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import de.terrestris.shogun2.web.EndpointDocController;
+
+/**
+ * Service class for the {@link EndpointDocController}.
+ *
+ * @author Christian Mayer
+ */
+@Service("endpoinDocService")
+public class EndpointDocService {
+
+	/**
+	 * Returns all RequestMappingInfo instances from type and
+	 * method-level @RequestMapping annotations in @Controller classes.
+	 *
+	 * @param requestMappingHandlerMapping
+	 *            The RequestMappingInfo collection of Spring
+	 * @return A set of RequestMappingInfo
+	 */
+	@PreAuthorize("hasRole(@configHolder.getSuperAdminRoleName())")
+	public Set<RequestMappingInfo> getEndpoints(RequestMappingHandlerMapping requestMappingHandlerMapping) {
+
+		if (requestMappingHandlerMapping.getHandlerMethods() != null) {
+			return requestMappingHandlerMapping.getHandlerMethods().keySet();
+		}
+
+		return null;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/EndpointDocService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/EndpointDocService.java
@@ -14,7 +14,7 @@ import de.terrestris.shogun2.web.EndpointDocController;
  *
  * @author Christian Mayer
  */
-@Service("endpoinDocService")
+@Service("endpointDocService")
 public class EndpointDocService {
 
 	/**

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/EndpointDocController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/EndpointDocController.java
@@ -1,0 +1,48 @@
+package de.terrestris.shogun2.web;
+
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+/**
+ * 
+ * @author Christian mayer
+ */
+@Controller
+public class EndpointDocController {
+
+	/**
+	 * Creates RequestMappingInfo instances from type and
+	 * method-level @RequestMapping annotations in @Controller classes.
+	 */
+	@Autowired
+	private RequestMappingHandlerMapping requestMappingHandlerMapping;
+
+
+	/**
+	 * Provides an overview of all mapped endpoints.
+	 */
+	@RequestMapping(value = "/endpointdoc", method = RequestMethod.GET)
+	public @ResponseBody Set<RequestMappingInfo> getEndpoints() {
+
+		if (requestMappingHandlerMapping.getHandlerMethods() != null) {
+			return requestMappingHandlerMapping.getHandlerMethods().keySet();
+		}
+		
+		return null;
+	}
+
+
+	/**
+	 * @param requestMappingHandlerMapping the requestMappingHandlerMapping to set
+	 */
+	public void setRequestMappingHandlerMapping(RequestMappingHandlerMapping requestMappingHandlerMapping) {
+		this.requestMappingHandlerMapping = requestMappingHandlerMapping;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/EndpointDocController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/EndpointDocController.java
@@ -3,6 +3,7 @@ package de.terrestris.shogun2.web;
 import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -10,7 +11,10 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
+import de.terrestris.shogun2.service.EndpointDocService;
+
 /**
+ * Web-controller for endpoint documentation.
  * 
  * @author Christian mayer
  */
@@ -24,6 +28,12 @@ public class EndpointDocController {
 	@Autowired
 	private RequestMappingHandlerMapping requestMappingHandlerMapping;
 
+	/**
+	 * The service layer instance
+	 */
+	@Autowired
+	@Qualifier("endpoinDocService")
+	private EndpointDocService service;
 
 	/**
 	 * Provides an overview of all mapped endpoints.
@@ -31,18 +41,24 @@ public class EndpointDocController {
 	@RequestMapping(value = "/endpointdoc", method = RequestMethod.GET)
 	public @ResponseBody Set<RequestMappingInfo> getEndpoints() {
 
-		if (requestMappingHandlerMapping.getHandlerMethods() != null) {
-			return requestMappingHandlerMapping.getHandlerMethods().keySet();
-		}
-		
-		return null;
+		return this.service.getEndpoints(requestMappingHandlerMapping);
 	}
 
 
 	/**
-	 * @param requestMappingHandlerMapping the requestMappingHandlerMapping to set
+	 * @param service
+	 *            the service to set
+	 */
+	public void setService(EndpointDocService service) {
+		this.service = service;
+	}
+
+	/**
+	 * @param requestMappingHandlerMapping
+	 *            the requestMappingHandlerMapping to set
 	 */
 	public void setRequestMappingHandlerMapping(RequestMappingHandlerMapping requestMappingHandlerMapping) {
 		this.requestMappingHandlerMapping = requestMappingHandlerMapping;
 	}
+
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/EndpointDocController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/EndpointDocController.java
@@ -32,7 +32,7 @@ public class EndpointDocController {
 	 * The service layer instance
 	 */
 	@Autowired
-	@Qualifier("endpoinDocService")
+	@Qualifier("endpointDocService")
 	private EndpointDocService service;
 
 	/**

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/web/EndpointDocControllerTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/web/EndpointDocControllerTest.java
@@ -1,0 +1,58 @@
+package de.terrestris.shogun2.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+/**
+ *
+ * @author Christian Mayer
+ */
+public class EndpointDocControllerTest {
+
+	private MockMvc mockMvc;
+
+	/**
+	 * The controller to test
+	 */
+	private EndpointDocController endpointDocController;
+
+	@Mock
+	private RequestMappingHandlerMapping requestMappingHandlerMapping;
+
+	@Before
+	public void setUp() {
+
+		// Process mock annotations
+		MockitoAnnotations.initMocks(this);
+
+		// init the controller to test. this is necessary as InjectMocks
+		// annotation will not work with the constructors of the controllers
+		// (entityClass). see https://goo.gl/jLbMZe
+		endpointDocController = new EndpointDocController();
+		endpointDocController.setRequestMappingHandlerMapping(requestMappingHandlerMapping);
+		// Setup Spring test in standalone mode
+		this.mockMvc = MockMvcBuilders.standaloneSetup(endpointDocController)
+				.build();
+	}
+
+	@Test
+	public void findAllRequestMappings_shouldReturnAllRequestMappings()
+			throws Exception {
+
+		// Perform and test the GET-Request
+		mockMvc.perform(get("/endpointdoc"))
+				.andExpect(status().isOk())
+				.andExpect(
+						content().contentType("application/json;charset=UTF-8"))
+				.andExpect(content().string("[]"));
+	}
+}

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/web/EndpointDocControllerTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/web/EndpointDocControllerTest.java
@@ -12,6 +12,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
+import de.terrestris.shogun2.service.EndpointDocService;
+
 /**
  *
  * @author Christian Mayer
@@ -26,6 +28,9 @@ public class EndpointDocControllerTest {
 	private EndpointDocController endpointDocController;
 
 	@Mock
+	private EndpointDocService endpointDocServiceMock;
+
+	@Mock
 	private RequestMappingHandlerMapping requestMappingHandlerMapping;
 
 	@Before
@@ -38,21 +43,19 @@ public class EndpointDocControllerTest {
 		// annotation will not work with the constructors of the controllers
 		// (entityClass). see https://goo.gl/jLbMZe
 		endpointDocController = new EndpointDocController();
+		endpointDocController.setService(endpointDocServiceMock);
 		endpointDocController.setRequestMappingHandlerMapping(requestMappingHandlerMapping);
 		// Setup Spring test in standalone mode
-		this.mockMvc = MockMvcBuilders.standaloneSetup(endpointDocController)
-				.build();
+		this.mockMvc = MockMvcBuilders.standaloneSetup(endpointDocController).build();
 	}
 
 	@Test
-	public void findAllRequestMappings_shouldReturnAllRequestMappings()
-			throws Exception {
+	public void findAllRequestMappings_shouldReturnAllRequestMappings() throws Exception {
 
 		// Perform and test the GET-Request
 		mockMvc.perform(get("/endpointdoc"))
 				.andExpect(status().isOk())
-				.andExpect(
-						content().contentType("application/json;charset=UTF-8"))
+				.andExpect(content().contentType("application/json;charset=UTF-8"))
 				.andExpect(content().string("[]"));
 	}
 }


### PR DESCRIPTION
This introduces an HTTP-endpoint ``/endpointdoc`` which delivers all mapped HTTP endpoints as JSON objects. Hereby all instances (types and methods) annotated with ``@RequestMapping`` annotations in ``@Controller`` classes are analyzed.

This is very useful to build an automated API documentation for all HTTP endpoints.

Sample output:

``` javascript
{
    name : null,
    patternsCondition : {
        patterns : [ "/my-super-shogun-endpoint" ],
        empty : false
    },
    methodsCondition : {
        methods : [ "POST", "PUT" ],
        empty : false
    },
    paramsCondition : {
        expressions : [],
        empty : true
    },
    headersCondition : {
        expressions : [],
        empty : true
    },
    consumesCondition : {
        expressions : [ {
            mediaType : {
                type : "application",
                subtype : "json",
                parameters : {},
                qualityValue : 1,
                charSet : null,
                wildcardType : false,
                concrete : true,
                wildcardSubtype : false
            },
            negated : false
        } ],
        empty : false,
        consumableMediaTypes : [ {
            type : "application",
            subtype : "json",
            parameters : {},
            qualityValue : 1,
            charSet : null,
            wildcardType : false,
            concrete : true,
            wildcardSubtype : false
        } ]
    },
    producesCondition : {
        expressions : [],
        empty : true,
        producibleMediaTypes : []
    },
    customCondition : null
}
```
