### PR TITLE
Forward GWC headers for missed caches

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
@@ -75,7 +75,8 @@ public class GeoServerInterceptorService {
         "geowebcache-crs",
         "geowebcache-gridset",
         "geowebcache-tile-bounds",
-        "geowebcache-tile-index"
+        "geowebcache-tile-index",
+        "geowebcache-miss-reason"
     };
 
     private final String WMS_REFLECT_ENDPOINT = "/reflect";
@@ -550,7 +551,7 @@ public class GeoServerInterceptorService {
     }
 
     /**
-     * 
+     *
      * @param request
      * @return
      */


### PR DESCRIPTION
Title says it all. In particular, `geowebcache-miss-reason` will be forwarded