### PR TITLE
Reduce the interceptor logging on DEBUG

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
@@ -154,7 +154,7 @@ public class GeoServerInterceptorService {
 	private OgcMessage getOgcMessage(MutableHttpServletRequest mutableRequest)
 			throws InterceptorException, IOException {
 
-		LOG.debug("Building the OGC message from the given request.");
+		LOG.trace("Building the OGC message from the given request.");
 
 		OgcMessage ogcMessage = new OgcMessage();
 
@@ -217,7 +217,7 @@ public class GeoServerInterceptorService {
 			LOG.debug("No interceptor rule found for the response.");
 		}
 
-		LOG.debug("Successfully build the OGC message: " + ogcMessage);
+		LOG.trace("Successfully build the OGC message: " + ogcMessage);
 
 		return ogcMessage;
 	}
@@ -320,8 +320,8 @@ public class GeoServerInterceptorService {
 					"least the basic sets of rules (e.g. ALLOW all WMS " +
 					"requests) when using the interceptor.");
 			throw new InterceptorException("No interceptor rule found.");
-		} else {
-			LOG.debug("Identified the following rule as most the specific " +
+		} else if(LOG.isTraceEnabled()) {
+			LOG.trace("Identified the following rule as most the specific " +
 					"one: " + mostSpecificRule);
 		}
 
@@ -406,7 +406,7 @@ public class GeoServerInterceptorService {
 		// get the namespace from the qualified endPoint name
 		String geoServerNamespace = getGeoServerNameSpace(message.getEndPoint());
 
-		LOG.debug("Found the following GeoServer namespace set in the "
+		LOG.trace("Found the following GeoServer namespace set in the "
 				+ "EndPoint: " + geoServerNamespace);
 
 		// set the GeoServer base URL

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
@@ -1891,7 +1891,7 @@ public class HttpUtil {
 
 				if (header.getName().equalsIgnoreCase("Transfer-Encoding") &&
 					header.getValue().equalsIgnoreCase("chunked")) {
-					LOG.debug("Removed the header 'Transfer-Encoding:chunked'" +
+					LOG.trace("Removed the header 'Transfer-Encoding:chunked'" +
 							" from a response, as its handled by the http-client");
 				} else {
 					headersMap.set(header.getName(), header.getValue());

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequest.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequest.java
@@ -98,7 +98,7 @@ public class MutableHttpServletRequest extends HttpServletRequestWrapper {
 	public static String getRequestParameterValue(HttpServletRequest httpServletRequest,
 			String parameter) throws InterceptorException, IOException {
 
-		LOG.debug("Finding the request parameter [" + parameter + "]");
+		LOG.trace("Finding the request parameter [" + parameter + "]");
 
 		String value = StringUtils.EMPTY;
 
@@ -152,7 +152,7 @@ public class MutableHttpServletRequest extends HttpServletRequestWrapper {
 			}
 		}
 
-		LOG.debug("Found the request parameter value: " + value);
+		LOG.trace("Found the request parameter value: " + value);
 
 		return value;
 	}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/GeoServerInterceptorController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/GeoServerInterceptorController.java
@@ -64,7 +64,7 @@ public class GeoServerInterceptorController<S extends GeoServerInterceptorServic
 
 		try {
 
-			LOG.debug("Trying to intercept a GeoServer resource.");
+			LOG.trace("Trying to intercept a GeoServer resource.");
 
 			httpResponse = this.service.interceptGeoServerRequest(request);
 
@@ -72,7 +72,7 @@ public class GeoServerInterceptorController<S extends GeoServerInterceptorServic
 			responseBody = httpResponse.getBody();
 			responseHeaders = httpResponse.getHeaders();
 
-			LOG.debug("Successfully intercepted a GeoServer resource.");
+			LOG.trace("Successfully intercepted a GeoServer resource.");
 
 			return new ResponseEntity<byte[]>(responseBody,
 					responseHeaders, responseStatus);


### PR DESCRIPTION
In my eyes the geoserver interceptor was logging too much on the DEBUG level, which lead to messy logs during development (and may even slow down the performance) as a lot of "trace-level" information like HTTP headers etc were logged.

This will PR changes some logs from DEBUG to TRACE, but for an intercepted request, the following logs will still remain on DEBUG:

```
2017-10-17 14:57:27,995 DEBUG [de.terrestris.shogun2.service.GeoServerInterceptorService] - Finding the GeoServer base URI by the provided EndPoint: foo:bar
2017-10-17 14:57:27,999 DEBUG [de.terrestris.shogun2.service.GeoServerInterceptorService] - The corresponding GeoServer base URI is: http://localhost:8080/geoserver/foo/ows
2017-10-17 14:57:27,999 DEBUG [de.terrestris.shogun2.util.interceptor.OgcMessageDistributor] - Request is ALLOWED, not intercepting the request.
2017-10-17 14:57:28,184 DEBUG [de.terrestris.shogun2.util.interceptor.OgcMessageDistributor] - Response is ALLOWED, not intercepting the response.
```