### PR TITLE
Provide an env.properties file in shogun2-webapp-archetype

### DIFF
--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/pom.xml
@@ -164,7 +164,7 @@
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
                 <includes>
-                    <include>META-INF/env.properties</include>
+                    <include>META-INF/**</include>
                 </includes>
             </resource>
         </resources>

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/pom.xml
@@ -157,6 +157,18 @@
             </plugin>
 
         </plugins>
+
+        <!-- Include maven variables (name, version, etc. from pom.xml) in the env.properties file -->
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>META-INF/env.properties</include>
+                </includes>
+            </resource>
+        </resources>
+
     </build>
 
     <dependencies>

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/env.properties
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/env.properties
@@ -1,0 +1,9 @@
+
+env.prj.groupId=${project.groupId}
+env.prj.artifactId=${project.artifactId}
+env.prj.version=${project.version}
+env.prj.packaging=${project.packaging}
+env.prj.name=${project.name}
+env.prj.description=${project.description}
+
+env.prj.shogun2.version=${shogun2.version}


### PR DESCRIPTION
This adds a properties file providing important project information derived from the project's pom.xml.
So the properties (name, version, etc.) can be easily used in the Java code. This is for example very useful for documenting things in an automated way. 

Access could be implemented like this:

``` Java
@PropertySource({ "classpath:META-INF/env.properties" })
public class MyClass {

    @Autowired
    private Environment env;

    private printEnv() {

        System.out.println("groupId " + this.env.getProperty("env.prj.groupId"));
        System.out.println("artifactId " + this.env.getProperty("env.prj.artifactId"));
        System.out.println("version " + this.env.getProperty("env.prj.version"));
        System.out.println("packaging " + this.env.getProperty("env.prj.packaging"));
        System.out.println("name " + this.env.getProperty("env.prj.name"));
        System.out.println("description " + this.env.getProperty("env.prj.description"));
        System.out.println("shogun2.version " + this.env.getProperty("env.prj.shogun2.version"));
    }
}
```
