### PR TITLE
Avoid exception when running test

### DIFF
--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/GeoServerInterceptorServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/GeoServerInterceptorServiceTest.java
@@ -27,6 +27,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
@@ -46,6 +47,7 @@ import de.terrestris.shogun2.util.model.Response;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(HttpUtil.class)
+@PowerMockIgnore("javax.management.*")
 public class GeoServerInterceptorServiceTest {
 
 	private final String TEST_GEOSERVER_BASE_PATH = "http://localhost:1234/geoserver/";


### PR DESCRIPTION
During the tests an exception occured (but the tests did not fail). By ignoring the `javax.management.*` classes, the exceptions will not occur anymore...