### PR TITLE
Remove version property of apache commons DBUtils 

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -167,7 +167,6 @@
         <commons-io.version>2.5</commons-io.version>
         <commons-beanutils.version>1.9.3</commons-beanutils.version>
         <commons-lang3.version>3.7</commons-lang3.version>
-        <commons-dbutils.version>1.7</commons-dbutils.version>
         <commons-collections4.version>4.1</commons-collections4.version>
         <commons-codec.version>1.9</commons-codec.version>
         <commons-collections.version>3.2.2</commons-collections.version>


### PR DESCRIPTION
Remove version property of apache commons DBUtils since it isn't used in SHOGUn2.