### PR TITLE
Migrate to latest JTS

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -62,7 +62,6 @@
         </repository>
     </repositories>
 
-
     <pluginRepositories>
         <pluginRepository>
             <id>nexus.terrestris.de-plugins</id>
@@ -202,7 +201,7 @@
         <apache-httpclient.version>4.5.5</apache-httpclient.version>
 
         <!-- GeoTools -->
-        <geotools.version>18.2</geotools.version>
+        <geotools.version>20.1</geotools.version>
 
         <!-- Zip4j -->
         <zip4j.version>1.3.2</zip4j.version>
@@ -214,10 +213,10 @@
         <powermock.version>1.7.3</powermock.version>
 
         <!-- Java Topology Suite -->
-        <jts.version>1.14.0</jts.version>
+        <jts.version>1.16.0</jts.version>
 
         <!-- JTS Jackson Datatype -->
-        <jackson-datatype-jts.version>2.4</jackson-datatype-jts.version>
+        <jackson-datatype-jts.version>0.10-2.5-2</jackson-datatype-jts.version>
 
         <clean-plugin.version>3.0.0</clean-plugin.version>
         <compiler-plugin.version>3.7.0</compiler-plugin.version>
@@ -763,7 +762,7 @@
             </dependency>
 
             <dependency>
-                <groupId>com.bedatadriven</groupId>
+                <groupId>com.graphhopper.external</groupId>
                 <artifactId>jackson-datatype-jts</artifactId>
                 <version>${jackson-datatype-jts.version}</version>
             </dependency>
@@ -941,7 +940,7 @@
             </dependency>
 
             <dependency>
-                <groupId>com.vividsolutions</groupId>
+                <groupId>org.locationtech.jts</groupId>
                 <artifactId>jts-core</artifactId>
                 <version>${jts.version}</version>
             </dependency>

--- a/src/shogun2-core/pom.xml
+++ b/src/shogun2-core/pom.xml
@@ -196,11 +196,11 @@
             <artifactId>jackson-datatype-joda</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.bedatadriven</groupId>
+            <groupId>com.graphhopper.external</groupId>
             <artifactId>jackson-datatype-jts</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>com.vividsolutions</groupId>
+                    <groupId>org.locationtech.jts</groupId>
                     <artifactId>jts</artifactId>
                 </exclusion>
             </exclusions>
@@ -263,7 +263,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.vividsolutions</groupId>
+            <groupId>org.locationtech.jts</groupId>
             <artifactId>jts-core</artifactId>
         </dependency>
 

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Territory.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/Territory.java
@@ -11,8 +11,8 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.locationtech.jts.geom.MultiPolygon;
 
-import com.vividsolutions.jts.geom.MultiPolygon;
 
 /**
  * @author Nils Bühner


### PR DESCRIPTION
This will migrate to the latest JTS, which is used by the latest versions of geotools. This is necessary to remain compatible to the latest geoserver versions. Major change in JTS is that the package name has changed.

Related links:

* https://github.com/locationtech/jts/blob/master/MIGRATION.md
* https://github.com/bedatadriven/jackson-datatype-jts/pull/18#issuecomment-399002136