### PR TITLE
Fix toString methods

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Application.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Application.java
@@ -17,8 +17,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 import org.joda.time.ReadableDateTime;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
@@ -257,16 +255,6 @@ public class Application extends PersistentObject {
 				append(getUrl(), other.getUrl()).
 				append(getViewport(), other.getViewport()).
 				isEquals();
-	}
-
-	/**
-	 * @see java.lang.Object#equals(java.lang.Object)
-	 *
-	 *      Using Apache Commons String Builder.
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/File.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/File.java
@@ -11,8 +11,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -148,13 +146,5 @@ public class File extends PersistentObject {
 				.append(getFileName(), other.getFileName())
 				.append(getFileType(), other.getFileType())
 				.isEquals();
-	}
-
-	/**
-	 *
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/ImageFile.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/ImageFile.java
@@ -9,8 +9,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -124,13 +122,5 @@ public class ImageFile extends File {
 				.append(getWidth(), other.getWidth())
 				.append(getHeight(), other.getHeight())
 				.isEquals();
-	}
-
-	/**
-	 *
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Plugin.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Plugin.java
@@ -222,12 +222,11 @@ public class Plugin extends PersistentObject {
 	 */
 	@Override
 	public String toString(){
-		return new ToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE)
+		return new ToStringBuilder(this, ToStringStyle.DEFAULT_STYLE)
 			.appendSuper(super.toString())
 			.append("name", name)
 			.append("className", className)
 			.append("xtype", xtype)
-			.append("sourcecode", sourceCode)
 			.append("stylesheet", styleSheet)
 			.append("systemPlugin", systemPlugin)
 			.toString();

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Role.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Role.java
@@ -6,8 +6,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * @author Nils Bühner
@@ -103,12 +101,5 @@ public class Role extends PersistentObject {
 				append(getName(), other.getName()).
 				append(getDescription(), other.getDescription()).
 				isEquals();
-	}
-
-	/**
-	 *
-	 */
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Territory.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Territory.java
@@ -1,20 +1,15 @@
 package de.terrestris.shogun2.model;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import com.vividsolutions.jts.geom.MultiPolygon;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-
