### PR TITLE
Assure that read-only methods will not persist

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractCrudService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractCrudService.java
@@ -12,6 +12,7 @@ import org.hibernate.criterion.SimpleExpression;
 import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.MultiValueMap;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -75,6 +76,7 @@ public abstract class AbstractCrudService<E extends PersistentObject, D extends 
 	 * @return
 	 */
 	@PostAuthorize("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(returnObject, 'READ')")
+	@Transactional(readOnly = true)
 	public E findById(Integer id) {
 		return dao.findById(id);
 	}
@@ -88,6 +90,7 @@ public abstract class AbstractCrudService<E extends PersistentObject, D extends 
 	 * @return
 	 */
 	@PostAuthorize("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(returnObject, 'READ')")
+	@Transactional(readOnly = true)
 	public E loadById(int id) {
 		return dao.loadById(id);
 	}
@@ -97,6 +100,7 @@ public abstract class AbstractCrudService<E extends PersistentObject, D extends 
 	 * @return
 	 */
 	@PostFilter("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(filterObject, 'READ')")
+	@Transactional(readOnly = true)
 	public List<E> findAll() {
 		return dao.findAll();
 	}
@@ -129,6 +133,7 @@ public abstract class AbstractCrudService<E extends PersistentObject, D extends 
 	 * @return
 	 */
 	@PostFilter("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(filterObject, 'READ')")
