### PR TITLE
Adjust column content length

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/ImageWmsLayerDataSource.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/ImageWmsLayerDataSource.java
@@ -1,6 +1,7 @@
 package de.terrestris.shogun2.model.layer.source;
 
 import javax.persistence.Cacheable;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 
@@ -32,11 +33,13 @@ public class ImageWmsLayerDataSource extends LayerDataSource {
     /**
      *
      */
+    @Column(length = 2048)
     private String layerNames;
 
     /**
      *
      */
+    @Column(length = 2048)
     private String layerStyles;
 
     /**


### PR DESCRIPTION
This increases the maximum content length of the fields `layerNames` and `layerStyles` from 255 to 2048 characters.