### PR TITLE
Add boundless maven repo

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -72,6 +72,10 @@
             </releases>
         </repository>
         <repository>
+            <id>OSGeo GeoTools repo</id>
+            <url>http://download.osgeo.org/webdav/geotools</url>
+        </repository>
+        <repository>
             <id>Boundless repo</id>
             <url>https://repo.boundlessgeo.com/main/</url>
         </repository>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -72,8 +72,8 @@
             </releases>
         </repository>
         <repository>
-            <id>OSGeo GeoTools repo</id>
-            <url>http://download.osgeo.org/webdav/geotools</url>
+            <id>Boundless repo</id>
+            <url>https://repo.boundlessgeo.com/main/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
As http://download.osgeo.org/webdav/geotools is not responding reliable, we may have better luck by using https://repo.boundlessgeo.com/main/