### PR TITLE
Bump version of spring, hikari, h2 and jackson

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -125,20 +125,20 @@
         <tomcat.version>9.0.2</tomcat.version>
 
         <!-- Core -->
-        <spring.version>5.0.2.RELEASE</spring.version>
-        <spring-security.version>5.0.0.RELEASE</spring-security.version>
-        <spring-ldap.version>2.3.1.RELEASE</spring-ldap.version>
+        <spring.version>5.1.1.RELEASE</spring.version>
+        <spring-security.version>5.1.1.RELEASE</spring-security.version>
+        <spring-ldap.version>2.3.2.RELEASE</spring-ldap.version>
         <log4j.version>2.10.0</log4j.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <jackson.version>2.9.3</jackson.version>
+        <jackson.version>2.9.7</jackson.version>
         <opencsv.version>4.1</opencsv.version>
         <ehcache.version>3.4.0</ehcache.version>
 
         <!-- Persistence -->
         <hibernate.version>5.2.12.Final</hibernate.version>
         <hikari-jdk7.version>2.4.11</hikari-jdk7.version>
-        <hikari.version>2.7.6</hikari.version>
-        <h2.version>1.4.196</h2.version>
+        <hikari.version>3.2.0</hikari.version>
+        <h2.version>1.4.197</h2.version>
 
         <jdom.version>1.1.3</jdom.version>
 


### PR DESCRIPTION
Title says it all.

Should be updated due to security vulnerabilities in `com.fasterxml.jackson.core:jackson-databind` and `org.springframework:spring-core`
