### PR TITLE
Make getGeoServerBaseURIFromNameSpace method be public again

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
@@ -414,7 +414,7 @@ public class GeoServerInterceptorService {
 	 * @throws URISyntaxException
 	 * @throws InterceptorException
 	 */
-	private URI getGeoServerBaseURIFromNameSpace(String geoServerNamespace, boolean useWmsReflector, boolean isWMS)
+	public URI getGeoServerBaseURIFromNameSpace(String geoServerNamespace, boolean useWmsReflector, boolean isWMS)
 			throws URISyntaxException, InterceptorException {
 
 		URI uri = null;


### PR DESCRIPTION
Visibility of the method `getGeoServerBaseUriFromNameSpace` was [decreased](https://github.com/terrestris/shogun2/pull/280/files#diff-3ca41da6aab8eea4ad1630eec73b2825L374) from `public` to `private` in #280. That has broken backwards compatibility for some projects which make use of this method.

This PR makes `getGeoServerBaseURIFromNameSpace` be public again.

Please review @buehner @ahennr 
