### PR TITLE
ResultSet util - return error map containing additional information

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/data/ResultSet.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/data/ResultSet.java
@@ -53,4 +53,20 @@ public final class ResultSet {
 
 		return returnMap;
 	}
+
+	/**
+	 * Method returning error message and additional return values
+	 * @param errorMsg The error message
+	 * @param additionalReturnValuesMap {@link Map} containing additional information
+	 * @return Map to use e.g. as {@link org.springframework.http.ResponseEntity}
+	 */
+	public static final Map<String, Object> error(String errorMsg, Map additionalReturnValuesMap) {
+
+		Map<String, Object> returnMap = new HashMap<String, Object>(3);
+		returnMap.put("message", errorMsg);
+		returnMap.put("additionalInfo", additionalReturnValuesMap);
+		returnMap.put("success", false);
+
+		return returnMap;
+	}
 }

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/data/ResultSetTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/data/ResultSetTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -71,6 +72,26 @@ public class ResultSetTest {
 
 		assertNotNull("Message does not become null", resultSet);
 		makeErrorFieldAssertions(resultSet);
+	}
+
+	@Test
+	public void testErrorWithMessageAndAdditionalInfo() {
+		final String additionalInfoKey = "additionalInfo";
+		final String testKey = "foo";
+		final String testValue = "bar";
+		final Map<String, Object> testMap = new HashMap<>();
+		testMap.put(testKey, testValue);
+		Map<String, Object> resultSet = ResultSet.error("My error message", testMap);
+
+		assertNotNull("Result does not become null", resultSet);
+		makeErrorFieldAssertions(resultSet);
+
+		final Object additionalInfoMapObj = resultSet.get(additionalInfoKey);
+		assertNotNull("Value for key '" + additionalInfoKey + "' is defined", additionalInfoMapObj);
+		assertTrue("Additional info is an instance of map", additionalInfoMapObj instanceof Map);
+
+		final Map additionalInfoMap = (Map) additionalInfoMapObj;
+		assertEquals("Provided additional info matches returned one", additionalInfoMap.get(testKey), testValue);
 	}
 
 


### PR DESCRIPTION
This PR adds a further `error` method (and its corresponding test) to `ResultSet`. The new method returns an "error" map (containing `success=false`) and a child `additionalInfo` holding additional information to be included.