### PR TITLE
Enhance models of WMTS layers

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/WmtsLayerDataSource.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/WmtsLayerDataSource.java
@@ -1,13 +1,15 @@
 package de.terrestris.shogun2.model.layer.source;
 
-import javax.persistence.Cacheable;
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import javax.persistence.*;
 
+import de.terrestris.shogun2.model.layer.util.TileGrid;
+import de.terrestris.shogun2.model.layer.util.WmtsTileGrid;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
+
+import java.util.List;
 
 /**
  * Class representing a layer source for tile data from WMTS servers.
@@ -26,11 +28,177 @@ public class WmtsLayerDataSource extends LayerDataSource {
      */
     private static final long serialVersionUID = 1L;
 
+    @ManyToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "TILEGRID_ID")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+    private WmtsTileGrid tileGrid;
+
+    @ElementCollection(targetClass = String.class)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+    private List<String> urls;
+
+    private String wmtsLayer;
+    private String wmtsStyle;
+    private String projection;
+    private String matrixSet;
+    private String requestEncoding;
+    private String format;
+
     /**
-     *
+     * Default constructor
      */
     public WmtsLayerDataSource() {
         super();
+    }
+
+    /**
+     * @param tileGrid
+     * @param wmtsLayer
+     * @param wmtsStyle
+     * @param projection
+     * @param matrixSet
+     * @param requestEncoding
+     * @param format
+     * @param urls
+     */
+    public WmtsLayerDataSource(WmtsTileGrid tileGrid, String wmtsLayer, String wmtsStyle, String projection, String matrixSet, String requestEncoding, String format, List<String> urls) {
+        this();
+        this.tileGrid = tileGrid;
+        this.wmtsLayer = wmtsLayer;
+        this.wmtsStyle = wmtsStyle;
+        this.projection = projection;
+        this.matrixSet = matrixSet;
+        this.requestEncoding = requestEncoding;
+        this.format = format;
+        this.urls = urls;
+    }
+
+    /**
+     *
+     * @return the {@link WmtsTileGrid}
+     */
+    public WmtsTileGrid getTileGrid() {
+        return tileGrid;
+    }
+
+    /**
+     *
+     * @param tileGrid WmtsTileGrid to set
+     */
+    public void setTileGrid(WmtsTileGrid tileGrid) {
+        this.tileGrid = tileGrid;
+    }
+
+    /**
+     *
+     * @return The layer name of WMTS layer
+     */
+    public String getWmtsLayer() {
+        return wmtsLayer;
+    }
+
+    /**
+     *
+     * @param wmtsLayer The layer name to set
+     */
+    public void setWmtsLayer(String wmtsLayer) {
+        this.wmtsLayer = wmtsLayer;
+    }
+
+    /**
+     *
+     * @return The style name to set
+     */
+    public String getWmtsStyle() {
+        return wmtsStyle;
+    }
+
+    /**
+     *
+     * @param wmtsStyle The style name to set
+     */
+    public void setWmtsStyle(String wmtsStyle) {
+        this.wmtsStyle = wmtsStyle;
+    }
+
+    /**
+     *
+     * @return The projection
+     */
+    public String getProjection() {
+        return projection;
+    }
+
+    /**
+     *
+     * @param projection The projection code to set
+     */
+    public void setProjection(String projection) {
+        this.projection = projection;
+    }
+
+    /**
+     *
+     * @return matrix set to use
+     */
+    public String getMatrixSet() {
+        return matrixSet;
+    }
+
+    /**
+     *
+     * @param matrixSet The matrix set to set
+     */
+    public void setMatrixSet(String matrixSet) {
+        this.matrixSet = matrixSet;
+    }
+
+    /**
+     *
+     * @return the request encoding
+     */
+    public String getRequestEncoding() {
+        return requestEncoding;
+    }
+
+    /**
+     *
+     * @param requestEncoding the request encoding to set
+     */
+    public void setRequestEncoding(String requestEncoding) {
+        this.requestEncoding = requestEncoding;
+    }
+
+    /**
+     *
+     * @return the image format
+     */
+    public String getFormat() {
+        return format;
+    }
+
+    /**
+     *
+     * @param format the image format to set
+     */
+    public void setFormat(String format) {
+        this.format = format;
+    }
+
+    /**
+     *
+     * @return The urls as {@link List} of {@link String}
+     */
+    public List<String> getUrls() {
+        return urls;
+    }
+
+    /**
+     *
+     * @param urls The urls to set
+     */
+    public void setUrls(List<String> urls) {
+        this.urls = urls;
     }
 
     /**
@@ -45,6 +213,14 @@ public class WmtsLayerDataSource extends LayerDataSource {
         // two randomly chosen prime numbers
         return new HashCodeBuilder(11, 19).
             appendSuper(super.hashCode()).
+            append(getFormat()).
+            append(getRequestEncoding()).
+            append(getWmtsLayer()).
+            append(getMatrixSet()).
+            append(getProjection()).
+            append(getWmtsStyle()).
+            append(getTileGrid()).
+            append(getUrls()).
             toHashCode();
     }
 
@@ -63,6 +239,14 @@ public class WmtsLayerDataSource extends LayerDataSource {
 
         return new EqualsBuilder().
             appendSuper(super.equals(other)).
+            append(getFormat(), other.getFormat()).
+            append(getRequestEncoding(), other.getRequestEncoding()).
+            append(getWmtsLayer(), other.getWmtsLayer()).
+            append(getMatrixSet(), other.getMatrixSet()).
+            append(getProjection(), other.getProjection()).
+            append(getWmtsStyle(), other.getWmtsStyle()).
+            append(getTileGrid(), other.getTileGrid()).
+            append(getUrls(), other.getUrls()).
             isEquals();
     }
 

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/util/WmtsTileGrid.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/util/WmtsTileGrid.java
@@ -1,11 +1,14 @@
 package de.terrestris.shogun2.model.layer.util;
 
-import de.terrestris.shogun2.model.layer.util.TileGrid;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.Table;
+import java.util.List;
 
 /**
  * Class representing a WMTS tile grid
@@ -16,52 +19,54 @@ import javax.persistence.Table;
 @Table
 public class WmtsTileGrid extends TileGrid {
 
-	// String array holding the matrix IDs.
-	private String[] matrixIds;
+    // String list holding the matrix IDs.
+    @ElementCollection(targetClass = String.class)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+    private List<String> matrixIds;
 
-	/**
-	 *
-	 * @return the matrix IDs.
-	 */
-	public String[] getMatrixIds() {
-		return matrixIds;
-	}
+    /**
+     * @return the matrix IDs.
+     */
+    public List<String> getMatrixIds() {
+        return matrixIds;
+    }
 
