### PR TITLE
Intercept OGC requests with basic auth by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ release.properties
 .idea/
 *.iml
 *.iws
+
+##### Visual Studio Code #####
+.vscode
+.factorypath
+

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/BasicAuthHeaderRequest.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/BasicAuthHeaderRequest.java
@@ -1,0 +1,82 @@
+/**
+ *
+ */
+package de.terrestris.shogun2.util.interceptor;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.http.HttpHeaders;
+
+import de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest;
+
+/**
+ * Utility class for basic auth based requests in the geoserver interceptor context.
+ * Accepts a user and password via the constructor, which will be used to add an
+ * appropriate basic auth header to the requests.
+ *
+ * Credits go to https://stackoverflow.com/a/2811841 and
+ * https://stackoverflow.com/a/44200124
+ *
+ * @author Nils Bühner
+ *
+ */
+public class BasicAuthHeaderRequest extends MutableHttpServletRequest {
+
+	/**
+	 *
+	 */
+	public final String encoding;
+
+	/**
+	 *
+	 * @param request
+	 * @param user
+	 * @param password
+	 */
+	public BasicAuthHeaderRequest(HttpServletRequest request, String user, String password) {
+		super(request);
+		this.encoding = "Basic " + Base64.getEncoder().encodeToString(user.concat(":").concat(password).getBytes());
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public String getHeader(String name) {
+
+		if (name.equals(HttpHeaders.AUTHORIZATION)) {
+			return encoding;
+		}
+		return super.getHeader(name);
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public Enumeration<String> getHeaders(String name) {
+		if (name.equals(HttpHeaders.AUTHORIZATION)) {
+			List<String> list = new ArrayList<>();
+			list.add(encoding);
+			return Collections.enumeration(list);
+		}
+		return super.getHeaders(name);
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public Enumeration<String> getHeaderNames() {
+		List<String> list = Collections.list(super.getHeaderNames());
+		list.add(HttpHeaders.AUTHORIZATION);
+		return Collections.enumeration(list);
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/impl/WcsRequestInterceptor.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/impl/WcsRequestInterceptor.java
@@ -13,20 +13,20 @@ import de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest;
 import de.terrestris.shogun2.util.interceptor.WcsRequestInterceptorInterface;
 
 /**
- * Interceptor class for WCS requests.
- * Adds basic auth headers based on the GS properties by default.
+ * Interceptor class for WCS requests. Adds basic auth headers based on the GS
+ * properties by default.
  *
  * @author Nils Bühner
  *
  */
 public class WcsRequestInterceptor implements WcsRequestInterceptorInterface {
 
-    /**
+	/**
 	 *
 	 */
-    private static final Logger LOG = getLogger(WcsRequestInterceptor.class);
+	private static final Logger LOG = getLogger(WcsRequestInterceptor.class);
 
-    /**
+	/**
 	 *
 	 */
 	@Value("${geoserver.username}")
@@ -38,31 +38,31 @@ public class WcsRequestInterceptor implements WcsRequestInterceptorInterface {
 	@Value("${geoserver.password}")
 	private String gsPass;
 
-    /**
-     *
-     */
+	/**
+	 *
+	 */
 	@Override
 	public MutableHttpServletRequest interceptGetCapabilities(MutableHttpServletRequest request) {
-        LOG.debug("Intercepting WCS GetCapabilities and adding Basic auth credentials.");
-        return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+		LOG.debug("Intercepting WCS GetCapabilities and adding Basic auth credentials.");
+		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
 	}
 
-    /**
-     *
-     */
+	/**
+	 *
+	 */
 	@Override
 	public MutableHttpServletRequest interceptDescribeCoverage(MutableHttpServletRequest request) {
 		LOG.debug("Intercepting WCS DescribeCoverage and adding Basic auth credentials.");
-        return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
 	}
 
-    /**
-     *
-     */
+	/**
+	 *
+	 */
 	@Override
 	public MutableHttpServletRequest interceptGetCoverage(MutableHttpServletRequest request) {
 		LOG.debug("Intercepting WCS GetCoverage and adding Basic auth credentials.");
-        return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
 	}
 
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/impl/WcsRequestInterceptor.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/impl/WcsRequestInterceptor.java
@@ -1,0 +1,68 @@
+/**
+ *
+ */
+package de.terrestris.shogun2.util.interceptor.impl;
+
+import static org.apache.logging.log4j.LogManager.getLogger;
+
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
+
+import de.terrestris.shogun2.util.interceptor.BasicAuthHeaderRequest;
+import de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest;
+import de.terrestris.shogun2.util.interceptor.WcsRequestInterceptorInterface;
+
+/**
+ * Interceptor class for WCS requests.
+ * Adds basic auth headers based on the GS properties by default.
+ *
+ * @author Nils Bühner
+ *
+ */
+public class WcsRequestInterceptor implements WcsRequestInterceptorInterface {
+
+    /**
+	 *
+	 */
+    private static final Logger LOG = getLogger(WcsRequestInterceptor.class);
+
+    /**
+	 *
+	 */
+	@Value("${geoserver.username}")
+	private String gsUser;
+
+	/**
+	 *
+	 */
+	@Value("${geoserver.password}")
+	private String gsPass;
+
+    /**
+     *
+     */
+	@Override
+	public MutableHttpServletRequest interceptGetCapabilities(MutableHttpServletRequest request) {
+        LOG.debug("Intercepting WCS GetCapabilities and adding Basic auth credentials.");
+        return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+	}
+
+    /**
+     *
+     */
+	@Override
+	public MutableHttpServletRequest interceptDescribeCoverage(MutableHttpServletRequest request) {
+		LOG.debug("Intercepting WCS DescribeCoverage and adding Basic auth credentials.");
+        return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+	}
+
+    /**
+     *
+     */
+	@Override
+	public MutableHttpServletRequest interceptGetCoverage(MutableHttpServletRequest request) {
+		LOG.debug("Intercepting WCS GetCoverage and adding Basic auth credentials.");
+        return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/impl/WfsRequestInterceptor.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/impl/WfsRequestInterceptor.java
@@ -1,0 +1,86 @@
+/**
+ *
+ */
+package de.terrestris.shogun2.util.interceptor.impl;
+
+import static org.apache.logging.log4j.LogManager.getLogger;
+
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
+
+import de.terrestris.shogun2.util.interceptor.BasicAuthHeaderRequest;
+import de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest;
+import de.terrestris.shogun2.util.interceptor.WfsRequestInterceptorInterface;
+
+/**
+ * Interceptor class for WFS requests.
+ * Adds basic auth headers based on the GS properties by default.
+ *
+ * @author Nils Bühner
+ *
+ */
+public class WfsRequestInterceptor implements WfsRequestInterceptorInterface {
+
+	/**
+	 *
+	 */
+	private static final Logger LOG = getLogger(WfsRequestInterceptor.class);
+
+	/**
+	 *
+	 */
+	@Value("${geoserver.username}")
+	private String gsUser;
+
+	/**
+	 *
+	 */
+	@Value("${geoserver.password}")
+	private String gsPass;
+
+    /**
+     *
+     */
+	@Override
+	public MutableHttpServletRequest interceptGetCapabilities(MutableHttpServletRequest request) {
+		LOG.debug("Intercepting WFS GetCapabilities and adding Basic auth credentials.");
+		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+	}
+
+    /**
+     *
+     */
+	@Override
+	public MutableHttpServletRequest interceptDescribeFeatureType(MutableHttpServletRequest request) {
+		LOG.debug("Intercepting WFS DescribeFeatureType and adding Basic auth credentials.");
+		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+	}
+
+    /**
+     *
+     */
+	@Override
+	public MutableHttpServletRequest interceptGetFeature(MutableHttpServletRequest request) {
+		LOG.debug("Intercepting WFS GetFeature and adding Basic auth credentials.");
+		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+	}
+
+    /**
+     *
+     */
+	@Override
+	public MutableHttpServletRequest interceptLockFeature(MutableHttpServletRequest request) {
+		LOG.debug("Intercepting WFS LockFeature and adding Basic auth credentials.");
+		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+	}
+
+    /**
+     *
+     */
+	@Override
+	public MutableHttpServletRequest interceptTransaction(MutableHttpServletRequest request) {
+		LOG.debug("Intercepting WFS Transaction and adding Basic auth credentials.");
+		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/impl/WfsRequestInterceptor.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/impl/WfsRequestInterceptor.java
@@ -13,8 +13,8 @@ import de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest;
 import de.terrestris.shogun2.util.interceptor.WfsRequestInterceptorInterface;
 
 /**
- * Interceptor class for WFS requests.
- * Adds basic auth headers based on the GS properties by default.
+ * Interceptor class for WFS requests. Adds basic auth headers based on the GS
+ * properties by default.
  *
  * @author Nils Bühner
  *
@@ -38,45 +38,45 @@ public class WfsRequestInterceptor implements WfsRequestInterceptorInterface {
 	@Value("${geoserver.password}")
 	private String gsPass;
 
-    /**
-     *
-     */
+	/**
+	 *
+	 */
 	@Override
 	public MutableHttpServletRequest interceptGetCapabilities(MutableHttpServletRequest request) {
 		LOG.debug("Intercepting WFS GetCapabilities and adding Basic auth credentials.");
 		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
 	}
 
-    /**
-     *
-     */
+	/**
+	 *
+	 */
 	@Override
 	public MutableHttpServletRequest interceptDescribeFeatureType(MutableHttpServletRequest request) {
 		LOG.debug("Intercepting WFS DescribeFeatureType and adding Basic auth credentials.");
 		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
 	}
 
-    /**
-     *
-     */
+	/**
+	 *
+	 */
 	@Override
 	public MutableHttpServletRequest interceptGetFeature(MutableHttpServletRequest request) {
 		LOG.debug("Intercepting WFS GetFeature and adding Basic auth credentials.");
 		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
 	}
 
-    /**
-     *
-     */
+	/**
+	 *
+	 */
 	@Override
 	public MutableHttpServletRequest interceptLockFeature(MutableHttpServletRequest request) {
 		LOG.debug("Intercepting WFS LockFeature and adding Basic auth credentials.");
 		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
 	}
 
-    /**
-     *
-     */
+	/**
+	 *
+	 */
 	@Override
 	public MutableHttpServletRequest interceptTransaction(MutableHttpServletRequest request) {
 		LOG.debug("Intercepting WFS Transaction and adding Basic auth credentials.");

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/impl/WmsRequestInterceptor.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/impl/WmsRequestInterceptor.java
@@ -1,0 +1,95 @@
+/**
+ *
+ */
+package de.terrestris.shogun2.util.interceptor.impl;
+
+import static org.apache.logging.log4j.LogManager.getLogger;
+
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
+
+import de.terrestris.shogun2.util.interceptor.BasicAuthHeaderRequest;
+import de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest;
+import de.terrestris.shogun2.util.interceptor.WmsRequestInterceptorInterface;
+
+/**
+ * Interceptor class for WMS requests.
+ * Adds basic auth headers based on the GS properties by default.
+ *
+ * @author Nils Bühner
+ *
+ */
+public class WmsRequestInterceptor implements WmsRequestInterceptorInterface {
+
+	/**
+	 *
+	 */
+	private static final Logger LOG = getLogger(WmsRequestInterceptor.class);
+
+	/**
+	 *
+	 */
+	@Value("${geoserver.username}")
+	private String gsUser;
+
+	/**
+	 *
+	 */
+	@Value("${geoserver.password}")
+	private String gsPass;
+
+	/**
+	 *
+	 */
+	@Override
+	public MutableHttpServletRequest interceptGetMap(MutableHttpServletRequest request) {
+		LOG.debug("Intercepting WMS GetMap and adding Basic auth credentials.");
+		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public MutableHttpServletRequest interceptGetFeatureInfo(MutableHttpServletRequest request) {
+		LOG.debug("Intercepting WMS GetFeatureInfo and adding Basic auth credentials.");
+		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public MutableHttpServletRequest interceptDescribeLayer(MutableHttpServletRequest request) {
+		LOG.debug("Intercepting WMS DescribeLayer and adding Basic auth credentials.");
+		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public MutableHttpServletRequest interceptGetLegendGraphic(MutableHttpServletRequest request) {
+		LOG.debug("Intercepting WMS GetLegendGraphic and adding Basic auth credentials.");
+		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public MutableHttpServletRequest interceptGetStyles(MutableHttpServletRequest request) {
+		LOG.debug("Intercepting WMS GetStyles and adding Basic auth credentials.");
+		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	public MutableHttpServletRequest interceptGetCapabilities(MutableHttpServletRequest request) {
+		LOG.debug("Intercepting WMS GetCapabilities and adding Basic auth credentials.");
+		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/impl/WmsRequestInterceptor.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/impl/WmsRequestInterceptor.java
@@ -13,8 +13,8 @@ import de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest;
 import de.terrestris.shogun2.util.interceptor.WmsRequestInterceptorInterface;
 
 /**
- * Interceptor class for WMS requests.
- * Adds basic auth headers based on the GS properties by default.
+ * Interceptor class for WMS requests. Adds basic auth headers based on the GS
+ * properties by default.
  *
  * @author Nils Bühner
  *

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/impl/WpsRequestInterceptor.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/impl/WpsRequestInterceptor.java
@@ -1,0 +1,68 @@
+/**
+ *
+ */
+package de.terrestris.shogun2.util.interceptor.impl;
+
+import static org.apache.logging.log4j.LogManager.getLogger;
+
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
+
+import de.terrestris.shogun2.util.interceptor.BasicAuthHeaderRequest;
+import de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest;
+import de.terrestris.shogun2.util.interceptor.WpsRequestInterceptorInterface;
+
+/**
+ * Interceptor class for WPS requests.
+ * Adds basic auth headers based on the GS properties by default.
+ *
+ * @author Nils Bühner
+ *
+ */
+public class WpsRequestInterceptor implements WpsRequestInterceptorInterface {
+
+	/**
+	 *
+	 */
+	private static final Logger LOG = getLogger(WpsRequestInterceptor.class);
+
+	/**
+	 *
+	 */
+	@Value("${geoserver.username}")
+	private String gsUser;
+
+	/**
+	 *
+	 */
+	@Value("${geoserver.password}")
+	private String gsPass;
+
+	/**
+	 * @see de.terrestris.shogun2.util.interceptor.WpsRequestInterceptorInterface#interceptGetCapabilities(de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest)
+	 */
+	@Override
+	public MutableHttpServletRequest interceptGetCapabilities(MutableHttpServletRequest request) {
+		LOG.debug("Intercepting WPS GetCapabilities and adding Basic auth credentials.");
+		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+	}
+
+	/**
+	 * @see de.terrestris.shogun2.util.interceptor.WpsRequestInterceptorInterface#interceptDescribeProcess(de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest)
+	 */
+	@Override
+	public MutableHttpServletRequest interceptDescribeProcess(MutableHttpServletRequest request) {
+		LOG.debug("Intercepting WPS DescribeProcess and adding Basic auth credentials.");
+		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+	}
+
+	/**
+	 * @see de.terrestris.shogun2.util.interceptor.WpsRequestInterceptorInterface#interceptExecute(de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest)
+	 */
+	@Override
+	public MutableHttpServletRequest interceptExecute(MutableHttpServletRequest request) {
+		LOG.debug("Intercepting WPS Execute and adding Basic auth credentials.");
+		return new BasicAuthHeaderRequest(request, gsUser, gsPass);
+	}
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/impl/WpsRequestInterceptor.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/impl/WpsRequestInterceptor.java
@@ -13,8 +13,8 @@ import de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest;
 import de.terrestris.shogun2.util.interceptor.WpsRequestInterceptorInterface;
 
 /**
- * Interceptor class for WPS requests.
- * Adds basic auth headers based on the GS properties by default.
+ * Interceptor class for WPS requests. Adds basic auth headers based on the GS
+ * properties by default.
  *
  * @author Nils Bühner
  *

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context.xml
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/spring/__artifactId__-context.xml
@@ -78,16 +78,10 @@
         <value>${package}.model</value>
     </util:list>
 
-    <!--
-     | The interceptor beans, uncomment to be able to use the interceptor
-     | classes for OGC requests
-     |
-    <bean id="wmsRequestInterceptor" class="${package}.util.WmsRequestInterceptor" />
-    <bean id="wmsResponseInterceptor" class="${package}.util.WmsResponseInterceptor" />
-    <bean id="wfsRequestInterceptor" class="${package}.util.WfsRequestInterceptor" />
-    <bean id="wfsResponseInterceptor" class="${package}.util.WfsResponseInterceptor" />
-    <bean id="wcsRequestInterceptor" class="${package}.util.WcsRequestInterceptor" />
-    <bean id="wcsResponseInterceptor" class="${package}.util.WcsResponseInterceptor" />
-     |
-     +-->
+    <!-- The default shogun2 OWS request interceptors -->
+    <bean id="wfsRequestInterceptor" class="de.terrestris.shogun2.util.interceptor.impl.WfsRequestInterceptor" />
+    <bean id="wcsRequestInterceptor" class="de.terrestris.shogun2.util.interceptor.impl.WcsRequestInterceptor" />
+    <bean id="wmsRequestInterceptor" class="de.terrestris.shogun2.util.interceptor.impl.WmsRequestInterceptor" />
+    <bean id="wpsRequestInterceptor" class="de.terrestris.shogun2.util.interceptor.impl.WpsRequestInterceptor" />
+
 </beans>


### PR DESCRIPTION
This is a solution for #315 to add basic auth credentials (based on geoserver properties) for each OGC request within the interceptor. In case the geoserver or certain services are not protected, this will not break anything.

The main class is `BasicAuthHeaderRequest.java` (extending our `MutableHttpServletRequest`), which will actually add the basic auth header. The credentials can be passed in the constructor, which may also be helpful in project solutions with more specific requirements.

The new classes in the `de.terrestris.shogun2.util.interceptor.impl` package are default implementations for shogun2 and use the credentials from the `geoserver.user` and `geoserver.password` properties. They can be seen as a demo on how to use the `BasicAuthHeaderRequest` class.

The webapp archetype has also been adapted to make use of the new default implementations.