### PR TITLE
Adds a jsonb user type to handle more complex documents

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -555,6 +555,10 @@
             <artifactId>hibernate-jcache</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-spatial</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-api</artifactId>
         </dependency>
@@ -791,6 +795,18 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
+                <version>${hibernate.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.logging</groupId>
+                        <artifactId>jboss-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-spatial</artifactId>
                 <version>${hibernate.version}</version>
                 <exclusions>
                     <exclusion>

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/hibernate/JsonbUserType.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/hibernate/JsonbUserType.java
@@ -1,0 +1,107 @@
+package de.terrestris.shogun2.hibernate;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.usertype.UserType;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonWriter;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+
+/**
+ * Generic jsonb user type. Annotate your entities with javax.json.JsonObject as the type.
+ */
+public class JsonbUserType implements UserType {
+
+    private static final int[] SQL_TYPES = { Types.LONGVARCHAR };
+
+    @Override
+    public Object assemble(Serializable cached, Object owner) throws HibernateException {
+        return deepCopy(cached);
+    }
+
+    @Override
+    public Object deepCopy(Object value) throws HibernateException {
+        if (value == null) {
+            return null;
+        }
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        JsonWriter writer =  Json.createWriter(bos);
+        writer.writeObject((JsonObject) value);
+        writer.close();
+        byte[] bs = bos.toByteArray();
+        JsonReader reader = Json.createReader(new ByteArrayInputStream(bs));
+        return reader.readObject();
+    }
+
+    @Override
+    public Serializable disassemble(Object value) throws HibernateException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        JsonWriter writer = Json.createWriter(bos);
+        writer.close();
+        return new String(bos.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public boolean isMutable() {
+        return true;
+    }
+
+    @Override
+    public Object replace(Object original, Object target, Object owner) throws HibernateException {
+        return deepCopy(original);
+    }
+
+    @Override
+    public Class returnedClass() {
+        return JsonObject.class;
+    }
+
+    @Override
+    public boolean equals(Object x, Object y) throws HibernateException {
+        return x.equals(y);
+    }
+
+    @Override
+    public int hashCode(Object x) throws HibernateException {
+        return x.hashCode();
+    }
+
+    @Override
+    public Object nullSafeGet(ResultSet rs, String[] names, SharedSessionContractImplementor session, Object owner) throws HibernateException, SQLException {
+        if (!rs.wasNull()) {
+            JsonReader reader = Json.createReader(rs.getBinaryStream(names[0]));
+            return reader.readObject();
+        }
+        return null;
+    }
+
+    @Override
+    public void nullSafeSet(PreparedStatement st, Object value, int index, SharedSessionContractImplementor session) throws HibernateException, SQLException {
+        if (value == null) {
+            st.setNull(index, Types.OTHER);
+        } else {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            JsonWriter writer = Json.createWriter(bos);
+            writer.write((JsonObject) value);
+            writer.close();
+            st.setString(index, new String(bos.toByteArray(), StandardCharsets.UTF_8));
+        }
+    }
+
+    @Override
+    public int[] sqlTypes() {
+        return SQL_TYPES;
+    }
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/hibernate/ShogunPostgresqlDialect.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/hibernate/ShogunPostgresqlDialect.java
@@ -1,0 +1,15 @@
+package de.terrestris.shogun2.hibernate;
+
+import org.hibernate.spatial.dialect.postgis.PostgisPG9Dialect;
+
+import java.sql.Types;
+
+public class ShogunPostgresqlDialect extends PostgisPG9Dialect {
+
+    private static final long serialVersionUID = 9177170273858773475L;
+
+    public ShogunPostgresqlDialect() {
+        this.registerColumnType(Types.OTHER, "jsonb");
+    }
+
+}


### PR DESCRIPTION
This enables us to incorporate PostgreSQL jsonb fields into object graphs.

Use it like this:

```java
    @org.hibernate.annotations.Type(type="de.terrestris.shogun2.hibernate.JsonbUserType")
    private Map<String, Object> custom;
```

and add the appropriate getter/setter as needed. The stored json can be of any depth and will be incorporated as the value of the `custom` field of the annotated entity transparently.

@terrestris/devs Please review.