### PR TITLE
Do not run CI with oracle JDK 7 anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
 sudo: false
 
 jdk:
-  - oraclejdk7
   - oraclejdk8
   - openjdk7
 


### PR DESCRIPTION
`oraclejdk7` is no longer supported in travis CI, so we should remove it from the `.travis.yml` to avoid failing builds.

see

https://github.com/travis-ci/travis-ci/issues/7019#issuecomment-316769716
https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
http://www.webupd8.org/2017/06/why-oracle-java-7-and-6-installers-no.html