### PR TITLE
GeoServer REST importer

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -367,6 +367,8 @@
                 <configuration>
                     <excludes>
                         <exclude>de/terrestris/shogun2/model/**/*.class</exclude>
+                        <exclude>de/terrestris/shogun2/importer/communication/*.class</exclude>
+                        <exclude>de/terrestris/shogun2/importer/transform/*.class</exclude>
                         <exclude>de/terrestris/shogun2/paging/PagingResult.class</exclude>
                     </excludes>
                 </configuration>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -71,6 +71,10 @@
                 <enabled>true</enabled>
             </releases>
         </repository>
+        <repository>
+            <id>OSGeo GeoTools repo</id>
+            <url>http://download.osgeo.org/webdav/geotools</url>
+        </repository>
     </repositories>
 
     <developers>
@@ -192,6 +196,12 @@
 
         <!-- Apache HTTP Client -->
         <apache-httpclient.version>4.5.3</apache-httpclient.version>
+
+        <!-- GeoTools -->
+        <geotools.version>17.3</geotools.version>
+
+        <!-- Zip4j -->
+        <zip4j.version>1.3.2</zip4j.version>
 
         <!-- Java XML Parser -->
         <jaxp-api.version>1.4.5</jaxp-api.version>
@@ -807,6 +817,18 @@
                 <groupId>com.vividsolutions</groupId>
                 <artifactId>jts-core</artifactId>
                 <version>${jts.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.geotools</groupId>
+                <artifactId>gt-main</artifactId>
+                <version>${geotools.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>net.lingala.zip4j</groupId>
+                <artifactId>zip4j</artifactId>
+                <version>${zip4j.version}</version>
             </dependency>
 
         </dependencies>

--- a/src/shogun2-core/pom.xml
+++ b/src/shogun2-core/pom.xml
@@ -248,6 +248,16 @@
             <artifactId>jts-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-main</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>net.lingala.zip4j</groupId>
+            <artifactId>zip4j</artifactId>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/GeoServerRESTImporter.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/GeoServerRESTImporter.java
@@ -1,0 +1,566 @@
+package de.terrestris.shogun2.importer;
+
+import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpException;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.log4j.Logger;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import de.terrestris.shogun2.importer.communication.AbstractRESTEntity;
+import de.terrestris.shogun2.importer.communication.RESTData;
+import de.terrestris.shogun2.importer.communication.RESTImport;
+import de.terrestris.shogun2.importer.communication.RESTImportTask;
+import de.terrestris.shogun2.importer.communication.RESTImportTaskList;
+import de.terrestris.shogun2.importer.communication.RESTLayer;
+import de.terrestris.shogun2.importer.communication.RESTTargetDataStore;
+import de.terrestris.shogun2.importer.communication.RESTTargetWorkspace;
+import de.terrestris.shogun2.importer.transform.RESTGdalAddoTransform;
+import de.terrestris.shogun2.importer.transform.RESTGdalTranslateTransform;
+import de.terrestris.shogun2.importer.transform.RESTGdalWarpTransform;
+import de.terrestris.shogun2.importer.transform.RESTReprojectTransform;
+import de.terrestris.shogun2.importer.transform.RESTTransform;
+import de.terrestris.shogun2.util.http.HttpUtil;
+import de.terrestris.shogun2.util.model.Response;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+@Component
+public class GeoServerRESTImporter {
+
+	/**
+	 * The Logger.
+	 */
+	private final static Logger LOG = Logger.getLogger(GeoServerRESTImporter.class);
+
+	/**
+	 *
+	 */
+	private String username;
+
+	/**
+	 *
+	 */
+	private String password;
+
+	/**
+	 *
+	 */
+	private ObjectMapper mapper = new ObjectMapper();
+
+	/**
+	 *
+	 */
+	private URI baseUri;
+
+	/**
+	 *
+	 */
+	public GeoServerRESTImporter() {
+
+	}
+
+	/***
+	 *
+	 * @param importerBaseURL
+	 * @param defaultSRS
+	 * @param username
+	 * @param password
+	 * @throws URISyntaxException
+	 */
+	public GeoServerRESTImporter(String importerBaseURL, String username,
+			String password) throws URISyntaxException {
+		if (StringUtils.isEmpty(importerBaseURL) || StringUtils.isEmpty(username) ||
+				StringUtils.isEmpty(password)) {
+			LOG.error("Missing Constructor arguments. Could not create " +
+				"the GeoServerRESTImporter.");
+		}
+
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.configure(DeserializationFeature.UNWRAP_ROOT_VALUE, true);
+		mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, true);
+		mapper.setSerializationInclusion(Include.NON_NULL);
+
+		this.username = username;
+		this.password = password;
+
+		this.mapper = mapper;
+		this.baseUri = new URI(importerBaseURL);
+	}
+
+	/**
+	 *
+	 * @param importJob
+	 * @return
+	 * @throws Exception
+	 */
+	public RESTImport createImportJob(String workSpaceName, String dataStoreName)
+			throws Exception {
+
+		if (StringUtils.isEmpty(workSpaceName)) {
+			throw new GeoServerRESTImporterException("No workspace given. Please provide a "
+					+ "workspace to import the data in.");
+		}
+
+		RESTImport importJob = new RESTImport();
+
+		LOG.debug("Creating a new import job to import into workspace " + workSpaceName);
+
+		RESTTargetWorkspace targetWorkspace = new RESTTargetWorkspace(workSpaceName);
+		importJob.setTargetWorkspace(targetWorkspace);
+
+		if (!StringUtils.isEmpty(dataStoreName)) {
+			LOG.debug("The data will be imported into datastore " + dataStoreName);
+			RESTTargetDataStore targetDataStore = new RESTTargetDataStore(dataStoreName, null);
+			importJob.setTargetStore(targetDataStore);
+		} else {
+			LOG.debug("No datastore given. A new datastore will be created in relation to the"
+					+ "input data.");
+		}
+
+		Response httpResponse = HttpUtil.post(
+				this.addEndPoint(""),
+				this.asJSON(importJob),
+				ContentType.APPLICATION_JSON,
+				this.username,
+				this.password
+		);
+
+		HttpStatus responseStatus = httpResponse.getStatusCode();
+		if (responseStatus == null || !responseStatus.is2xxSuccessful()) {
+			throw new GeoServerRESTImporterException("Import job cannot be "
+					+ "created. Is the GeoServer Importer extension installed?");
+		}
+
+		RESTImport restImport = (RESTImport) this.asEntity(httpResponse.getBody(), RESTImport.class);
+
+		LOG.debug("Successfully created the import job with ID " + restImport.getId());
+
+		return restImport;
+	}
+
+	/**
+	 *
+	 * @param importJobId
+	 * @param taskId
+	 * @param transformTask
+	 * @throws HttpException
+	 * @throws URISyntaxException
+	 */
+	public boolean createReprojectTransformTask(Integer importJobId, Integer taskId,
+			String sourceSrs, String targetSrs) throws URISyntaxException, HttpException {
+		RESTReprojectTransform transformTask = new RESTReprojectTransform();
+		if (StringUtils.isNotEmpty(sourceSrs)) {
+			transformTask.setSource(sourceSrs);
+		}
+		transformTask.setTarget(targetSrs);
+
+		return createTransformTask(importJobId, taskId, transformTask);
+	}
+
+	/**
+	 * Create and append importer task for <code>gdaladdo</code>
+	 *
+	 * @param importJobId
+	 * @param importTaskId
+	 * @param opts
+	 * @param levels
+	 * @return
+	 * @throws HttpException
+	 * @throws URISyntaxException
+	 */
+	public boolean createGdalAddOverviewTask(Integer importJobId, Integer importTaskId,
+			List<String> opts, List<Integer> levels) throws URISyntaxException, HttpException {
+		RESTGdalAddoTransform transformTask = new RESTGdalAddoTransform();
+		if (! opts.isEmpty()) {
+			transformTask.setOptions(opts);
+		}
+		if (! levels.isEmpty()) {
+			transformTask.setLevels(levels);;
+		}
+		return this.createTransformTask(importJobId, importTaskId, transformTask);
+	}
+
+	/**
+	 * Create and append importer task for <code>gdalwarp</code>
+	 *
+	 * @param importJobId
+	 * @param importTaskId
+	 * @param optsGdalWarp
+	 * @return
+	 * @throws HttpException
+	 * @throws URISyntaxException
+	 */
+	public boolean createGdalWarpTask(Integer importJobId, Integer importTaskId,
+			List<String> optsGdalWarp) throws URISyntaxException, HttpException {
+		RESTGdalWarpTransform transformTask = new RESTGdalWarpTransform();
+		if (! optsGdalWarp.isEmpty()){
+			transformTask.setOptions(optsGdalWarp);
+		}
+		return this.createTransformTask(importJobId, importTaskId, transformTask);
+	}
+
+	/**
+	 * Create and append importer task for <code>gdal_translate</code>
+	 *
+	 * @param importJobId
+	 * @param importTaskId
+	 * @param opts
+	 * @return
+	 * @throws HttpException
+	 * @throws URISyntaxException
+	 */
+	public boolean createGdalTranslateTask(Integer importJobId, Integer importTaskId,
+			List<String> optsGdalTranslate) throws URISyntaxException, HttpException {
+		RESTGdalTranslateTransform transformTask = new RESTGdalTranslateTransform();
+		if (! optsGdalTranslate.isEmpty()){
+			transformTask.setOptions(optsGdalTranslate);
+		}
+		return this.createTransformTask(importJobId, importTaskId, transformTask);
+	}
+
+	/**
+	 *
+	 * @param importJobId
+	 * @param file
+	 * @return
+	 * @throws Exception
+	 */
+	public RESTImportTaskList uploadFile(Integer importJobId, File file) throws Exception {
+
+		LOG.debug("Uploading file " + file.getName() + " to import job " + importJobId);
+
+		Response httpResponse = HttpUtil.post(
+				this.addEndPoint(importJobId + "/tasks"),
+				file,
+				this.username,
+				this.password
+		);
+
+		HttpStatus responseStatus = httpResponse.getStatusCode();
+		if (responseStatus == null || !responseStatus.is2xxSuccessful()) {
+			throw new GeoServerRESTImporterException("Error while uploading the file.");
+		}
+
+		LOG.debug("Successfully uploaded the file to import job " + importJobId);
+
+		RESTImportTaskList importTaskLists =  null;
+		// check, if it is a list of import tasks (for multiple layers)
+		try {
+			importTaskLists = mapper.readValue(httpResponse.getBody(), RESTImportTaskList.class);
+			LOG.info("Imported file "+ file.getName() + " contains data for multiple layers.");
+		} catch (Exception e) {
+			LOG.info("Imported file "+ file.getName() + " likely contains data for single " +
+					"layer. Will check this now.");
+			RESTImportTask helperTask = mapper.readValue(httpResponse.getBody(), RESTImportTask.class);
+			if (helperTask != null) {
+				importTaskLists = new RESTImportTaskList();
+				importTaskLists.add(helperTask);
+				LOG.info("Imported file "+ file.getName() + " contains data for a single layers.");
+			}
+		}
+
+		return importTaskLists;
+	}
+
+	/**
+	 * Modify the "srs" definition of the target layer
+	 *
+	 * @param importJobId
+	 * @param importTask
+	 * @param sourceSrs
+	 *
+	 * @return
+	 * @throws Exception
+	 */
+	public RESTImportTask updateSrsForRESTImportTask(Integer importJobId, RESTImportTask importTask,
+			String sourceSrs) throws Exception {
+		Integer taskId = importTask.getId();
+
+		RESTLayer updatableLayer = new RESTLayer();
+		updatableLayer.setSrs(sourceSrs);
+
+		Response httpResponse = HttpUtil.put(
+				this.addEndPoint(importJobId + "/tasks/" + taskId + "/layer"),
+				this.asJSON(updatableLayer),
+				ContentType.APPLICATION_JSON,
+				this.username,
+				this.password
+		);
+
+		return (RESTImportTask) this.asEntity(httpResponse.getBody(), RESTImportTask.class);
+	}
+
+	/**
+	 * delete an importJob
+	 *
+	 * @param importJobId
+	 * @return
+	 * @throws HttpException
+	 * @throws URISyntaxException
+	 */
+	public boolean deleteImportJob(Integer importJobId) throws URISyntaxException, HttpException{
+		Response httpResponse = HttpUtil.delete(
+			this.addEndPoint(importJobId.toString()),
+			this.username,
+			this.password);
+
+		return httpResponse.getStatusCode().equals(HttpStatus.NO_CONTENT);
+	}
+
+	/**
+	 *
+	 * @param importJobId
+	 * @return
+	 * @throws UnsupportedEncodingException
+	 * @throws URISyntaxException
+	 * @throws HttpException
+	 */
+	public boolean runImportJob(Integer importJobId) throws
+			UnsupportedEncodingException, URISyntaxException, HttpException {
+
+		LOG.debug("Run import for job " + importJobId);
+
+		Response httpResponse = HttpUtil.post(
+				this.addEndPoint(Integer.toString(importJobId)),
+				this.username,
+				this.password
+		);
+
+		if (httpResponse.getStatusCode().equals(HttpStatus.NO_CONTENT)) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 *
+	 * @param importJobId
+	 * @param taskId
+	 * @return
+	 * @throws Exception
+	 */
+	public RESTLayer getLayer(Integer importJobId, Integer taskId) throws Exception {
+		Response httpResponse = HttpUtil.get(
+				this.addEndPoint(importJobId + "/tasks/" + taskId + "/layer"),
+				this.username,
+				this.password
+		);
+
+		return (RESTLayer) this.asEntity(httpResponse.getBody(), RESTLayer.class);
+	}
+
+	/**
+	 * fetch all created Layers of import job
+	 *
+	 * @param importJobId
+	 * @return
+	 * @throws Exception
+	 */
+	public List<RESTLayer> getAllImportedLayers(Integer importJobId, List<RESTImportTask> tasks) throws Exception {
+		ArrayList<RESTLayer> layers = new ArrayList<RESTLayer>();
+		for (RESTImportTask task : tasks) {
+
+			RESTImportTask refreshedTask = this.getRESTImportTask(importJobId, task.getId());
+			if (refreshedTask.getState().equalsIgnoreCase("COMPLETE")){
+				Response httpResponse = HttpUtil.get(
+						this.addEndPoint(importJobId + "/tasks/" + task.getId() + "/layer"),
+						this.username,
+						this.password
+				);
+				RESTLayer layer = (RESTLayer) this.asEntity(httpResponse.getBody(), RESTLayer.class);
+
+				if (layer != null) {
+					layers.add(layer);
+				}
+			} else if ((tasks.size() == 1) && refreshedTask.getState().equalsIgnoreCase("ERROR")) {
+				throw new GeoServerRESTImporterException(refreshedTask.getErrorMessage());
+			}
+		}
+		return layers;
+	}
+
+	/**
+	 *
+	 * @param importJobId
+	 * @param taskId
+	 * @return
+	 * @throws Exception
+	 */
+	public RESTData getDataOfImportTask(Integer importJobId, Integer taskId)
+			throws Exception {
+		final DeserializationFeature unwrapRootValueFeature = DeserializationFeature.UNWRAP_ROOT_VALUE;
+		boolean unwrapRootValueFeatureIsEnabled = mapper.isEnabled(unwrapRootValueFeature);
+
+		Response httpResponse = HttpUtil.get(
+				this.addEndPoint(importJobId + "/tasks/" + taskId + "/data"),
+				this.username,
+				this.password
+		);
+
+		// we have to disable the feature. otherwise deserialize would not work here
+		mapper.disable(unwrapRootValueFeature);
+
+		final RESTData resultEntity = (RESTData) this.asEntity(httpResponse.getBody(), RESTData.class);
+
+		if(unwrapRootValueFeatureIsEnabled) {
+			mapper.enable(unwrapRootValueFeature);
+		}
+
+		return resultEntity;
+	}
+
+	/**
+	 *
+	 * @param importJobId
+	 * @param taskId
+	 * @return
+	 * @throws Exception
+	 */
+	public RESTImportTask getRESTImportTask(Integer importJobId, Integer taskId) throws
+		Exception {
+		Response httpResponse = HttpUtil.get(
+				this.addEndPoint(importJobId + "/tasks/" + taskId),
+				this.username,
+				this.password
+		);
+
+		return (RESTImportTask) this.asEntity(httpResponse.getBody(), RESTImportTask.class);
+	}
+
+	/**
+	 *
+	 * @param importJobId
+	 * @return
+	 * @throws Exception
+	 */
+	public RESTImportTaskList getRESTImportTasks(Integer importJobId) throws Exception {
+		Response httpResponse = HttpUtil.get(
+				this.addEndPoint(importJobId + "/tasks"),
+				this.username,
+				this.password
+		);
+		return mapper.readValue(httpResponse.getBody(), RESTImportTaskList.class);
+	}
+
+	/**
+	 * Helper method to create an importer transformTask
+	 *
+	 * @param importJobId
+	 * @param taskId
+	 * @param transformTask
+	 * @return
+	 * @throws URISyntaxException
+	 * @throws HttpException
+	 */
+	private boolean createTransformTask(Integer importJobId, Integer taskId, RESTTransform transformTask)
+			throws URISyntaxException, HttpException {
+
+		LOG.debug("Creating a new transform task for import job" + importJobId + " and task " + taskId);
+
+		mapper.disable(SerializationFeature.WRAP_ROOT_VALUE);
+
+		Response httpResponse = HttpUtil.post(
+				this.addEndPoint(importJobId + "/tasks/" + taskId + "/transforms"),
+				this.asJSON(transformTask),
+				ContentType.APPLICATION_JSON,
+				this.username,
+				this.password
+		);
+
+		mapper.enable(SerializationFeature.WRAP_ROOT_VALUE);
+
+		if (httpResponse.getStatusCode().equals(HttpStatus.CREATED)) {
+			LOG.debug("Successfully created the transform task");
+			return true;
+		} else {
+			LOG.error("Error while creating the transform task");
+			return false;
+		}
+	}
+
+	/**
+	 *
+	 * @param responseBody
+	 * @param clazz
+	 * @return
+	 * @throws Exception
+	 */
+	private AbstractRESTEntity asEntity(byte[] responseBody, Class<?> clazz)
+			throws Exception {
+
+		AbstractRESTEntity entity = null;
+
+		entity = (AbstractRESTEntity) mapper.readValue(responseBody, clazz);
+
+		return entity;
+	}
+
+	/**
+	 *
+	 * @param entity
+	 * @return
+	 */
+	private String asJSON(Object entity) {
+
+		String entityJson = null;
+
+		try {
+			entityJson = this.mapper.writeValueAsString(entity);
+		} catch (Exception e) {
+			LOG.error("Could not parse as JSON: " + e.getMessage());
+		}
+
+		return entityJson;
+	}
+
+	/**
+	 *
+	 * @param endPoint
+	 * @return
+	 * @throws URISyntaxException
+	 */
+	private URI addEndPoint(String endPoint) throws URISyntaxException {
+
+		if (StringUtils.isEmpty(endPoint) || endPoint.equals("/")) {
+			return this.baseUri;
+		}
+
+		if (this.baseUri.getPath().endsWith("/") || endPoint.startsWith("/")) {
+			endPoint = this.baseUri.getPath() + endPoint;
+		} else {
+			endPoint = this.baseUri.getPath() + "/" + endPoint;
+		}
+
+		URI uri = null;
+
+		URIBuilder builder = new URIBuilder();
+
+		builder.setScheme(this.baseUri.getScheme());
+		builder.setHost(this.baseUri.getHost());
+		builder.setPort(this.baseUri.getPort());
+		builder.setPath(endPoint);
+
+		uri = builder.build();
+		return uri;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/GeoServerRESTImporter.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/GeoServerRESTImporter.java
@@ -93,7 +93,6 @@ public class GeoServerRESTImporter {
 	/***
 	 *
 	 * @param importerBaseURL
-	 * @param defaultSRS
 	 * @param username
 	 * @param password
 	 * @throws URISyntaxException
@@ -120,7 +119,8 @@ public class GeoServerRESTImporter {
 
 	/**
 	 *
-	 * @param importJob
+	 * @param workSpaceName
+	 * @param dataStoreName
 	 * @return
 	 * @throws Exception
 	 */

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/GeoServerRESTImporterException.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/GeoServerRESTImporterException.java
@@ -1,0 +1,43 @@
+package de.terrestris.shogun2.importer;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class GeoServerRESTImporterException extends Exception {
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 *
+	 */
+	public GeoServerRESTImporterException() {}
+
+	/**
+	 * @param message
+	 */
+	public GeoServerRESTImporterException(String message) {
+		super(message);
+	}
+
+	/**
+	 * @param cause
+	 */
+	public GeoServerRESTImporterException(Throwable cause) {
+		super(cause);
+	}
+
+	/**
+	 * @param message
+	 * @param cause
+	 */
+	public GeoServerRESTImporterException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/AbstractRESTEntity.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/AbstractRESTEntity.java
@@ -1,0 +1,21 @@
+package de.terrestris.shogun2.importer.communication;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class AbstractRESTEntity {
+
+	/**
+	 * Default constructor.
+	 */
+	public AbstractRESTEntity() {
+
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTAttribute.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTAttribute.java
@@ -1,0 +1,68 @@
+package de.terrestris.shogun2.importer.communication;
+
+import de.terrestris.shogun2.importer.communication.AbstractRESTEntity;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class RESTAttribute extends AbstractRESTEntity {
+
+	/**
+	 *
+	 */
+	private String name;
+
+	/**
+	 *
+	 */
+	private String binding;
+
+	/**
+	 * Default constructor.
+	 */
+	public RESTAttribute() {
+
+	}
+
+	/**
+	 *
+	 * @param name
+	 * @param binding
+	 */
+	public RESTAttribute(String name, String binding) {
+		this.name = name;
+		this.binding = binding;
+	}
+
+	/**
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @param name the name to set
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * @return the binding
+	 */
+	public String getBinding() {
+		return binding;
+	}
+
+	/**
+	 * @param binding the binding to set
+	 */
+	public void setBinding(String binding) {
+		this.binding = binding;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTBoundingBox.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTBoundingBox.java
@@ -1,0 +1,131 @@
+package de.terrestris.shogun2.importer.communication;
+
+import de.terrestris.shogun2.importer.communication.AbstractRESTEntity;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class RESTBoundingBox extends AbstractRESTEntity {
+
+	/**
+	 *
+	 */
+	private String minx;
+
+	/**
+	 *
+	 */
+	private String miny;
+
+	/**
+	 *
+	 */
+	private String maxx;
+
+	/**
+	 *
+	 */
+	private String maxy;
+
+	/**
+	 *
+	 */
+	private String crs;
+
+	/**
+	 * Default constructor.
+	 */
+	public RESTBoundingBox() {
+
+	}
+
+	/**
+	 *
+	 * @param minx
+	 * @param miny
+	 * @param maxx
+	 * @param maxy
+	 * @param crs
+	 */
+	public RESTBoundingBox(String minx, String miny, String maxx, String maxy,
+			String crs) {
+		this.minx = minx;
+		this.miny = miny;
+		this.maxx = maxx;
+		this.maxy = maxy;
+		this.crs = crs;
+	}
+
+	/**
+	 * @return the minx
+	 */
+	public String getMinx() {
+		return minx;
+	}
+
+	/**
+	 * @param minx the minx to set
+	 */
+	public void setMinx(String minx) {
+		this.minx = minx;
+	}
+
+	/**
+	 * @return the miny
+	 */
+	public String getMiny() {
+		return miny;
+	}
+
+	/**
+	 * @param miny the miny to set
+	 */
+	public void setMiny(String miny) {
+		this.miny = miny;
+	}
+
+	/**
+	 * @return the maxx
+	 */
+	public String getMaxx() {
+		return maxx;
+	}
+
+	/**
+	 * @param maxx the maxx to set
+	 */
+	public void setMaxx(String maxx) {
+		this.maxx = maxx;
+	}
+
+	/**
+	 * @return the maxy
+	 */
+	public String getMaxy() {
+		return maxy;
+	}
+
+	/**
+	 * @param maxy the maxy to set
+	 */
+	public void setMaxy(String maxy) {
+		this.maxy = maxy;
+	}
+
+	/**
+	 * @return the crs
+	 */
+	public String getCrs() {
+		return crs;
+	}
+
+	/**
+	 * @param crs the crs to set
+	 */
+	public void setCrs(String crs) {
+		this.crs = crs;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTCoverageStore.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTCoverageStore.java
@@ -1,0 +1,18 @@
+package de.terrestris.shogun2.importer.communication;
+
+import de.terrestris.shogun2.importer.communication.RESTDataStore;
+
+/**
+ *
+ * terrestris GmbH & Co. KG
+ * @author ahenn
+ * @date 01.04.2016
+ *
+ */
+public class RESTCoverageStore extends RESTDataStore {
+
+	public RESTCoverageStore() {
+		super();
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTData.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTData.java
@@ -1,0 +1,109 @@
+package de.terrestris.shogun2.importer.communication;
+
+import de.terrestris.shogun2.importer.communication.AbstractRESTEntity;
+
+/**
+ * A data is the description of the source data of a import (overall) or a
+ * task. In case the import has a global data definition, this normally refers
+ * to an aggregate store such as a directory or a database, and the data
+ * associated to the tasks refers to a single element inside such aggregation,
+ * such as a single file or table.
+ *
+ * A import can have a "data" representing the source of the data to be
+ * imported. The data can be of different types, in particular: "file",
+ * "directory", "mosaic", "database" and "remote". During the import
+ * initialization the importer will scan the contents of said resource, and
+ * generate import tasks for each data found in it.
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class RESTData extends AbstractRESTEntity {
+
+	/**
+	 *
+	 */
+	private String type;
+
+	/**
+	 *
+	 */
+	private String format;
+
+	/**
+	 *
+	 */
+	private String file;
+
+	/**
+	 *
+	 */
+	private String location;
+
+	/**
+	 * Default constructor.
+	 */
+	public RESTData() {
+
+	}
+
+	/**
+	 * @return the type
+	 */
+	public String getType() {
+		return type;
+	}
+
+	/**
+	 * @param type the type to set
+	 */
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	/**
+	 * @return the format
+	 */
+	public String getFormat() {
+		return format;
+	}
+
+	/**
+	 * @param format the format to set
+	 */
+	public void setFormat(String format) {
+		this.format = format;
+	}
+
+	/**
+	 * @return the file
+	 */
+	public String getFile() {
+		return file;
+	}
+
+	/**
+	 * @param file the file to set
+	 */
+	public void setFile(String file) {
+		this.file = file;
+	}
+
+	/**
+	 * 
+	 * @return
+	 */
+	public String getLocation() {
+		return location;
+	}
+
+	/**
+	 * 
+	 * @param location
+	 */
+	public void setLocation(String location) {
+		this.location = location;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTDataDirectory.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTDataDirectory.java
@@ -1,0 +1,19 @@
+package de.terrestris.shogun2.importer.communication;
+
+import de.terrestris.shogun2.importer.communication.RESTData;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class RESTDataDirectory extends RESTData {
+
+	/**
+	 *
+	 */
+	@SuppressWarnings("unused")
+	private String location;
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTDataFile.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTDataFile.java
@@ -1,0 +1,51 @@
+package de.terrestris.shogun2.importer.communication;
+
+import java.util.List;
+
+import de.terrestris.shogun2.importer.communication.RESTData;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class RESTDataFile extends RESTData {
+
+	/**
+	 *
+	 */
+	@SuppressWarnings("unused")
+	private String format;
+
+	/**
+	 *
+	 */
+	@SuppressWarnings("unused")
+	private String location;
+
+	/**
+	 *
+	 */
+	@SuppressWarnings("unused")
+	private String file;
+
+	/**
+	 *
+	 */
+	@SuppressWarnings("unused")
+	private String href;
+
+	/**
+	 *
+	 */
+	@SuppressWarnings("unused")
+	private String prj;
+
+	/**
+	 *
+	 */
+	@SuppressWarnings("unused")
+	private List<String> other;
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTDataRemote.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTDataRemote.java
@@ -1,0 +1,37 @@
+package de.terrestris.shogun2.importer.communication;
+
+import de.terrestris.shogun2.importer.communication.RESTData;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class RESTDataRemote extends RESTData {
+
+	/**
+	 *
+	 */
+	@SuppressWarnings("unused")
+	private String location;
+
+	/**
+	 *
+	 */
+	@SuppressWarnings("unused")
+	private String username;
+
+	/**
+	 *
+	 */
+	@SuppressWarnings("unused")
+	private String password;
+
+	/**
+	 *
+	 */
+	@SuppressWarnings("unused")
+	private String domain;
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTDataStore.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTDataStore.java
@@ -1,0 +1,67 @@
+package de.terrestris.shogun2.importer.communication;
+
+import de.terrestris.shogun2.importer.communication.AbstractRESTEntity;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class RESTDataStore extends AbstractRESTEntity {
+
+	/**
+	 *
+	 */
+	private String name;
+
+	/**
+	 *
+	 */
+	private String type;
+
+	/**
+	 * Default constructor.
+	 */
+	public RESTDataStore() {
+
+	}
+
+	/**
+	 *
+	 * @param name
+	 * @param type
+	 */
+	public RESTDataStore(String name, String type) {
+		this.name = name;
+		this.type = type;
+	}
+
+	/**
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @param name the name to set
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * @return the type
+	 */
+	public String getType() {
+		return type;
+	}
+
+	/**
+	 * @param type the type to set
+	 */
+	public void setType(String type) {
+		this.type = type;
+	}
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTImport.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTImport.java
@@ -1,0 +1,140 @@
+package de.terrestris.shogun2.importer.communication;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import de.terrestris.shogun2.importer.communication.AbstractRESTEntity;
+import de.terrestris.shogun2.importer.communication.RESTData;
+import de.terrestris.shogun2.importer.communication.RESTImportTask;
+import de.terrestris.shogun2.importer.communication.RESTTargetDataStore;
+import de.terrestris.shogun2.importer.communication.RESTTargetWorkspace;
+
+/**
+ * An import refers to the top level object and is a "session" like entity the
+ * state of the entire import. It maintains information relevant to the import
+ * as a whole such as user information, timestamps along with optional
+ * information that is uniform along all tasks, such as a target workspace, the
+ * shared input data (e.g. a directory, a database). An import is made of any
+ * number of task objects.
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+@JsonRootName(value = "import")
+public class RESTImport extends AbstractRESTEntity {
+
+	/**
+	 *
+	 */
+	private Integer id;
+
+	/**
+	 *
+	 */
+	private String href;
+
+	/**
+	 *
+	 */
+	private String state;
+
+	/**
+	 *
+	 */
+	private RESTTargetWorkspace targetWorkspace;
+
+	/**
+	 *
+	 */
+	private RESTTargetDataStore targetStore;
+
+	/**
+	 *
+	 */
+	private RESTData data;
+
+	/**
+	 *
+	 */
+	private List<RESTImportTask> importTasks;
+
+	/**
+	 * Default constructor.
+	 */
+	public RESTImport() {
+
+	}
+
+	/**
+	 * @return the targetWorkspace
+	 */
+	public RESTTargetWorkspace getTargetWorkspace() {
+		return targetWorkspace;
+	}
+
+	/**
+	 * @param targetWorkspace the targetWorkspace to set
+	 */
+	public void setTargetWorkspace(RESTTargetWorkspace targetWorkspace) {
+		this.targetWorkspace = targetWorkspace;
+	}
+
+	/**
+	 * @return the targetStore
+	 */
+	public RESTTargetDataStore getTargetStore() {
+		return targetStore;
+	}
+
+	/**
+	 * @param targetStore the targetStore to set
+	 */
+	public void setTargetStore(RESTTargetDataStore targetStore) {
+		this.targetStore = targetStore;
+	}
+
+	/**
+	 * @return the data
+	 */
+	public RESTData getData() {
+		return data;
+	}
+
+	/**
+	 * @param data the data to set
+	 */
+	public void setData(RESTData data) {
+		this.data = data;
+	}
+
+	/**
+	 * @return the id
+	 */
+	public Integer getId() {
+		return id;
+	}
+
+	/**
+	 * @return the href
+	 */
+	public String getHref() {
+		return href;
+	}
+
+	/**
+	 * @return the state
+	 */
+	public String getState() {
+		return state;
+	}
+
+	/**
+	 * @return the importTasks
+	 */
+	public List<RESTImportTask> getImportTasks() {
+		return importTasks;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTImportTask.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTImportTask.java
@@ -1,0 +1,175 @@
+package de.terrestris.shogun2.importer.communication;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import de.terrestris.shogun2.importer.communication.AbstractRESTEntity;
+import de.terrestris.shogun2.importer.communication.RESTData;
+import de.terrestris.shogun2.importer.communication.RESTLayer;
+import de.terrestris.shogun2.importer.communication.RESTTarget;
+import de.terrestris.shogun2.importer.transform.RESTTransformChain;
+
+
+/**
+ * A task represents a unit of work to the importer needed to register one
+ * new layer, or alter an existing one, and contains the following information:
+ *
+ *   * The data being imported
+ *   * The target store that is the destination of the import
+ *   * The target layer
+ *   * The data of a task, referred to as its source, is the data to be
+ *     processed as part of the task.
+ *   * The transformations that we need to apply to the data before it gets
+ *     imported
+ *
+ * This data comes in a variety of forms including:
+ *
+ *   * A spatial file (Shapefile, GeoTiff, KML, etc...)
+ *   * A directory of spatial files
+ *   * A table in a spatial database
+ *   * A remote location that the server will download data from
+ *
+ * A task is classified as either “direct” or “indirect”. A direct task is one
+ * in which the data being imported requires no transformation to be imported.
+ * It is imported directly. An example of such a task is one that involves
+ * simply importing an existing Shapefile as is. An indirect task is one that
+ * does require a transformation to the original import data. An example of an
+ * indirect task is one that involves importing a Shapefile into an existing
+ * PostGIS database. Another example of indirect task might involve taking a
+ * CSV file as an input, turning a x and y column into a Point, remapping a
+ * string column into a timestamp, and finally import the result into a PostGIS.
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+@JsonRootName(value = "task")
+public class RESTImportTask extends AbstractRESTEntity {
+
+	/**
+	 *
+	 */
+	private Integer id;
+
+	/**
+	 *
+	 */
+	private String href;
+
+	/**
+	 *
+	 */
+	private String state;
+
+	/**
+	 *
+	 */
+	private String updateMode;
+
+	/**
+	 *
+	 */
+	private RESTData data;
+
+	/**
+	 *
+	 */
+	private RESTTarget target;
+
+	/**
+	 *
+	 */
+	private String progress;
+
+	/**
+	 *
+	 */
+	private RESTLayer layer;
+
+	/**
+	 *
+	 */
+	private String errorMessage;
+
+	/**
+	 *
+	 */
+	private RESTTransformChain transformChain;
+
+	/**
+	 * Default constructor.
+	 */
+	public RESTImportTask() {
+
+	}
+
+	/**
+	 * @return the id
+	 */
+	public Integer getId() {
+		return id;
+	}
+
+	/**
+	 * @return the href
+	 */
+	public String getHref() {
+		return href;
+	}
+
+	/**
+	 * @return the state
+	 */
+	public String getState() {
+		return state;
+	}
+
+	/**
+	 * @return the updateMode
+	 */
+	public String getUpdateMode() {
+		return updateMode;
+	}
+
+	/**
+	 * @return the data
+	 */
+	public RESTData getData() {
+		return data;
+	}
+
+	/**
+	 * @return the target
+	 */
+	public RESTTarget getTarget() {
+		return target;
+	}
+
+	/**
+	 * @return the progress
+	 */
+	public String getProgress() {
+		return progress;
+	}
+
+	/**
+	 * @return the layer
+	 */
+	public RESTLayer getLayer() {
+		return layer;
+	}
+
+	/**
+	 * @return the errorMessage
+	 */
+	public String getErrorMessage() {
+		return errorMessage;
+	}
+
+	/**
+	 * @return the transformChain
+	 */
+	public RESTTransformChain getTransformChain() {
+		return transformChain;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTImportTaskList.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTImportTaskList.java
@@ -1,0 +1,28 @@
+package de.terrestris.shogun2.importer.communication;
+
+import java.util.ArrayList;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import de.terrestris.shogun2.importer.communication.RESTImportTask;
+
+/**
+ *
+ * terrestris GmbH & Co. KG
+ * @author ahenn
+ * @date 15.04.2016
+ *
+ */
+@JsonRootName("tasks")
+public class RESTImportTaskList extends ArrayList<RESTImportTask> {
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 1L;
+
+	public RESTImportTaskList(){
+
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTLayer.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTLayer.java
@@ -1,0 +1,241 @@
+package de.terrestris.shogun2.importer.communication;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+@JsonRootName(value = "layer")
+public class RESTLayer extends AbstractRESTEntity {
+
+	/**
+	 *
+	 */
+	private String name;
+
+	/**
+	 *
+	 */
+	private String href;
+
+	/**
+	 *
+	 */
+	private String title;
+
+	/**
+	 *
+	 */
+	private String description;
+
+	/**
+	 *
+	 */
+	private String originalName;
+
+	/**
+	 *
+	 */
+	private String nativeName;
+
+	/**
+	 *
+	 */
+	private String srs;
+
+	/**
+	 *
+	 */
+	private RESTBoundingBox bbox;
+
+	/**
+	 *
+	 */
+	private List<RESTAttribute> attributes;
+
+	/**
+	 *
+	 */
+	private RESTStyle style;
+
+	/**
+	 * Default constructor.
+	 */
+	public RESTLayer() {
+
+	}
+
+	/**
+	 *
+	 * @param name
+	 * @param href
+	 * @param title
+	 * @param originalName
+	 * @param nativeName
+	 * @param srs
+	 * @param bbox
+	 * @param attributes
+	 * @param style
+	 */
+	public RESTLayer(String name, String href, String title, String description,
+			String originalName, String nativeName, String srs,
+			RESTBoundingBox bbox, List<RESTAttribute> attributes,
+			RESTStyle style) {
+		this.name = name;
+		this.href = href;
+		this.title = title;
+		this.description = description;
+		this.originalName = originalName;
+		this.nativeName = nativeName;
+		this.srs = srs;
+		this.bbox = bbox;
+		this.attributes = attributes;
+		this.style = style;
+	}
+
+	/**
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @param name the name to set
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * @return the href
+	 */
+	public String getHref() {
+		return href;
+	}
+
+	/**
+	 * @param href the href to set
+	 */
+	public void setHref(String href) {
+		this.href = href;
+	}
+
+	/**
+	 * @return the title
+	 */
+	public String getTitle() {
+		return title;
+	}
+
+	/**
+	 * @param title the title to set
+	 */
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	/**
+	 * @return the description
+	 */
+	public String getDescription() {
+		return description;
+	}
+
+	/**
+	 * @param description the description to set
+	 */
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	/**
+	 * @return the originalName
+	 */
+	public String getOriginalName() {
+		return originalName;
+	}
+
+	/**
+	 * @param originalName the originalName to set
+	 */
+	public void setOriginalName(String originalName) {
+		this.originalName = originalName;
+	}
+
+	/**
+	 * @return the nativeName
+	 */
+	public String getNativeName() {
+		return nativeName;
+	}
+
+	/**
+	 * @param nativeName the nativeName to set
+	 */
+	public void setNativeName(String nativeName) {
+		this.nativeName = nativeName;
+	}
+
+	/**
+	 * @return the srs
+	 */
+	public String getSrs() {
+		return srs;
+	}
+
+	/**
+	 * @param srs the srs to set
+	 */
+	public void setSrs(String srs) {
+		this.srs = srs;
+	}
+
+	/**
+	 * @return the bbox
+	 */
+	public RESTBoundingBox getBbox() {
+		return bbox;
+	}
+
+	/**
+	 * @param bbox the bbox to set
+	 */
+	public void setBbox(RESTBoundingBox bbox) {
+		this.bbox = bbox;
+	}
+
+	/**
+	 * @return the attributes
+	 */
+	public List<RESTAttribute> getAttributes() {
+		return attributes;
+	}
+
+	/**
+	 * @param attributes the attributes to set
+	 */
+	public void setAttributes(List<RESTAttribute> attributes) {
+		this.attributes = attributes;
+	}
+
+	/**
+	 * @return the style
+	 */
+	public RESTStyle getStyle() {
+		return style;
+	}
+
+	/**
+	 * @param style the style to set
+	 */
+	public void setStyle(RESTStyle style) {
+		this.style = style;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTStore.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTStore.java
@@ -1,0 +1,70 @@
+package de.terrestris.shogun2.importer.communication;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import de.terrestris.shogun2.importer.communication.AbstractRESTEntity;
+
+/***
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+@JsonRootName(value = "dataStore")
+public class RESTStore extends AbstractRESTEntity{
+
+	/**
+	 *
+	 */
+	private String name;
+
+	/**
+	 *
+	 */
+	private String type;
+
+	/**
+	 * Default constructor.
+	 */
+	public RESTStore() {
+
+	}
+
+	/**
+	 *
+	 * @param name
+	 */
+	public RESTStore(String name) {
+		super();
+		this.name = name;
+	}
+
+	/**
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @param name the name to set
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * @return the type
+	 */
+	public String getType() {
+		return type;
+	}
+
+	/**
+	 * @param type the type to set
+	 */
+	public void setType(String type) {
+		this.type = type;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTStyle.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTStyle.java
@@ -1,0 +1,68 @@
+package de.terrestris.shogun2.importer.communication;
+
+import de.terrestris.shogun2.importer.communication.AbstractRESTEntity;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class RESTStyle extends AbstractRESTEntity {
+
+	/**
+	 *
+	 */
+	private String name;
+
+	/**
+	 *
+	 */
+	private String href;
+
+	/**
+	 * Default constructor.
+	 */
+	public RESTStyle() {
+
+	}
+
+	/**
+	 *
+	 * @param name
+	 * @param href
+	 */
+	public RESTStyle(String name, String href) {
+		this.name = name;
+		this.href = href;
+	}
+
+	/**
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @param name the name to set
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * @return the href
+	 */
+	public String getHref() {
+		return href;
+	}
+
+	/**
+	 * @param href the href to set
+	 */
+	public void setHref(String href) {
+		this.href = href;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTTarget.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTTarget.java
@@ -1,0 +1,26 @@
+package de.terrestris.shogun2.importer.communication;
+
+import de.terrestris.shogun2.importer.communication.AbstractRESTEntity;
+import de.terrestris.shogun2.importer.communication.RESTDataStore;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class RESTTarget extends AbstractRESTEntity {
+
+	/**
+	 *
+	 */
+	@SuppressWarnings("unused")
+	private String href;
+
+	/**
+	 *
+	 */
+	@SuppressWarnings("unused")
+	private RESTDataStore dataStore;
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTTargetDataStore.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTTargetDataStore.java
@@ -1,0 +1,49 @@
+package de.terrestris.shogun2.importer.communication;
+
+import de.terrestris.shogun2.importer.communication.AbstractRESTEntity;
+import de.terrestris.shogun2.importer.communication.RESTDataStore;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class RESTTargetDataStore extends AbstractRESTEntity {
+
+	/**
+	 *
+	 */
+	private RESTDataStore dataStore;
+
+	/**
+	 * Default constructor.
+	 */
+	public RESTTargetDataStore() {
+
+	}
+
+	/**
+	 *
+	 * @param name
+	 * @param type
+	 */
+	public RESTTargetDataStore(String name, String type) {
+		this.dataStore = new RESTDataStore(name, type);
+	}
+
+	/**
+	 * @return the dataStore
+	 */
+	public RESTDataStore getDataStore() {
+		return dataStore;
+	}
+
+	/**
+	 * @param dataStore the dataStore to set
+	 */
+	public void setDataStore(RESTDataStore dataStore) {
+		this.dataStore = dataStore;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTTargetWorkspace.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTTargetWorkspace.java
@@ -1,0 +1,48 @@
+package de.terrestris.shogun2.importer.communication;
+
+import de.terrestris.shogun2.importer.communication.AbstractRESTEntity;
+import de.terrestris.shogun2.importer.communication.RESTWorkspace;
+
+/**
+ * 
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class RESTTargetWorkspace extends AbstractRESTEntity {
+
+	/**
+	 * 
+	 */
+	private RESTWorkspace workspace;
+
+	/**
+	 * Default constructor.
+	 */
+	public RESTTargetWorkspace() {
+
+	}
+
+	/**
+	 * 
+	 * @param name
+	 */
+	public RESTTargetWorkspace(String name) {
+		this.workspace = new RESTWorkspace(name);
+	}
+
+	/**
+	 * @return the workspace
+	 */
+	public RESTWorkspace getWorkspace() {
+		return workspace;
+	}
+
+	/**
+	 * @param workspace the workspace to set
+	 */
+	public void setWorkspace(RESTWorkspace workspace) {
+		this.workspace = workspace;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTWorkspace.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/communication/RESTWorkspace.java
@@ -1,0 +1,50 @@
+package de.terrestris.shogun2.importer.communication;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import de.terrestris.shogun2.importer.communication.AbstractRESTEntity;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+@JsonRootName(value = "workspace")
+public class RESTWorkspace extends AbstractRESTEntity {
+
+	/**
+	 *
+	 */
+	private String name;
+
+	/**
+	 * Default constructor.
+	 */
+	public RESTWorkspace() {
+
+	}
+
+	/**
+	 * 
+	 * @param name
+	 */
+	public RESTWorkspace(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @param name the name to set
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/transform/RESTDateFormatTransform.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/transform/RESTDateFormatTransform.java
@@ -1,0 +1,31 @@
+package de.terrestris.shogun2.importer.transform;
+
+import de.terrestris.shogun2.importer.transform.RESTTransform;
+
+/**
+ * 
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class RESTDateFormatTransform extends RESTTransform {
+
+	/**
+	 * 
+	 */
+	@SuppressWarnings("unused")
+	private String href;
+
+	/**
+	 * 
+	 */
+	@SuppressWarnings("unused")
+	private String field;
+
+	/**
+	 * 
+	 */
+	@SuppressWarnings("unused")
+	private String format;
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/transform/RESTGdalAddoTransform.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/transform/RESTGdalAddoTransform.java
@@ -1,0 +1,60 @@
+package de.terrestris.shogun2.importer.transform;
+
+import java.util.List;
+
+import de.terrestris.shogun2.importer.transform.RESTTransform;
+
+/**
+ *
+ * terrestris GmbH & Co. KG
+ * @author ahenn
+ * @date 01.04.2016
+ *
+ * Task performing gdaladdo which builds or rebuilds overview images.
+ * @see <a href="http://www.gdal.org/gdaladdo.html">GDAL (gdaladdo) documentation</a>
+ * Requires <code>gdaladdo</code> to be inside the PATH used by the web container running GeoServer.
+ */
+public class RESTGdalAddoTransform extends RESTTransform {
+
+	public static final String TYPE_NAME = "GdalAddoTransform";
+
+	private List<String> options;
+	private List<Integer> levels;
+
+	/**
+	 * Default constructor; sets <code>type</code> of
+	 * {@link RESTTransform} to "GdalAddoTransform"
+	 */
+	public RESTGdalAddoTransform() {
+		super(TYPE_NAME);
+	}
+
+	/**
+	 * @return the options
+	 */
+	public List<String> getOptions() {
+		return options;
+	}
+
+	/**
+	 * @param options the options to set
+	 */
+	public void setOptions(List<String> options) {
+		this.options = options;
+	}
+
+	/**
+	 * @return the levels
+	 */
+	public List<Integer> getLevels() {
+		return levels;
+	}
+
+	/**
+	 * @param levels the levels to set
+	 */
+	public void setLevels(List<Integer> levels) {
+		this.levels = levels;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/transform/RESTGdalTranslateTransform.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/transform/RESTGdalTranslateTransform.java
@@ -1,0 +1,51 @@
+/**
+ *
+ */
+package de.terrestris.shogun2.importer.transform;
+
+import java.util.List;
+
+import de.terrestris.shogun2.importer.transform.RESTTransform;
+
+/**
+ * terrestris GmbH & Co. KG
+ * @author ahenn
+ * @date 01.04.2016
+ *
+ * Importer transform task representing gdal_translate, a tool which converts
+ * raster data between different formats
+ * @see <a href="http://www.gdal.org/gdal_translate.html">GDAL (gdal_translate) documentation</a>
+ * Requires <code>gdal_translate</code> to be inside the PATH used by the web container running GeoServer.
+ */
+public class RESTGdalTranslateTransform extends RESTTransform {
+
+	/**
+	 *
+	 */
+	public static final String TYPE_NAME = "GdalTranslateTransform";
+
+	private List<String> options;
+
+	/**
+	 * Default constructor; sets <code>type</code> of
+	 * {@link RESTTransform} to "GdalTranslateTransform"
+	 */
+	public RESTGdalTranslateTransform() {
+		super(TYPE_NAME);
+	}
+
+	/**
+	 * @return the options
+	 */
+	public List<String> getOptions() {
+		return options;
+	}
+
+	/**
+	 * @param options the options to set
+	 */
+	public void setOptions(List<String> options) {
+		this.options = options;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/transform/RESTGdalWarpTransform.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/transform/RESTGdalWarpTransform.java
@@ -1,0 +1,48 @@
+package de.terrestris.shogun2.importer.transform;
+
+import java.util.List;
+
+import de.terrestris.shogun2.importer.transform.RESTTransform;
+
+/**
+ *
+ * terrestris GmbH & Co. KG
+ * @author ahenn
+ * @date 01.04.2016
+ *
+ *  Importer transform task representing gdalwarp, an image reprojection and warping utility,
+ *  @see <a href="http://www.gdal.org/gdalwarp.html">GDAL (gdalwarp) documentation</a>
+ *  Requires <code>gdalwarp</code> to be inside the PATH used by the web container running GeoServer.
+ */
+public class RESTGdalWarpTransform extends RESTTransform {
+
+	/**
+	 *
+	 */
+	public static final String TYPE_NAME = "GdalWarpTransform";
+
+	private List<String> options;
+
+	/**
+	 * Default constructor; sets <code>type</code> of
+	 * {@link RESTTransform} to "GdalWarpTransform"
+	 */
+	public RESTGdalWarpTransform() {
+		super(TYPE_NAME);
+	}
+
+	/**
+	 * @return the options
+	 */
+	public List<String> getOptions() {
+		return options;
+	}
+
+	/**
+	 * @param options the options to set
+	 */
+	public void setOptions(List<String> options) {
+		this.options = options;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/transform/RESTReprojectTransform.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/transform/RESTReprojectTransform.java
@@ -1,0 +1,84 @@
+package de.terrestris.shogun2.importer.transform;
+
+import de.terrestris.shogun2.importer.transform.RESTTransform;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+//@JsonRootName
+public class RESTReprojectTransform extends RESTTransform {
+
+	/**
+	 * constant field for transform type name
+	 */
+	public static final String TYPE_NAME = "ReprojectTransform";
+
+	/**
+	 *
+	 */
+	private String href;
+
+	/**
+	 *
+	 */
+	private String source;
+
+	/**
+	 *
+	 */
+	private String target;
+
+	/**
+	 * Default constructor; sets <code>type</code> of
+	 * {@link RESTTransform} to "ReprojectTransform"
+	 */
+	public RESTReprojectTransform() {
+		super(TYPE_NAME);
+	}
+
+	/**
+	 * @return the source
+	 */
+	public String getSource() {
+		return source;
+	}
+
+	/**
+	 * @param source the source to set
+	 */
+	public void setSource(String source) {
+		this.source = source;
+	}
+
+	/**
+	 * @return the target
+	 */
+	public String getTarget() {
+		return target;
+	}
+
+	/**
+	 * @param target the target to set
+	 */
+	public void setTarget(String target) {
+		this.target = target;
+	}
+
+	/**
+	 * @return the href
+	 */
+	public String getHref() {
+		return href;
+	}
+
+	/**
+	 * @param href the href to set
+	 */
+	public void setHref(String href) {
+		this.href = href;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/transform/RESTTransform.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/transform/RESTTransform.java
@@ -1,0 +1,47 @@
+package de.terrestris.shogun2.importer.transform;
+
+import de.terrestris.shogun2.importer.communication.AbstractRESTEntity;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class RESTTransform extends AbstractRESTEntity {
+
+	/**
+	 *
+	 */
+	private String type;
+
+	/**
+	 * Default constructor
+	 */
+	public RESTTransform() {
+
+	}
+
+	/**
+	 *
+	 * @param type
+	 */
+	public RESTTransform(String type) {
+		this.type = type;
+	}
+
+	/**
+	 * @return the type
+	 */
+	public String getType() {
+		return type;
+	}
+
+	/**
+	 * @param type the type to set
+	 */
+	public void setType(String type) {
+		this.type = type;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/transform/RESTTransformChain.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/importer/transform/RESTTransformChain.java
@@ -1,0 +1,61 @@
+package de.terrestris.shogun2.importer.transform;
+
+import java.util.List;
+
+import de.terrestris.shogun2.importer.transform.RESTTransform;
+import de.terrestris.shogun2.importer.communication.AbstractRESTEntity;
+
+/**
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+public class RESTTransformChain extends AbstractRESTEntity {
+
+	/**
+	 *
+	 */
+	private String type;
+
+	/**
+	 *
+	 */
+	private List<RESTTransform> transforms;
+
+	/**
+	 * Default constructor.
+	 */
+	public RESTTransformChain() {
+
+	}
+
+	/**
+	 * @return the type
+	 */
+	public String getType() {
+		return type;
+	}
+
+	/**
+	 * @return the transforms
+	 */
+	public List<RESTTransform> getTransforms() {
+		return transforms;
+	}
+
+	/**
+	 * @param type the type to set
+	 */
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	/**
+	 * @param transforms the transforms to set
+	 */
+	public void setTransforms(List<RESTTransform> transforms) {
+		this.transforms = transforms;
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
@@ -1861,6 +1861,8 @@ public class HttpUtil {
 			httpContext.setAuthCache(authCache);
 
 			httpClient = HttpClients.custom()
+					// TODO Temporarily workaround!
+					.disableContentCompression()
 					.setDefaultCredentialsProvider(credentialsProvider)
 					.build();
 

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
@@ -1207,8 +1207,10 @@ public class HttpUtil {
 	private static Response postParams(HttpPost httpRequest, List<NameValuePair> queryParams, Credentials credentials, Header[] requestHeaders)
 			throws URISyntaxException, UnsupportedEncodingException, HttpException {
 
-		HttpEntity httpEntity = new UrlEncodedFormEntity(queryParams);
-		httpRequest.setEntity(httpEntity);
+		if (!queryParams.isEmpty()) {
+			HttpEntity httpEntity = new UrlEncodedFormEntity(queryParams);
+			httpRequest.setEntity(httpEntity);
+		}
 
 		return send(httpRequest, credentials, requestHeaders);
 	}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -1890,7 +1891,6 @@ public class HttpUtil {
 			response.setStatusCode(httpStatus);
 
 			for (Header header : headers) {
-
 				if (header.getName().equalsIgnoreCase("Transfer-Encoding") &&
 					header.getValue().equalsIgnoreCase("chunked")) {
 					LOG.debug("Removed the header 'Transfer-Encoding:chunked'" +
@@ -1911,27 +1911,13 @@ public class HttpUtil {
 		} finally {
 
 			// cleanup
+			httpRequest.reset();
 
-			httpRequest.releaseConnection();
-
-			try {
-				if (httpResponse != null) {
-					httpResponse.close();
-				}
-			} catch (IOException e) {
-				LOG.error("Could not close CloseableHttpResponse: " + e.getMessage());
-			}
-
-			try {
-				httpClient.close();
-			} catch (IOException e) {
-				LOG.error("Could not close CloseableHttpClient: " + e.getMessage());
-			}
-
+			IOUtils.closeQuietly(httpResponse);
+			IOUtils.closeQuietly(httpClient);
 		}
 
 		return response;
-
 	}
 
 	/**

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
@@ -74,6 +74,11 @@ public class HttpUtil {
 	private static int httpTimeout;
 
 	/**
+	 * The default timeout given by the config beans.
+	 */
+	private static int defaultHttpTimeout;
+
+	/**
 	 * Performs an HTTP GET on the given URL <i>without authentication</i>
 	 *
 	 * @param url The URL to connect to.
@@ -88,7 +93,7 @@ public class HttpUtil {
 	}
 
 	/**
-	 * Performs an HTTP GET on the given URL <i>without authentication</i> and 
+	 * Performs an HTTP GET on the given URL <i>without authentication</i> and
 	 * additional HTTP request headers.
 	 *
 	 * @param url The URL to connect to.
@@ -126,7 +131,7 @@ public class HttpUtil {
 	 * @param url The URL to connect to.
 	 * @param credentials instance implementing {@link Credentials} interface holding a set of credentials
 	 * @param requestHeaders Additional HTTP headers added to the request
-	 * 
+	 *
 	 * @return The HTTP response as Response object.
 	 *
 	 * @throws URISyntaxException
@@ -157,7 +162,7 @@ public class HttpUtil {
 	 * @param username Credentials - username
 	 * @param password Credentials - password
 	 * @param requestHeaders Additional HTTP headers added to the request
-	 * 
+	 *
 	 * @throws HttpException
 	 * @throws URISyntaxException
 	 */
@@ -258,7 +263,7 @@ public class HttpUtil {
 	 * @param uri The URI to connect to.
 	 * @param credentials Instance implementing {@link Credentials} interface holding a set of credentials
 	 * @param requestHeaders Additional HTTP headers added to the request
-	 * 
+	 *
 	 * @return The HTTP response as Response object.
 	 *
 	 * @throws URISyntaxException
@@ -1982,8 +1987,29 @@ public class HttpUtil {
 	 */
 	@Value("${http.timeout}")
 	@SuppressWarnings("static-method")
-	public void setHttpTimeout(int httpTimeout) {
+	public void setDefaultHttpTimeout(int httpTimeout) {
+		HttpUtil.defaultHttpTimeout = httpTimeout;
 		HttpUtil.httpTimeout = httpTimeout;
 	}
 
+	/**
+	 * @return the httpTimeout
+	 */
+	public static int getHttpTimeout() {
+		return httpTimeout;
+	}
+
+	/**
+	 * @param httpTimeout the httpTimeout to set
+	 */
+	public static void setHttpTimeout(int httpTimeout) {
+		HttpUtil.httpTimeout = httpTimeout;
+	}
+
+	/**
+	 * Resets the http timeout to the default one given by the app config.
+	 */
+	public static void resetHttpTimeout() {
+		HttpUtil.httpTimeout = HttpUtil.defaultHttpTimeout;
+	}
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/http/HttpUtil.java
@@ -1866,8 +1866,6 @@ public class HttpUtil {
 			httpContext.setAuthCache(authCache);
 
 			httpClient = HttpClients.custom()
-					// TODO Temporarily workaround!
-					.disableContentCompression()
 					.setDefaultCredentialsProvider(credentialsProvider)
 					.build();
 


### PR DESCRIPTION
This adds the `GeoServerRESTImporter` that can be used to easily call the GeoServer importer extension's REST API.