-import de.terrestris.shogun2.model.PersistentObject;
 
 /**
  *
@@ -127,14 +122,6 @@ public class Territory extends PersistentObject {
 				append(getName(), other.getName()).
 				append(getGeometry(), other.getGeometry()).
 				isEquals();
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/UserGroup.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/UserGroup.java
@@ -15,8 +15,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * @author Nils Bühner
@@ -155,12 +153,5 @@ public class UserGroup extends PersistentObject {
 				append(getMembers(), other.getMembers()).
 				append(getRoles(), other.getRoles()).
 				isEquals();
-	}
-
-	/**
-	 *
-	 */
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/Layer.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/Layer.java
@@ -8,8 +8,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 
@@ -186,14 +184,6 @@ public class Layer extends PersistentObject {
 				append(getSource(), other.getSource()).
 				append(getAppearance(), other.getAppearance()).
 				isEquals();
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/appearance/LayerAppearance.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/appearance/LayerAppearance.java
@@ -14,8 +14,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.shogun2.converter.PropertyValueConverter;
 import de.terrestris.shogun2.model.PersistentObject;
@@ -292,14 +290,6 @@ public class LayerAppearance extends PersistentObject{
 				append(getHoverTemplate(), other.getHoverTemplate()).
 				append(getProperties(), other.getProperties()).
 				isEquals();
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/ImageWmsLayerDataSource.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/ImageWmsLayerDataSource.java
@@ -5,8 +5,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * Class representing a layer data source for WMS servers providing single,
@@ -178,14 +176,6 @@ public class ImageWmsLayerDataSource extends LayerDataSource {
 				append(getLayerNames(), other.getLayerNames()).
 				append(getLayerStyles(), other.getLayerStyles()).
 				isEquals();
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/LayerDataSource.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/LayerDataSource.java
@@ -1,14 +1,11 @@
 package de.terrestris.shogun2.model.layer.source;
 
+import javax.persistence.Entity;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
-
-import javax.persistence.Entity;
 
 import de.terrestris.shogun2.model.PersistentObject;
 
@@ -126,14 +123,6 @@ public abstract class LayerDataSource extends PersistentObject {
 				append(getType(), other.getType()).
 				append(getUrl(), other.getUrl()).
 				isEquals();
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/TileWmsLayerDataSource.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/TileWmsLayerDataSource.java
@@ -7,8 +7,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.ColumnDefault;
@@ -82,6 +80,21 @@ public class TileWmsLayerDataSource extends ImageWmsLayerDataSource {
 	}
 
 	/**
+	 * @return the requestWithTiled
+	 */
+	public Boolean getRequestWithTiled() {
+		return requestWithTiled;
+	}
+
+	/**
+	 * @param requestWithTiled
+	 *            the requestWithTiled to set
+	 */
+	public void setRequestWithTiled(Boolean requestWithTiled) {
+		this.requestWithTiled = requestWithTiled;
+	}
+
+	/**
 	 * @see java.lang.Object#hashCode()
 	 *
 	 *      According to
@@ -116,29 +129,6 @@ public class TileWmsLayerDataSource extends ImageWmsLayerDataSource {
 				appendSuper(super.equals(other)).
 				append(getTileGrid(), other.getTileGrid()).
 				isEquals();
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
-	}
-
-	/**
-	 * @return the requestWithTiled
-	 */
-	public Boolean getRequestWithTiled() {
-		return requestWithTiled;
-	}
-
-	/**
-	 * @param requestWithTiled
-	 *            the requestWithTiled to set
-	 */
-	public void setRequestWithTiled(Boolean requestWithTiled) {
-		this.requestWithTiled = requestWithTiled;
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/VectorLayerDataSource.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/VectorLayerDataSource.java
@@ -5,8 +5,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * Data source of <a href= "http://openlayers.org/en/master/apidoc/ol.layer.Vector.html">OpenLayers 3 vector layer</a>
@@ -90,14 +88,6 @@ public class VectorLayerDataSource extends LayerDataSource {
 				appendSuper(super.equals(other)).
 				append(getFormat(), other.getFormat()).
 				isEquals();
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/WmtsLayerDataSource.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/WmtsLayerDataSource.java
@@ -5,8 +5,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  *
@@ -63,14 +61,6 @@ public class WmtsLayerDataSource extends LayerDataSource {
 		return new EqualsBuilder().
 				appendSuper(super.equals(other)).
 				isEquals();
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/XyzLayerDataSource.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/XyzLayerDataSource.java
@@ -19,8 +19,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.shogun2.model.layer.util.Extent;
 
@@ -184,14 +182,6 @@ public class XyzLayerDataSource extends LayerDataSource {
 				append(getResolutions(), other.getResolutions()).
 				append(getTileSize(), other.getTileSize()).
 				isEquals();
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/util/Extent.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/util/Extent.java
@@ -15,8 +15,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.shogun2.model.PersistentObject;
 
@@ -154,14 +152,5 @@ public class Extent extends PersistentObject {
 				append(getUpperRight(), other.getUpperRight()).
 				isEquals();
 	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
-	}
-
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/util/TileGrid.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/util/TileGrid.java
@@ -20,8 +20,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
 
@@ -219,14 +217,6 @@ public class TileGrid extends PersistentObject {
 				append(getTileSize(), other.getTileSize()).
 				append(getTileGridResolutions(), other.getTileGridResolutions()).
 				isEquals();
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layout/AbsoluteLayout.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layout/AbsoluteLayout.java
@@ -17,8 +17,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.shogun2.model.module.CompositeModule;
 
@@ -107,13 +105,6 @@ public class AbsoluteLayout extends Layout {
 				appendSuper(super.equals(other)).
 				append(getCoords(), other.getCoords()).
 				isEquals();
-	}
-
-	/**
-	 *
-	 */
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layout/BorderLayout.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layout/BorderLayout.java
@@ -16,8 +16,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.shogun2.model.module.CompositeModule;
 
@@ -106,13 +104,6 @@ public class BorderLayout extends Layout {
 				appendSuper(super.equals(other)).
 				append(getRegions(), other.getRegions()).
 				isEquals();
-	}
-
-	/**
-	 *
-	 */
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layout/Layout.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layout/Layout.java
@@ -17,8 +17,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.model.module.CompositeModule;
@@ -161,10 +159,4 @@ public class Layout extends PersistentObject {
 				isEquals();
 	}
 
-	/**
-	 *
-	 */
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
-	}
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/map/MapConfig.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/map/MapConfig.java
@@ -17,8 +17,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.shogun2.model.PersistentObject;
 import de.terrestris.shogun2.model.layer.util.Extent;
@@ -328,14 +326,6 @@ public class MapConfig extends PersistentObject{
 				append(getRotation(), other.getRotation()).
 				append(getProjection(), other.getProjection()).
 				isEquals();
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/map/MapControl.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/map/MapControl.java
@@ -14,8 +14,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.shogun2.converter.PropertyValueConverter;
 import de.terrestris.shogun2.model.PersistentObject;
@@ -141,14 +139,6 @@ public class MapControl extends PersistentObject {
 				append(getMapControlName(), other.getMapControlName()).
 				append(getMapControlProperties(), other.getMapControlProperties()).
 				isEquals();
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/AccordionPanel.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/AccordionPanel.java
@@ -8,8 +8,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * This class represents the an Panel with an accordion layout.
@@ -85,13 +83,6 @@ public class AccordionPanel extends CompositeModule {
 				appendSuper(super.equals(other)).
 				append(getExpandedItem(), other.getExpandedItem()).
 				isEquals();
-	}
-
-	/**
-	 *
-	 */
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Button.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Button.java
@@ -8,8 +8,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.shogun2.model.Application;
 
@@ -229,13 +227,6 @@ public class Button extends Module {
 				append(getButtonAction(), other.getButtonAction()).
 				append(getDefaultButton(), other.getDefaultButton()).
 				isEquals();
-	}
-
-	/**
-	 *
-	 */
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/CompositeModule.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/CompositeModule.java
@@ -16,8 +16,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.shogun2.model.layout.Layout;
 
@@ -146,13 +144,5 @@ public class CompositeModule extends Module {
 				.append(getLayout(), other.getLayout())
 				.append(getSubModules(), other.getSubModules())
 				.isEquals();
-	}
-
-	/**
-	 *
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/CoordinateTransformation.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/CoordinateTransformation.java
@@ -16,8 +16,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * The CoordinateTransform module allows the user to transform map coordinates into
@@ -122,13 +120,6 @@ public class CoordinateTransformation extends Module {
 				append(getEpsgCodes(), other.getEpsgCodes()).
 				append(getTransformCenterOnRender(), other.getTransformCenterOnRender()).
 				isEquals();
-	}
-
-	/**
-	 *
-	 */
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Image.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Image.java
@@ -8,8 +8,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * The Image Module is the Ext JS representation of an HTML img element.
@@ -127,13 +125,6 @@ public class Image extends Module {
 				append(getLink(), other.getLink()).
 				append(getAltText(), other.getAltText()).
 				isEquals();
-	}
-
-	/**
-	 *
-	 */
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Map.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Map.java
@@ -18,8 +18,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.shogun2.model.layer.Layer;
 import de.terrestris.shogun2.model.map.MapConfig;
@@ -170,14 +168,6 @@ public class Map extends Module {
 				append(getMapControls(), other.getMapControls()).
 				append(getMapLayers(), other.getMapLayers()).
 				isEquals();
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Module.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Module.java
@@ -19,8 +19,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.shogun2.converter.PropertyValueConverter;
 import de.terrestris.shogun2.model.PersistentObject;
@@ -164,13 +162,5 @@ public class Module extends PersistentObject {
 				append(getXtype(), other.getXtype()).
 				append(getProperties(), other.getProperties()).
 				isEquals();
-	}
-
-	/**
-	 *
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/NominatimSearch.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/NominatimSearch.java
@@ -18,8 +18,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -265,13 +263,6 @@ public class NominatimSearch extends Module {
 				append(getTypeDelay(), other.getTypeDelay()).
 				append(getGroupHeaderTpl(), other.getGroupHeaderTpl()).
 				isEquals();
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/OverpassSearch.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/OverpassSearch.java
@@ -18,8 +18,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -265,13 +263,6 @@ public class OverpassSearch extends Module {
 				append(getTypeDelay(), other.getTypeDelay()).
 				append(getGroupHeaderTpl(), other.getGroupHeaderTpl()).
 				isEquals();
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/OverviewMap.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/OverviewMap.java
@@ -16,8 +16,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
@@ -165,14 +163,6 @@ public class OverviewMap extends Module {
 				append(getOverviewMapLayers(), other.getOverviewMapLayers()).
 				append(getParentMapModule(), other.getParentMapModule()).
 				isEquals();
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Print.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Print.java
@@ -8,8 +8,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * A module which contains a formular to print the map with the mapfish print v3.
@@ -85,13 +83,6 @@ public class Print extends Module {
 				appendSuper(super.equals(other)).
 				append(getUrl(), other.getUrl()).
 				isEquals();
-	}
-
-	/**
-	 *
-	 */
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/WfsSearch.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/WfsSearch.java
@@ -18,8 +18,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
@@ -228,13 +226,6 @@ public class WfsSearch extends Module {
 				append(getLayers(), other.getLayers()).
 				append(getAllowedFeatureTypeDataTypes(), other.getAllowedFeatureTypeDataTypes()).
 				isEquals();
-	}
-
-	/**
-	 *
-	 */
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/token/PasswordResetToken.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/token/PasswordResetToken.java
@@ -3,9 +3,6 @@ package de.terrestris.shogun2.model.token;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
-
 import de.terrestris.shogun2.model.User;
 
 /**
@@ -44,14 +41,6 @@ public class PasswordResetToken extends UserToken {
 	 */
 	public PasswordResetToken(User user, int expirationInMinutes) {
 		super(user, expirationInMinutes);
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/token/RegistrationToken.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/token/RegistrationToken.java
@@ -3,9 +3,6 @@ package de.terrestris.shogun2.model.token;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
-
 import de.terrestris.shogun2.model.User;
 
 /**
@@ -44,14 +41,6 @@ public class RegistrationToken extends UserToken {
 	 */
 	public RegistrationToken(User user, int expirationInMinutes) {
 		super(user, expirationInMinutes);
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/token/Token.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/token/Token.java
@@ -9,8 +9,6 @@ import javax.persistence.InheritanceType;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 import org.hibernate.annotations.Type;
 import org.joda.time.DateTime;
 import org.joda.time.ReadableDateTime;
@@ -130,14 +128,6 @@ public abstract class Token extends PersistentObject {
 				append(getToken(), other.getToken()).
 				append(getExpirationDate(), other.getExpirationDate()).
 				isEquals();
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/token/UserToken.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/token/UserToken.java
@@ -6,8 +6,6 @@ import javax.persistence.OneToOne;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import de.terrestris.shogun2.model.User;
 
@@ -113,14 +111,6 @@ public abstract class UserToken extends Token {
 				appendSuper(super.equals(other)).
 				append(getUser(), other.getUser()).
 				isEquals();
-	}
-
-	/* (non-Javadoc)
-	 * @see java.lang.Object#toString()
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/tree/TreeFolder.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/tree/TreeFolder.java
@@ -13,8 +13,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * This class represents a (simple) composite {@link TreeNode}, i.e. a folder
@@ -110,13 +108,5 @@ public class TreeFolder extends TreeNode {
 				.appendSuper(super.equals(other))
 				.append(getChildren(), other.getChildren())
 				.isEquals();
-	}
-
-	/**
-	 *
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/tree/TreeNode.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/tree/TreeNode.java
@@ -12,8 +12,6 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
@@ -369,13 +367,5 @@ public class TreeNode extends PersistentObject {
 				append(getqTip(), other.getqTip()).
 				append(getqTitle(), other.getqTitle()).
 				isEquals();
-	}
-
-	/**
-	 *
-	 */
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);
 	}
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsParameter.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsParameter.java
@@ -185,7 +185,7 @@ public abstract class WpsParameter extends PersistentObject {
 	 */
 	@Override
 	public String toString(){
-		return new ToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE)
+		return new ToStringBuilder(this, ToStringStyle.DEFAULT_STYLE)
 			.appendSuper(super.toString())
 			.append("valueType", valueType)
 			.append("displayName", displayName)

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsPlugin.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsPlugin.java
@@ -101,7 +101,7 @@ public class WpsPlugin extends Plugin {
 	 */
 	@Override
 	public String toString(){
-		return new ToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE)
+		return new ToStringBuilder(this, ToStringStyle.DEFAULT_STYLE)
 			.appendSuper(super.toString())
 			.append("process", process)
 			.toString();

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsPrimitive.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsPrimitive.java
@@ -88,7 +88,7 @@ public class WpsPrimitive extends WpsParameter {
 	 */
 	@Override
 	public String toString(){
-		return new ToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE)
+		return new ToStringBuilder(this, ToStringStyle.DEFAULT_STYLE)
 			.appendSuper(super.toString())
 			.append("inputPlugin", inputPlugin)
 			.toString();

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsProcessExecute.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsProcessExecute.java
@@ -150,7 +150,7 @@ public class WpsProcessExecute extends WpsReference {
 	 */
 	@Override
 	public String toString(){
-		return new ToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE)
+		return new ToStringBuilder(this, ToStringStyle.DEFAULT_STYLE)
 			.appendSuper(super.toString())
 			.append("identifier", identifier)
 			.toString();

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsReference.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/wps/WpsReference.java
@@ -156,7 +156,7 @@ public class WpsReference extends WpsParameter {
 	 */
 	@Override
 	public String toString(){
-		return new ToStringBuilder(this, ToStringStyle.MULTI_LINE_STYLE)
+		return new ToStringBuilder(this, ToStringStyle.DEFAULT_STYLE)
 			.appendSuper(super.toString())
 			.append("url", url)
 			.append("mimeType", mimeType)


### PR DESCRIPTION
This will simplify the implementations of `toString` methods. This makes sense as the use of `ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE);` may impact the performance (because hibernate will lazily query all related data).