+	@Transactional(readOnly = true)
 	public List<E> findBySimpleFilter(MultiValueMap<String,String> requestedFilter) {
 
 		MultiValueMap<String, Object> origFieldNamesToCastedValues = EntityUtil
@@ -181,6 +186,7 @@ public abstract class AbstractCrudService<E extends PersistentObject, D extends 
 	 * @return The list of objects
 	 */
 	@PostFilter("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(filterObject, 'READ')")
+	@Transactional(readOnly = true)
 	public List<E> findAllWhereFieldEquals(String fieldName, Object fieldValue) {
 		return dao.findAllWhereFieldEquals(fieldName, fieldValue);
 	}
@@ -198,6 +204,7 @@ public abstract class AbstractCrudService<E extends PersistentObject, D extends 
 	 * @return The list of objects
 	 */
 	@PostFilter("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(filterObject, 'READ')")
+	@Transactional(readOnly = true)
 	public List<E> findAllWithCollectionContaining(String fieldName, PersistentObject subElement) {
 		return dao.findAllWithCollectionContaining(fieldName, subElement);
 	}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractTokenService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractTokenService.java
@@ -3,6 +3,7 @@ package de.terrestris.shogun2.service;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
 import org.joda.time.DateTime;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.shogun2.dao.AbstractTokenDao;
 import de.terrestris.shogun2.model.token.Token;
@@ -36,6 +37,7 @@ public abstract class AbstractTokenService<E extends Token, D extends AbstractTo
 	 *
 	 * @return
 	 */
+	@Transactional(readOnly = true)
 	public E findByTokenValue(String token) {
 
 		Criterion criteria = Restrictions.eq("token", token);
@@ -53,6 +55,7 @@ public abstract class AbstractTokenService<E extends Token, D extends AbstractTo
 	 * @throws Exception
 	 *             if the token is not valid (e.g. because it is expired)
 	 */
+	@Transactional(readOnly = true)
 	public void validateToken(E token) throws Exception {
 
 		if (token == null) {

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractUserTokenService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/AbstractUserTokenService.java
@@ -4,6 +4,7 @@ import java.lang.reflect.InvocationTargetException;
 
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.criterion.SimpleExpression;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.shogun2.dao.AbstractUserTokenDao;
 import de.terrestris.shogun2.model.User;
@@ -61,6 +62,7 @@ public abstract class AbstractUserTokenService<E extends UserToken, D extends Ab
 	 * @param user
 	 * @return
 	 */
+	@Transactional(readOnly = true)
 	public E findByUser(User user) {
 
 		SimpleExpression eqUser = Restrictions.eq("user", user);
@@ -79,6 +81,7 @@ public abstract class AbstractUserTokenService<E extends UserToken, D extends Ab
 	 *             if the token is not valid (e.g. because it is expired)
 	 */
 	@Override
+	@Transactional(readOnly = true)
 	public void validateToken(E userToken) throws Exception {
 
 		// call super

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/InterceptorRuleService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/InterceptorRuleService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.shogun2.dao.InterceptorRuleDao;
 import de.terrestris.shogun2.model.interceptor.InterceptorRule;
@@ -44,6 +45,7 @@ public class InterceptorRuleService<E extends InterceptorRule, D extends Interce
 	 * @param event
 	 * @return
 	 */
+	@Transactional(readOnly = true)
 	public List<E> findAllRulesForServiceAndEvent(String service, String event) {
 		return this.dao.findAllRulesForServiceAndEvent(service, event);
 	}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/MapService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/MapService.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.shogun2.dao.LayerDao;
 import de.terrestris.shogun2.dao.MapDao;
@@ -65,6 +66,7 @@ public class MapService<E extends Map, D extends MapDao<E>> extends
 	 * @return
 	 */
 	@PreAuthorize("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(#layer, 'READ')")
+	@Transactional(readOnly = true)
 	public Set<E> findMapsWithLayer(Layer layer) {
 		return dao.findMapsWithLayer(layer);
 	}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/PermissionAwareCrudService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/PermissionAwareCrudService.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.shogun2.dao.GenericHibernateDao;
 import de.terrestris.shogun2.dao.PermissionCollectionDao;
@@ -344,6 +345,7 @@ public class PermissionAwareCrudService<E extends PersistentObject, D extends Ge
 	 * @return
 	 */
 	@PreAuthorize("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(#user, 'READ')")
+	@Transactional(readOnly = true)
 	public Map<PersistentObject, PermissionCollection> findAllUserPermissionsOfUser(User user) {
 		return dao.findAllUserPermissionsOfUser(user);
 	}
@@ -359,6 +361,7 @@ public class PermissionAwareCrudService<E extends PersistentObject, D extends Ge
 	 * @return
 	 */
 	@PreAuthorize("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(#userGroup, 'READ')")
+	@Transactional(readOnly = true)
 	public Map<PersistentObject, PermissionCollection> findAllUserGroupPermissionsOfUserGroup(UserGroup userGroup) {
 		return dao.findAllUserGroupPermissionsOfUserGroup(userGroup);
 	}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/PluginService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/PluginService.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.shogun2.dao.ApplicationDao;
 import de.terrestris.shogun2.dao.PluginDao;
@@ -77,6 +78,7 @@ public class PluginService<E extends Plugin, D extends PluginDao<E>> extends
 	 * @return
 	 * @throws Exception
 	 */
+	@Transactional(readOnly = true)
 	public String getPluginSource(String simpleClassName) throws Exception {
 
 		// qualify className
@@ -103,6 +105,7 @@ public class PluginService<E extends Plugin, D extends PluginDao<E>> extends
 	 * @return List of application names that contain the given plugin
 	 */
 	@PreAuthorize("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(#pluginId, 'de.terrestris.shogun2.model.Plugin', 'DELETE')")
+	@Transactional(readOnly = true)
 	public List<String> preCheckDelete(Integer pluginId) {
 		List<String> result = new ArrayList<>();
 

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/RoleService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/RoleService.java
@@ -5,6 +5,7 @@ import org.hibernate.criterion.SimpleExpression;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.shogun2.dao.RoleDao;
 import de.terrestris.shogun2.model.Role;
@@ -42,6 +43,7 @@ public class RoleService<E extends Role, D extends RoleDao<E>> extends
 	 * @param roleName A unique role name.
 	 * @return The unique role for the role name or null.
 	 */
+	@Transactional(readOnly = true)
 	public E findByRoleName(String roleName) {
 
 		SimpleExpression eqRoleName =

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/UserGroupService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/UserGroupService.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.shogun2.dao.UserGroupDao;
 import de.terrestris.shogun2.model.User;
@@ -59,6 +60,7 @@ public class UserGroupService<E extends UserGroup, D extends UserGroupDao<E>>
 	 * @throws Exception
 	 */
 	@PostFilter("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(filterObject, 'READ')")
+	@Transactional(readOnly = true)
 	public Set<User> getUsersOfGroup(Integer groupId) throws Exception {
 
 		Set<User> groupUsersSet = new HashSet<User>();

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/UserService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/UserService.java
@@ -12,6 +12,7 @@ import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.shogun2.dao.RegistrationTokenDao;
 import de.terrestris.shogun2.dao.RoleDao;
@@ -98,6 +99,7 @@ public class UserService<E extends User, D extends UserDao<E>> extends
 	 * @return The unique user for the account name or null.
 	 */
 	@PostAuthorize("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(#accountName, 'READ')")
+	@Transactional(readOnly = true)
 	public E findByAccountName(String accountName) {
 		return dao.findByAccountName(accountName);
 	}
@@ -108,6 +110,7 @@ public class UserService<E extends User, D extends UserDao<E>> extends
 	 * @return
 	 */
 	@PostAuthorize("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(#email, 'READ')")
+	@Transactional(readOnly = true)
 	public E findByEmail(String email) {
 		return dao.findByEmail(email);
 	}
@@ -232,6 +235,7 @@ public class UserService<E extends User, D extends UserDao<E>> extends
 	 * @param request
 	 * @throws Exception
 	 */
+	@Transactional(readOnly = true)
 	public E getUserBySession() {
 
 		final Object principal = SecurityContextHolder.getContext()
@@ -259,6 +263,7 @@ public class UserService<E extends User, D extends UserDao<E>> extends
 	 * @throws Exception
 	 */
 	@PostFilter("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(filterObject, 'READ')")
+	@Transactional(readOnly = true)
 	public Set<UserGroup> getGroupsOfUser(Integer userId) throws Exception {
 
 		Set<UserGroup> userGroupsSet = new HashSet<UserGroup>();

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/WpsProcessExecuteService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/WpsProcessExecuteService.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.terrestris.shogun2.dao.WpsPluginDao;
 import de.terrestris.shogun2.dao.WpsProcessExecuteDao;
@@ -106,6 +107,7 @@ public class WpsProcessExecuteService<E extends WpsProcessExecute, D extends Wps
 	 * @return List of {@link WpsPlugin}s that are connected to the given {@link WpsProcessExecute}
 	 */
 	@PreAuthorize("hasRole(@configHolder.getSuperAdminRoleName()) or hasPermission(#wpsId, 'de.terrestris.shogun2.model.wps.WpsProcessExecute', 'DELETE')")
+	@Transactional(readOnly = true)
 	public List<String> preCheckDelete(Integer wpsId) {
 		List<String> result = new ArrayList<>();
 


### PR DESCRIPTION
Last week, we had a strange bug in a project where database entries disappeared after calling a _read-only_ method. The reason was related to the fact that a persisted entity has been manipulated within this transactional method. Even though no `saveOrUpdate` was called, the manipulated entity has been persisted automatically by the underlying transaction manager.

We could fix this bug by annotating the method with `@Transactional(readOnly = true)`

This PR annotates all _read-only_ transactional service methods within the shogun2 project to assure that this will not happen due to shogun2 code :wink: 