### PR TITLE
Handlermapping qualifier

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/EndpointDocController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/EndpointDocController.java
@@ -26,7 +26,7 @@ public class EndpointDocController {
 	 * method-level @RequestMapping annotations in @Controller classes.
 	 */
 	@Autowired
-	@Qualifier("handlerMapping")
+	@Qualifier("requestHandlerMapping")
 	private RequestMappingHandlerMapping requestMappingHandlerMapping;
 
 	/**

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/EndpointDocController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/EndpointDocController.java
@@ -15,7 +15,7 @@ import de.terrestris.shogun2.service.EndpointDocService;
 
 /**
  * Web-controller for endpoint documentation.
- * 
+ *
  * @author Christian mayer
  */
 @Controller
@@ -26,6 +26,7 @@ public class EndpointDocController {
 	 * method-level @RequestMapping annotations in @Controller classes.
 	 */
 	@Autowired
+	@Qualifier("handlerMapping")
 	private RequestMappingHandlerMapping requestMappingHandlerMapping;
 
 	/**

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/__artifactId__-servlet.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/__artifactId__-servlet.xml
@@ -48,11 +48,8 @@ ${shogun2-parent-package}.*.web" )
 
 	<annotation-config />
 	
-	<!-- Use the full path within the current servlet context to find an appropriate handler.
-		s. http://docs.spring.io/spring/docs/4.0.7.RELEASE/spring-framework-reference/htmlsingle/#mvc-handlermapping -->
-	<beans:bean id="handlerMapping" class="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
-		<beans:property name="alwaysUseFullPath" value="true"/>
-	</beans:bean>
+	<beans:bean id="requestHandlerMapping"
+		class="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping" />
 
 	<beans:bean id="jacksonObjectMapper"
 		class="de.terrestris.shogun2.util.json.Shogun2JsonObjectMapper" />

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/__artifactId__-servlet.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/__artifactId__-servlet.xml
@@ -47,6 +47,12 @@ ${shogun2-parent-package}.*.web" )
 	</beans:bean>
 
 	<annotation-config />
+	
+	<!-- Use the full path within the current servlet context to find an appropriate handler.
+		s. http://docs.spring.io/spring/docs/4.0.7.RELEASE/spring-framework-reference/htmlsingle/#mvc-handlermapping -->
+	<beans:bean id="handlerMapping" class="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+		<beans:property name="alwaysUseFullPath" value="true"/>
+	</beans:bean>
 
 	<beans:bean id="jacksonObjectMapper"
 		class="de.terrestris.shogun2.util.json.Shogun2JsonObjectMapper" />


### PR DESCRIPTION
The recently introduced  controller `EndpointDocController` for endpoint  to retrieve all request mappings as JSON (https://github.com/terrestris/shogun2/pull/265) contains no unique `@Qualifier` annotation for `requestMappingHandlerMapping` what can be conceivably fragile. 

This MR introduces `handlerMapping` bean inside of archetype servlet XML file and adds the corresponding qualifier to the controller mentioned above.

Please review  @chrismayer @terrestris/devs