### PR TITLE
Fixtures for usage of SHOGun2 with Oracle databases

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/TileWmsLayerDataSource.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/TileWmsLayerDataSource.java
@@ -37,8 +37,7 @@ public class TileWmsLayerDataSource extends ImageWmsLayerDataSource {
 	 * Whether to request the layer with TILED=true.
 	 */
 	@Column(name = "REQUEST_WITH_TILED")
-	@ColumnDefault(value = "true")
-	private Boolean requestWithTiled = true;
+	private Boolean requestWithTiled = Boolean.TRUE;
 
 	/**
 	 * default constructor

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/dialect/Shogun2OracleDialect.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/dialect/Shogun2OracleDialect.java
@@ -1,0 +1,36 @@
+package de.terrestris.shogun2.util.dialect;
+
+import org.hibernate.dialect.Oracle12cDialect;
+import org.hibernate.dialect.Dialect;
+
+import java.sql.Types;
+
+/**
+ * SQL {@link Dialect} extending {@link Oracle12cDialect} to register
+ * column mapping for LOB datatypes used in SHOGun2 (e.g. file content
+ * in {@link de.terrestris.shogun2.model.File})
+ *
+ * @author Andre Henn
+ * @author terrestris GmbH & co. KG
+ */
+public class Shogun2OracleDialect extends Oracle12cDialect {
+
+	/**
+	 *
+	 */
+	public Shogun2OracleDialect() {
+		super();
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	protected void registerLargeObjectTypeMappings() {
+		super.registerLargeObjectTypeMappings();
+
+		registerColumnType( Types.VARBINARY , "blob" );
+		registerColumnType( Types.LONGVARCHAR, "clob" );
+		registerColumnType( Types.LONGVARBINARY, "long raw" );
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/naming/OracleNamingStrategyShogun2.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/naming/OracleNamingStrategyShogun2.java
@@ -1,0 +1,62 @@
+package de.terrestris.shogun2.util.naming;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+/**
+ * Naming strategy for Oracle DBs checking if
+ * * length of column name is lesser than 30 characters
+ * * column name does not match a reserved word (determined from Oracle DB's system dictionary V$RESERVED_WORDS
+ *
+ * @author Andre Henn
+ * @author terrestris GmbH & co. KG
+ */
+public class OracleNamingStrategyShogun2 extends PhysicalNamingStrategyShogun2 {
+
+	private final String[] RESERVED_WORDS_ORACLE = new String[]{"TRIGGER", "WHERE", "REVOKE", "INTERSECT", "CONNECT",
+			"GRANT", "OF", "ORDER", "HAVING", "NULL", "SMALLINT", "RENAME", "BETWEEN", "SHARE", "MODE", "UNION", "SET",
+			"VALUES", "VIEW", "WITH", "CHAR", "FROM", "BY", "OR", "ELSE", "THEN", "CHECK", "VARCHAR2", "VARCHAR", "CREATE",
+			"AS", "LONG", "SYNONYM", "ASC", "DESC", "CLUSTER", "AND", "ALTER", "PCTFREE", "FLOAT", "COMPRESS", "INSERT",
+			"NOT", "DELETE", "IDENTIFIED", "ANY", "INTEGER", "SIZE", "NOWAIT", "EXCLUSIVE", "FOR", "DECIMAL", "SELECT",
+			"UNIQUE", "PRIOR", "RESOURCE", "TABLE", "DATE", "LIKE", "RAW", "OPTION", "MINUS", "ON", "INTO", "PUBLIC",
+			"TO", "DEFAULT", "DROP", "UPDATE", "NOCOMPRESS", "INDEX", "ALL", "IS", "EXISTS", "DISTINCT", "LOCK", "GROUP",
+			"NUMBER", "FILE", "START", "IN"};
+	/**
+	 * Prefix to use in case of naming conflicts
+	 */
+	private String columnNamePrefix = "_";
+
+	/**
+	 * Check if column {@link Identifier} equals reserved word. If true, add prefix to column name
+	 *
+	 * @param name    identifier to check
+	 * @param context JDBC env
+	 *
+	 * @return Identifier
+	 */
+	@Override
+	public Identifier toPhysicalColumnName(Identifier name, JdbcEnvironment context) {
+		// call superclass and get string value
+		Identifier columnIdentifier = super.toPhysicalColumnName(name, context);
+		String columnIdentifierText = columnIdentifier.getText();
+		if (StringUtils.equalsAnyIgnoreCase(columnIdentifierText, RESERVED_WORDS_ORACLE)) {
+			columnIdentifier = convertToLimitedLowerCase(context, columnIdentifier, columnNamePrefix);
+		}
+
+		return columnIdentifier;
+	}
+
+	/**
+	 * Set the column name prefix
+	 *
+	 * @param columnNamePrefix prefix to set
+	 */
+	@Autowired(required = false)
+	@Qualifier("columnNamePrefix")
+	public void setColumnNamePrefix(String columnNamePrefix) {
+		this.columnNamePrefix = columnNamePrefix;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/naming/PhysicalNamingStrategyShogun2.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/naming/PhysicalNamingStrategyShogun2.java
@@ -112,7 +112,7 @@ public class PhysicalNamingStrategyShogun2 implements PhysicalNamingStrategy, Se
 			// identifier limit of 30 chars -->
 			// http://stackoverflow.com/a/756569
 			return LENGTH_LIMIT_ORACLE;
-		} if (context.getDialect() instanceof Shogun2OracleDialect) {
+		} else if (context.getDialect() instanceof Shogun2OracleDialect) {
 			// identifier limit of 30 chars -->
 			return LENGTH_LIMIT_ORACLE;
 		} else if (dialectName.startsWith("PostgreSQL")) {

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/naming/PhysicalNamingStrategyShogun2.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/naming/PhysicalNamingStrategyShogun2.java
@@ -1,11 +1,14 @@
 package de.terrestris.shogun2.util.naming;
 
+import de.terrestris.shogun2.util.dialect.Shogun2OracleDialect;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.boot.model.naming.Identifier;
-import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl;
+import org.hibernate.boot.model.naming.PhysicalNamingStrategy;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.io.Serializable;
 
 /**
  * Limits identifier length if necessary.
@@ -13,7 +16,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
  * @author Nils Bühner
  *
  */
-public class PhysicalNamingStrategyShogun2 extends PhysicalNamingStrategyStandardImpl {
+public class PhysicalNamingStrategyShogun2 implements PhysicalNamingStrategy, Serializable {
 
 	private static final long serialVersionUID = 1L;
 
@@ -25,15 +28,26 @@ public class PhysicalNamingStrategyShogun2 extends PhysicalNamingStrategyStandar
 	@Qualifier("tablePrefix")
 	private String tablePrefix;
 
+	@Override
+	public Identifier toPhysicalSequenceName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+		return name;
+	}
+
+	@Override
+	public Identifier toPhysicalCatalogName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+		return name;
+	}
+
+	@Override
+	public Identifier toPhysicalSchemaName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+		return name;
+	}
+
 	/**
 	 * Converts table names to lower case and limits the length if necessary.
 	 */
 	@Override
-	public Identifier toPhysicalTableName(Identifier name, JdbcEnvironment context) {
-
-		// call superclass and get string value
-		Identifier tableIdentifier = super.toPhysicalTableName(name, context);
-
+	public Identifier toPhysicalTableName(Identifier tableIdentifier, JdbcEnvironment context) {
 		return convertToLimitedLowerCase(context, tableIdentifier, tablePrefix);
 	}
 
@@ -41,11 +55,7 @@ public class PhysicalNamingStrategyShogun2 extends PhysicalNamingStrategyStandar
 	 * Converts column names to lower case and limits the length if necessary.
 	 */
 	@Override
-	public Identifier toPhysicalColumnName(Identifier name, JdbcEnvironment context) {
-
-		// call superclass and get string value
-		Identifier columnIdentifier = super.toPhysicalColumnName(name, context);
-
+	public Identifier toPhysicalColumnName(Identifier columnIdentifier, JdbcEnvironment context) {
 		return convertToLimitedLowerCase(context, columnIdentifier, null);
 	}
 
@@ -63,7 +73,7 @@ public class PhysicalNamingStrategyShogun2 extends PhysicalNamingStrategyStandar
 	 *            null
 	 * @return
 	 */
-	private Identifier convertToLimitedLowerCase(JdbcEnvironment context, Identifier identifier, String prefix) {
+	protected Identifier convertToLimitedLowerCase(JdbcEnvironment context, Identifier identifier, String prefix) {
 		String identifierText = identifier.getText();
 
 		if(prefix != null) {
@@ -94,8 +104,7 @@ public class PhysicalNamingStrategyShogun2 extends PhysicalNamingStrategyStandar
 	 * @return The identifier length limit for the given context. null
 	 *         otherwise.
 	 */
-	private Integer getIdentifierLengthLimit(JdbcEnvironment context) {
-
+	protected Integer getIdentifierLengthLimit(JdbcEnvironment context) {
 		// https://docs.jboss.org/hibernate/orm/5.0/javadocs/org/hibernate/dialect/package-summary.html
 		String dialectName = context.getDialect().getClass().getSimpleName();
 
@@ -103,7 +112,9 @@ public class PhysicalNamingStrategyShogun2 extends PhysicalNamingStrategyStandar
 			// identifier limit of 30 chars -->
 			// http://stackoverflow.com/a/756569
 			return LENGTH_LIMIT_ORACLE;
-
+		} if (context.getDialect() instanceof Shogun2OracleDialect) {
+			// identifier limit of 30 chars -->
+			return LENGTH_LIMIT_ORACLE;
 		} else if (dialectName.startsWith("PostgreSQL")) {
 			// identifier limit of 63 chars -->
 			// http://stackoverflow.com/a/8218026

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/naming/OracleNamingStrategyShogun2Test.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/naming/OracleNamingStrategyShogun2Test.java
@@ -1,0 +1,76 @@
+package de.terrestris.shogun2.util.naming;
+
+import de.terrestris.shogun2.util.dialect.Shogun2OracleDialect;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.SQLException;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+/**
+ * TODO: add documentation
+ *
+ * @author Andre Henn
+ */
+public class OracleNamingStrategyShogun2Test extends PhysicalNamingStrategyShogun2Test{
+
+	private final String TEST_PREFIX = "pref_";
+
+	private OracleNamingStrategyShogun2 oracleNamingStrategyShogun2;
+
+	@Before
+	public void initStrategy() {
+		this.oracleNamingStrategyShogun2 = new OracleNamingStrategyShogun2();
+		oracleNamingStrategyShogun2.setColumnNamePrefix("pref_");
+	}
+
+	/**
+	 * Tests whether physical column are transformed to lowercase.
+	 *
+	 * @throws SQLException
+	 */
+	@Test
+	public void testPhysicalColumnNamesAreLowercaseForOracleDialect() throws SQLException {
+		String columnName = "SomeCamelCaseColumn";
+		String expectedPhysicalName = "somecamelcasecolumn";
+		Dialect dialect = new Shogun2OracleDialect();
+
+		assertExpectedPhysicalColumnName(dialect, columnName, expectedPhysicalName);
+	}
+
+	/**
+	 * Tests whether physical column are transformed to lowercase.
+	 *
+	 * @throws SQLException
+	 */
+	@Test
+	public void testPhysicalColumnNamesAddPrefixToReservedOracleWord() throws SQLException {
+		String columnName = "index";
+		String expectedPhysicalName = TEST_PREFIX+"index";
+		Dialect dialect = new Shogun2OracleDialect();
+
+		assertExpectedPhysicalColumnName(dialect, columnName, expectedPhysicalName);
+	}
+
+	/**
+	 * @param dialect
+	 * @param columnName
+	 * @param expectedPhysicalColumnName
+	 */
+	private void assertExpectedPhysicalColumnName(Dialect dialect, String columnName, String expectedPhysicalColumnName) {
+		JdbcEnvironment context = Mockito.mock(JdbcEnvironment.class);
+		when(context.getDialect()).thenReturn(dialect);
+
+		Identifier classIdentifier = Identifier.toIdentifier(columnName);
+		String actualPhysicalName = oracleNamingStrategyShogun2.toPhysicalColumnName(classIdentifier, context).getText();
+
+		assertEquals(expectedPhysicalColumnName, actualPhysicalName);
+	}
+
+}

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/naming/OracleNamingStrategyShogun2Test.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/naming/OracleNamingStrategyShogun2Test.java
@@ -14,8 +14,6 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 
 /**
- * TODO: add documentation
- *
  * @author Andre Henn
  */
 public class OracleNamingStrategyShogun2Test extends PhysicalNamingStrategyShogun2Test{


### PR DESCRIPTION
This PR contains some additions that are needed to get SHOGun2 running on a Oracle 12c database.
In particular:
* Custom Oracle dialect that registers certain LOB types (used e.g. in `File` or `Plugin`)
* Add a more specific implementation of [PhysicalNamingStrategy interface](https://docs.jboss.org/hibernate/orm/5.1/javadocs/org/hibernate/boot/model/naming/PhysicalNamingStrategy.html)  for oracle databases, that:
    * checks for reserved words (determined from Oracle DB's system dictionary`V$RESERVED_WORDS`)
    * checks that length of column name is lesser than 30 characters (as already implemented in `PhysicalNamingStrategyShogun2 `)

In order to use SHOGun2 using an Oracle instance, you've to include these in the following way (e.g. with column name prefix `pref_`)

`hibernate.properties`:
```
hibernate.dialect=de.terrestris.shogun2.util.Shogun2OracleDialect
....
ddl.colPrefix=pref_
....
```


`hibernate.properties`:
```
hibernate.dialect=de.terrestris.shogun2.util.Shogun2OracleDialect
....
ddl.colPrefix=pref_
....
```

In the database context definition, e.g. `project-context-db.xml`, include `columnNamePrefix` bean and set the naming strategy in your `sessionFactory`:

```
<bean id="columnNamePrefix" class="java.lang.String">
    <constructor-arg value="${ddl.colPrefix}"></constructor-arg>
</bean>
...
<bean id="sessionFactory"  class="org.springframework.orm.hibernate5.LocalSessionFactoryBean">
    ....
    <property name="physicalNamingStrategy">
        <bean class="de.terrestris.shogun2.util.naming.OracleNamingStrategyShogun2" />
    </property>
    ....
</bean>

```

Please review @terrestris/devs 