-	/**
-	 * Setter for matrix IDs
-	 * @param matrixIds The matrix IDs to set
-	 */
-	public void setMatrixIds(String[] matrixIds) {
-		this.matrixIds = matrixIds;
-	}
+    /**
+     * Setter for matrix IDs
+     *
+     * @param matrixIds The list of matrix IDs to set
+     */
+    public void setMatrixIds(List<String> matrixIds) {
+        this.matrixIds = matrixIds;
+    }
 
-	@Override
-	public int hashCode() {
-		// two randomly chosen prime numbers
-		return new HashCodeBuilder(89, 29).
-				appendSuper(super.hashCode()).
-				append(getMatrixIds()).
-				toHashCode();
-	}
+    @Override
+    public int hashCode() {
+        // two randomly chosen prime numbers
+        return new HashCodeBuilder(89, 29).
+            appendSuper(super.hashCode()).
+            append(getMatrixIds()).
+            toHashCode();
+    }
 
-	/**
-	 * @see java.lang.Object#equals(java.lang.Object)
-	 * <p>
-	 * According to
-	 * http://stackoverflow.com/questions/27581/overriding-equals
-	 * -and-hashcode-in-java it is recommended only to use getter-methods
-	 * when using ORM like Hibernate
-	 */
-	@Override
-	public boolean equals(Object obj) {
-		if (!(obj instanceof WmtsTileGrid))
-			return false;
-		WmtsTileGrid other = (WmtsTileGrid) obj;
+    /**
+     * @see java.lang.Object#equals(java.lang.Object)
+     * <p>
+     * According to
+     * http://stackoverflow.com/questions/27581/overriding-equals
+     * -and-hashcode-in-java it is recommended only to use getter-methods
+     * when using ORM like Hibernate
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof WmtsTileGrid))
+            return false;
+        WmtsTileGrid other = (WmtsTileGrid) obj;
 
-		return new EqualsBuilder().
-				appendSuper(super.equals(other)).
-				append(getMatrixIds(), other.getMatrixIds()).
-				isEquals();
-	}
+        return new EqualsBuilder().
+            appendSuper(super.equals(other)).
+            append(getMatrixIds(), other.getMatrixIds()).
+            isEquals();
+    }
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/util/WmtsTileGrid.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/util/WmtsTileGrid.java
@@ -1,0 +1,67 @@
+package de.terrestris.shogun2.model.layer.util;
+
+import de.terrestris.shogun2.model.layer.util.TileGrid;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+/**
+ * Class representing a WMTS tile grid
+ *
+ * @author Andre Henn
+ */
+@Entity
+@Table
+public class WmtsTileGrid extends TileGrid {
+
+	// String array holding the matrix IDs.
+	private String[] matrixIds;
+
+	/**
+	 *
+	 * @return the matrix IDs.
+	 */
+	public String[] getMatrixIds() {
+		return matrixIds;
+	}
+
+	/**
+	 * Setter for matrix IDs
+	 * @param matrixIds The matrix IDs to set
+	 */
+	public void setMatrixIds(String[] matrixIds) {
+		this.matrixIds = matrixIds;
+	}
+
+	@Override
+	public int hashCode() {
+		// two randomly chosen prime numbers
+		return new HashCodeBuilder(89, 29).
+				appendSuper(super.hashCode()).
+				append(getMatrixIds()).
+				toHashCode();
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 * <p>
+	 * According to
+	 * http://stackoverflow.com/questions/27581/overriding-equals
+	 * -and-hashcode-in-java it is recommended only to use getter-methods
+	 * when using ORM like Hibernate
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof WmtsTileGrid))
+			return false;
+		WmtsTileGrid other = (WmtsTileGrid) obj;
+
+		return new EqualsBuilder().
+				appendSuper(super.equals(other)).
+				append(getMatrixIds(), other.getMatrixIds()).
+				isEquals();
+	}
+
+}


### PR DESCRIPTION
This PR adds a bunch of further attributes to the existing `WmtsLayerDataSource` and adds a `WmtsTileGrid` model which can be used w.g. with a [WMTS source](https://openlayers.org/en/latest/apidoc/ol.source.WMTS.html) of OpenLayers .  