### PR TITLE
Fix performance problems

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Application.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Application.java
@@ -111,7 +111,7 @@ public class Application extends PersistentObject {
 	)
 	@JsonIdentityReference(alwaysAsId = true)
 	@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
-	@Fetch(FetchMode.JOIN)
+	@Fetch(FetchMode.SUBSELECT)
 	private List<Plugin> plugins = new ArrayList<>();
 
 	/**

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/Layer.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/Layer.java
@@ -32,7 +32,7 @@ import de.terrestris.shogun2.model.layer.source.LayerDataSource;
  */
 @Entity
 @Table
-@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@Inheritance(strategy = InheritanceType.JOINED)
 @Cacheable
 @Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 public class Layer extends PersistentObject {

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Map.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Map.java
@@ -79,7 +79,6 @@ public class Map extends Module {
 	)
 	@OrderColumn(name = "IDX")
 	@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
-	@Fetch(FetchMode.JOIN)
 	private List<Layer> mapLayers = new ArrayList<Layer>();
 
 	/**

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Module.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/module/Module.java
@@ -43,7 +43,7 @@ import de.terrestris.shogun2.model.layout.Layout;
  */
 @Entity
 @Table
-@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@Inheritance(strategy = InheritanceType.JOINED)
 @Cacheable
 @Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 public class Module extends PersistentObject {

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/tree/TreeFolder.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/tree/TreeFolder.java
@@ -16,8 +16,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
 
 /**
  * This class represents a (simple) composite {@link TreeNode}, i.e. a folder
@@ -50,7 +48,6 @@ public class TreeFolder extends TreeNode {
 	@OneToMany(mappedBy = "parentFolder")
 	@OrderBy("index")
 	@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
-	@Fetch(FetchMode.JOIN)
 	private List<TreeNode> children = new ArrayList<TreeNode>();
 
 	/**

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/tree/TreeNode.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/tree/TreeNode.java
@@ -41,7 +41,7 @@ import de.terrestris.shogun2.model.PersistentObject;
  */
 @Entity
 @Table
-@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@Inheritance(strategy = InheritanceType.JOINED)
 @JsonInclude(Include.NON_NULL)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 @Cacheable


### PR DESCRIPTION
When requesting applications in certain projects with their own model extensions, performance will sometimes drop dramatically. The problematic SQL statements had the following characteristics:

- they used a ridiculous amount of left outer joins (more than 80)
- they were joining over a couple of (select ... union ... union) subselects

In order to reduce the amount of joins this PR removes some of the fetch mode annotations (or changes them to subselect) (in order to avoid too many joins at once) and changes the inheritance strategy for all related classes to joined instead of table_per_class (in order to avoid the unions).

Please note that this will result in changed table structures, so we should only merge this after a new release.

@terrestris/devs please review
