### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -188,7 +188,7 @@
         <jta.version>1.1</jta.version>
 
         <!-- Java Servlet API -->
-        <javax-servlet-api.version>4.0.0</javax-servlet-api.version>
+        <javax-servlet-api.version>3.1.0</javax-servlet-api.version>
 
         <!-- Apache HTTP Client -->
         <apache-httpclient.version>4.5.3</apache-httpclient.version>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -125,23 +125,23 @@
 
         <webapp-archetype-resource-pom>shogun2-webapp-archetype/src/main/resources/archetype-resources/pom.xml</webapp-archetype-resource-pom>
 
-        <tomcat.version>8.0.43</tomcat.version>
+        <tomcat.version>8.5.20</tomcat.version>
 
         <!-- Core -->
-        <spring.version>4.3.8.RELEASE</spring.version>
-        <spring-security.version>4.2.2.RELEASE</spring-security.version>
+        <spring.version>4.3.11.RELEASE</spring.version>
+        <spring-security.version>4.2.3.RELEASE</spring-security.version>
         <!-- TODO: Raise log4j to version 2 -->
         <log4j.version>1.2.17</log4j.version>
-        <slf4j.version>1.7.5</slf4j.version>
-        <jackson.version>2.8.8</jackson.version>
-        <opencsv.version>3.9</opencsv.version>
-        <ehcache.version>2.10.3</ehcache.version>
+        <slf4j.version>1.7.25</slf4j.version>
+        <jackson.version>2.9.1</jackson.version>
+        <opencsv.version>4.0</opencsv.version>
+        <ehcache.version>2.10.4</ehcache.version>
 
         <!-- Persistence -->
-        <hibernate.version>5.1.6.Final</hibernate.version>
+        <hibernate.version>5.1.10.Final</hibernate.version>
         <hikari-jdk7.version>2.4.11</hikari-jdk7.version>
         <hikari.version>2.6.1</hikari.version>
-        <h2.version>1.4.195</h2.version>
+        <h2.version>1.4.196</h2.version>
 
         <!-- Testing -->
         <junit.version>4.12</junit.version>
@@ -157,8 +157,8 @@
         <!-- Apache Commons -->
         <commons-io.version>2.5</commons-io.version>
         <commons-beanutils.version>1.9.3</commons-beanutils.version>
-        <commons-lang3.version>3.5</commons-lang3.version>
-        <commons-dbutils.version>1.6</commons-dbutils.version>
+        <commons-lang3.version>3.6</commons-lang3.version>
+        <commons-dbutils.version>1.7</commons-dbutils.version>
         <commons-collections4.version>4.1</commons-collections4.version>
 
         <!-- Joda Time -->
@@ -179,16 +179,16 @@
 
         <!-- Other -->
         <imgscalr.version>4.2</imgscalr.version>
-        <structured-content-tools.version>1.3.9</structured-content-tools.version>
+        <structured-content-tools.version>1.3.10</structured-content-tools.version>
 
         <!-- Java Mail API -->
-        <javax-mail-api.version>1.5.6</javax-mail-api.version>
+        <javax-mail-api.version>1.6.0</javax-mail-api.version>
 
         <!-- Java Transaction API -->
         <jta.version>1.1</jta.version>
 
         <!-- Java Servlet API -->
-        <javax-servlet-api.version>3.1.0</javax-servlet-api.version>
+        <javax-servlet-api.version>4.0.0</javax-servlet-api.version>
 
         <!-- Apache HTTP Client -->
         <apache-httpclient.version>4.5.3</apache-httpclient.version>
@@ -197,7 +197,7 @@
         <jaxp-api.version>1.4.5</jaxp-api.version>
 
         <!-- Powermock -->
-        <powermock.version>1.6.6</powermock.version>
+        <powermock.version>1.7.1</powermock.version>
 
         <!-- Java Topology Suite -->
         <jts.version>1.14.0</jts.version>

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/Csv2ExtJsLocaleService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/Csv2ExtJsLocaleService.java
@@ -20,7 +20,10 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Service;
 
+import com.opencsv.CSVParser;
+import com.opencsv.CSVParserBuilder;
 import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
 
 /**
  *
@@ -52,7 +55,16 @@ public class Csv2ExtJsLocaleService {
 
 		FileInputStream fileIs = new FileInputStream(csvResource.getFile().getCanonicalPath());
 		Reader reader = new InputStreamReader(fileIs, StandardCharsets.UTF_8);
-		CSVReader csvReader = new CSVReader(reader, ';', '"', '\\');
+
+		final CSVParser csvParser = new CSVParserBuilder().
+				withSeparator(';').
+				withQuoteChar('"').
+				withEscapeChar('\\').
+				build();
+
+		final CSVReader csvReader = new CSVReaderBuilder(reader).
+				withCSVParser(csvParser).
+				build();
 
 		try {
 			int columnIndexOfLocale = detectColumnIndexOfLocale(locale, csvReader);

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/json/Shogun2JsonObjectMapper.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/json/Shogun2JsonObjectMapper.java
@@ -5,7 +5,7 @@ import java.util.TimeZone;
 import com.bedatadriven.jackson.datatype.jts.JtsModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 
 /**
@@ -38,9 +38,9 @@ public class Shogun2JsonObjectMapper extends ObjectMapper {
 		// register JTS geometry types
 		this.registerModule(new JtsModule());
 
-		// serialize dates in ISO8601 with time zone of the host
+		// StdDateFormat is ISO8601 since jackson 2.9
 		configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-		setDateFormat(new ISO8601DateFormat());
+		setDateFormat(new StdDateFormat());
 		setTimeZone(TimeZone.getDefault());
 	}
 

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/json/Shogun2JsonObjectMapperTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/json/Shogun2JsonObjectMapperTest.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 
 /**
@@ -56,8 +56,8 @@ public class Shogun2JsonObjectMapperTest {
 		DateFormat serializationDateFormat = serializationConfig.getDateFormat();
 		DateFormat deserializationDateFormat = deserializationConfig.getDateFormat();
 
-		assertThat(serializationDateFormat, instanceOf(ISO8601DateFormat.class));
-		assertThat(deserializationDateFormat, instanceOf(ISO8601DateFormat.class));
+		assertThat(serializationDateFormat, instanceOf(StdDateFormat.class));
+		assertThat(deserializationDateFormat, instanceOf(StdDateFormat.class));
 	}
 
 	/**


### PR DESCRIPTION
This PR updates the depedencies to the latest compatible versions.

In case of the following libraries, smaller code adaptions were necessary to get rid of methods/constructors that are deprecated in the now used versions:

* open csv
* jackson

All tests are green and i successfully tested a complex application with the new dependencies.